### PR TITLE
Fix MCMC reference for acceptance criterion. Closes #12

### DIFF
--- a/GBOpt/GBMinimizer.py
+++ b/GBOpt/GBMinimizer.py
@@ -103,11 +103,10 @@ class MonteCarloMinimizer:
 
         # Set the minimum GBE
         min_gbe = min(self.GBE_vals)
+        prev_gbe = init_gbe
 
         # Run the MC iterations
         for i in range(1, max_steps + 1):
-            prev_gbe = self.GBE_vals[-1]
-
             # Generate a random mutation on the current GB atom structure
             new_system = self.mutator.mutate(
                 self.local_random, self.GB, self.manipulator)


### PR DESCRIPTION
**Summary**
  - `prev_gbe` was being reset to `self.GBE_vals[-1]` (the last evaluated energy) at the start of each MC iteration, rather than tracking the last accepted energy
  - After a rejection, this inflated the acceptance baseline for the next proposal, breaking detailed balance and causing spurious uphill acceptances
  - Fix: remove the in-loop reassignment; `prev_gbe` is initialized to `init_gbe` before the loop and updated only on acceptance (the `if accepted:` block already did this correctly)

**What changed**
`GBOpt/GBMinimizer.py`:
Removed line inside the MC loop:
```
# before (buggy)
for i in range(1, max_steps + 1):
    prev_gbe = self.GBE_vals[-1]   # ← reset to last evaluated, not last accepted
    ...

# after (fixed)
prev_gbe = init_gbe                 # initialized before loop
for i in range(1, max_steps + 1):
    ...
    if accepted:
        prev_gbe = new_gbe          # updated only on acceptance
```

**Validation**
Smoke test (near-zero temperature)

A greedy run using `E_accept=1e-10` (T ≈ 1.4 × 10<sup>-10</sup> J/m<sup>2</sup>) on the Ni Σ5(310) GBOpt-constructed structure was used to make the bug's effect unambiguous. Before the fix: 121/501 steps accepted uphill moves with a maximum accepted energy increase of 0.395 J/m<sup>2</sup>. After the fix: 0 uphill moves accepted; the run converged early via the energy-tolerance criterion, consistent with expected greedy behavior.

**Spot check against non-trivial starting condition**
Three additional runs were performed starting from a high-energy Ni Σ5(310) structure (GBE = 2.065 J/m<sup>2</sup>), requiring a ~0.8 J/m<sup>2</sup> descent. These were compared against a pre-fix run under identical conditions.

| Run | E_accept | Acceptance rate | Min GBE (J/m²) |
|-----|----------|-----------------|-----------------|
| run1 (buggy) | 0.1 | 87% | 1.331 |
| run2 (fixed) | 0.1 | 86% | 1.359 |
| run3 (fixed) | 0.1 | 85% | 1.287 |
| run4 (fixed) | 0.1 | 87% | 1.346 |
| run1 (buggy) | 0.01 | 66% | 1.336 |
| run2 (fixed) | 0.01 | 49% | 1.287 |
| run3 (fixed) | 0.01 | 47% | 1.287 |
| run4 (fixed) | 0.01 | 47% | 1.310 |

For `E_accept=0.1` the bug had no material effect — acceptance rates and minimum energies are statistically indistinguishable. For `E_accept=0.01` the bug inflated the acceptance rate by ~17 percentage points and the pre-fix run found a minimum 0.05 J/m<sup>2</sup> higher than two of three post-fix runs, indicating the walker was accepting spurious uphill moves and failing to exploit low-energy basins.