### PR TITLE
Refactor integer rotation approximation to row-by-row angular search

### DIFF
--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -108,7 +108,7 @@ class GBMaker:
         """
         reduced = np.asarray(row, dtype=int).copy()
         non_zero = np.abs(reduced[reduced != 0])
-        if non_zero.size == 0:
+        if not non_zero.size:
             return reduced
         gcd = np.gcd.reduce(non_zero)
         if gcd > 1:
@@ -126,7 +126,7 @@ class GBMaker:
         """
         ref_norm = np.linalg.norm(reference)
         cand_norm = np.linalg.norm(candidate)
-        if ref_norm == 0 or cand_norm == 0:
+        if np.isclose(ref_norm, 0) or np.isclose(cand_norm, 0):
             return 180.0
         cosine = np.dot(reference, candidate) / (ref_norm * cand_norm)
         return float(np.degrees(np.arccos(np.clip(cosine, -1.0, 1.0))))
@@ -148,7 +148,7 @@ class GBMaker:
         :param max_scale: Upper bound of the scale factor to try.
         :return: Best-matching integer vector.
         """
-        row = np.asarray(row, dtype=float)
+        row = np.asarray(row, dtype=np.float64)
         best = None
         best_err = 180.0
         batch_size = 1000
@@ -184,7 +184,7 @@ class GBMaker:
                 self.__approximate_rotation_row_as_int(
                     row, angle_tol_deg=0.5, max_scale=max_scale
                 )
-                for row in np.asarray(m, dtype=float)
+                for row in np.asarray(m, dtype=np.float64)
             ]
         ).astype(int)
 

--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -3,7 +3,6 @@
 
 import math
 import warnings
-from fractions import Fraction
 from numbers import Number
 from typing import Any, Sequence, Tuple, Union
 
@@ -99,7 +98,74 @@ class GBMaker:
         self.__set_gb_region()
         self.__box_dims = self.__calculate_box_dimensions()
 
+    @staticmethod
+    def __reduce_integer_row(row: np.ndarray) -> np.ndarray:
+        """
+        Reduce an integer row by its GCD
+
+        :param row: Integer row vector
+        :return: GCD-reduced integer row vector
+        """
+        reduced = np.asarray(row, dtype=int).copy()
+        non_zero = np.abs(reduced[reduced != 0])
+        if non_zero.size == 0:
+            return reduced
+        gcd = np.gcd.reduce(non_zero)
+        if gcd > 1:
+            reduced //= gcd
+        return reduced
+
+    @staticmethod
+    def __row_angle_error_deg(reference: np.ndarray, candidate: np.ndarray) -> float:
+        """
+        Compute the angular error in degrees between two vectors.
+
+        :param reference: Reference float vector.
+        :param candidate: Candidate integer vector.
+        :return: Angle between the two vectors in degrees
+        """
+        ref_norm = np.linalg.norm(reference)
+        cand_norm = np.linalg.norm(candidate)
+        if ref_norm == 0 or cand_norm == 0:
+            return 180.0
+        cosine = np.dot(reference, candidate) / (ref_norm * cand_norm)
+        return float(np.degrees(np.arccos(np.clip(cosine, -1.0, 1.0))))
+
     # Private class methods
+    def __approximate_rotation_row_as_int(
+        self, row: np.ndarray, angle_tol_deg: float = 0.5, max_scale: int = 10000
+    ) -> np.ndarray:
+        """
+        Find the smallest-norm integer vector that points within *angle_tol_deg* of
+        *row*. LLL lattice reduction was considered but not adopted: for CSL boundaries
+        the correct scale factor k equals ‖g‖ ≤ √Σ (typically < 10), so the loop exits
+        in a handful of iterations. The LLL selection step also requires enumerating
+        signed combinations of reduced basis rows — adding ~60 lines for no practical
+        gain.
+
+        :param row: A single float row from a rotation matrix.
+        :param angle_tol_deg: Maximum allowed angular error in degrees.
+        :param max_scale: Upper bound of the scale factor to try.
+        :return: Best-matching integer vector.
+        """
+        row = np.asarray(row, dtype=float)
+        best = None
+        best_err = 180.0
+        batch_size = 1000
+        for k_start in range(1, max_scale + 1, batch_size):
+            k_end = min(k_start + batch_size, max_scale + 1)
+            for k in range(k_start, k_end):
+                candidate = self.__reduce_integer_row(np.round(row * k).astype(int))
+                err = self.__row_angle_error_deg(row, candidate)
+                if err < best_err or (err == best_err and np.linalg.norm(candidate) < np.linalg.norm(best)):
+                    best_err = err
+                    best = candidate
+                if best_err <= angle_tol_deg:
+                    break
+            if best_err <= angle_tol_deg:
+                break
+        return best if best is not None else np.round(row).astype(int)
+
     def __approximate_rotation_matrix_as_int(
         self, m: np.ndarray, precision: float = 5
     ) -> np.ndarray:
@@ -111,109 +177,16 @@ class GBMaker:
         :param precision: Decimal precision to use during calculations, defaults to 5
         :return: Integer approximation of the rotation matrix m
         """
-        # first round the matrix to the desired precision
-        R0 = np.linalg.norm(Rotation.from_matrix(m).as_rotvec(degrees=True))
 
-        def gcd_reduce(matrix):
-            gcds = np.gcd.reduce(matrix, axis=1)
-            return matrix / gcds[:, np.newaxis]
-
-        def get_angle(matrix):
-            return np.linalg.norm(
-                Rotation.from_matrix(
-                    matrix / np.linalg.norm(matrix, axis=1)[:, np.newaxis]
-                ).as_rotvec(degrees=True)
-            )
-
-        def get_magnitude_sum(matrix):
-            abs_m = np.abs(matrix)
-            non_zero_elements = abs_m[abs_m > 0]
-            log_magnitudes = np.log(non_zero_elements)
-            return np.sum(log_magnitudes)
-
-        def calculate_best_approx(metrics1, metrics2, m1, m2):
-            diffs = [metrics1["angle"], metrics2["angle"]]
-            keys = list(metrics1.keys())
-
-            # Normalize each metric. Note that the if statement essentially only catches
-            # when both matrices gives essentially the same rotation as the original
-            # (as calculated by the get_angle function above).
-            metric1_norms = np.array(
-                [
-                    metrics1[key] / max(metrics1[key], metrics2[key])
-                    if not max(metrics1[key], metrics2[key]) == 0
-                    else 0
-                    for key in keys
-                ]
-            )
-            metric2_norms = np.array(
-                [
-                    metrics2[key] / max(metrics1[key], metrics2[key])
-                    if not max(metrics1[key], metrics2[key]) == 0
-                    else 0
-                    for key in keys
-                ]
-            )
-
-            # These weights *seem* to work, but there should be a better way to
-            # determine these (these were determine through trial and error for the
-            # R_right matrix for the misorientation matrix of [0.3, 0.4, 0.5, 0.6, 0.7])
-            # In a general sense, placing most of the weighting on the magnitude, then
-            # most of the rest on the condition, with the rest on the angle should give
-            # a good representation, at least based on the generated matrix mentioned.
-            weights = {"angle": 0.1, "condition": 0.3, "magnitude": 0.6}
-            weights = np.array([weights[key] for key in keys])  # keep order the same
-            metric1_overall = np.sum(metric1_norms * weights) / np.sum(weights)
-            metric2_overall = np.sum(metric2_norms * weights) / np.sum(weights)
-
-            if metric1_overall < metric2_overall:
-                return m1, diffs[0]
-            else:
-                return m2, diffs[1]
-
-        # Approximation with the least common multiple of denominators in their
-        # fraction representation
-        m_as_fractions = np.vectorize(
-            lambda val: Fraction(val).limit_denominator(10**precision)
-        )(m)
-        denominators = np.array(
-            [[f.denominator for f in row] for row in m_as_fractions]
-        )
-        scaling_factors = np.array([np.lcm.reduce(row) for row in denominators])
-        scaled_matrix = m * scaling_factors[:, np.newaxis]
-        approx_m_from_fractions = gcd_reduce(np.round(scaled_matrix).astype(int))
-        approx_m_from_fractions_metrics = {
-            "angle": abs(R0-get_angle(approx_m_from_fractions)),
-            "condition": np.linalg.cond(approx_m_from_fractions),
-            "magnitude": get_magnitude_sum(approx_m_from_fractions)
-        }
-
-        # Approximation by taking the ratio of the row values divided by the smallest
-        # values, scaling these ratios up by 10**precision, truncating the values,
-        # then simplifying.
-        min_by_row_excluding_0 = np.ma.amin(
-            np.ma.masked_less(np.abs(m), 10**-precision), axis=1).data
-        m_ratio = m / min_by_row_excluding_0[:, np.newaxis]  # ratios of values to mins
-        m_rounded = np.round(m_ratio, precision)  # round to the desired precision
-        m_scaled = (10**precision * m_rounded).astype(int)  # scale by 10**precision
-        approx_m_from_scaling = gcd_reduce(m_scaled)
-        approx_m_from_scaling_metrics = {
-            "angle": abs(R0-get_angle(approx_m_from_scaling)),
-            "condition": np.linalg.cond(approx_m_from_scaling),
-            "magnitude": get_magnitude_sum(approx_m_from_scaling)
-        }
-
-        result, diff = calculate_best_approx(
-            approx_m_from_fractions_metrics,
-            approx_m_from_scaling_metrics,
-            approx_m_from_fractions,
-            approx_m_from_scaling
-        )
-
-        if diff > 0.5:
-            warnings.warn(
-                "Approximated rotation matrix error is greater than 0.5 degrees.")
-        return result.astype(int)
+        max_scale = max(1000, 10**max(int(precision)-1, 0))
+        return np.vstack(
+            [
+                self.__approximate_rotation_row_as_int(
+                    row, angle_tol_deg=0.5, max_scale=max_scale
+                )
+                for row in np.asarray(m, dtype=float)
+            ]
+        ).astype(int)
 
     def __assign_orientations(self, misorientation: np.ndarray) -> None:
         """
@@ -631,7 +604,8 @@ class GBMaker:
         # Write LAMMPS data file
         with open(file_name, "w") as fdata:
             # First line is a comment line
-            fdata.write(f"Crystalline {"".join(np.unique(atoms["name"]))} atoms\n\n")
+            atom_names = "".join(np.unique(atoms["name"]))
+            fdata.write(f"Crystalline {atom_names} atoms\n\n")
 
             # --- Header ---#
             # Specify number of atoms and atom types

--- a/tests/test_gbmaker.py
+++ b/tests/test_gbmaker.py
@@ -220,9 +220,9 @@ class TestGBMaker(unittest.TestCase):
         approx_matrix = self.gbm._GBMaker__approximate_rotation_matrix_as_int(
             rotation_matrix)
 
-        expected_matrix = np.array([[27720,  19601,  19601],
-                                    [27720, -19601, -19601],
-                                    [0,      1,     -1]])
+        expected_matrix = np.array([[7,  5,  5],
+                                    [7, -5, -5],
+                                    [0,  1, -1]])
 
         np.testing.assert_array_equal(approx_matrix, expected_matrix)
 
@@ -244,18 +244,6 @@ class TestGBMaker(unittest.TestCase):
 
         with self.assertWarns(UserWarning):
             gbm.interaction_distance = 32
-
-    def test_non_periodic_boundary_warning(self):
-        with self.assertWarns(UserWarning):
-            self.gbm._GBMaker__approximate_rotation_matrix_as_int(
-                np.array(
-                    [
-                        [0.123456789, 0.56789123, -0.918273645],
-                        [-0.135792468, 0.246813579, 0.1],
-                        [0.159283746, -0.2, 0.1]
-                    ]
-                )
-            )
 
     # Additional tests
     # Output data file format is as expected.
@@ -343,6 +331,71 @@ class TestGBMaker(unittest.TestCase):
             # This test _will_ fail until we address #39
             self.assertFalse(
                 filecmp.cmp(temp_file.name, "./tests/gold/fcc_Cu.txt", shallow=False))
+
+
+class TestGBMakerIntRotationHelpers(unittest.TestCase):
+    def setUp(self):
+        a0 = 3.61
+        theta = math.radians(36.868698)
+        misorientation = np.array([theta, 0.0, 0.0, 0.0, -theta / 2.0])
+        self.gbm = GBMaker(a0, "fcc", 10.0, misorientation, "Cu")
+
+    # __reduce_integer_row
+    def test_reduce_integer_row_basic(self):
+        row = np.array([4, 6, 2])
+        result = self.gbm._GBMaker__reduce_integer_row(row)
+        np.testing.assert_array_equal(result, np.array([2, 3, 1]))
+
+    def test_reduce_integer_row_already_reduced(self):
+        row = np.array([1, 2, 3])
+        result = self.gbm._GBMaker__reduce_integer_row(row)
+        np.testing.assert_array_equal(result, np.array([1, 2, 3]))
+
+    def test_reduce_integer_row_all_zeros(self):
+        row = np.array([0, 0, 0])
+        result = self.gbm._GBMaker__reduce_integer_row(row)
+        np.testing.assert_array_equal(result, np.array([0, 0, 0]))
+
+    def test_reduce_integer_row_with_negatives(self):
+        row = np.array([-4, 6, -2])
+        result = self.gbm._GBMaker__reduce_integer_row(row)
+        np.testing.assert_array_equal(result, np.array([-2, 3, -1]))
+
+    # __row_angle_error_deg
+    def test_row_angle_error_parallel(self):
+        ref = np.array([1.0, 0.0, 0.0])
+        cand = np.array([5, 0, 0])
+        err = self.gbm._GBMaker__row_angle_error_deg(ref, cand)
+        self.assertAlmostEqual(err, 0.0, places=10)
+
+    def test_row_angle_error_perpendicular(self):
+        ref = np.array([1.0, 0.0, 0.0])
+        cand = np.array([0, 1, 0])
+        err = self.gbm._GBMaker__row_angle_error_deg(ref, cand)
+        self.assertAlmostEqual(err, 90.0, places=10)
+
+    def test_row_angle_error_antiparallel(self):
+        ref = np.array([1.0, 0.0, 0.0])
+        cand = np.array([-1, 0, 0])
+        err = self.gbm._GBMaker__row_angle_error_deg(ref, cand)
+        self.assertAlmostEqual(err, 180, places=10)
+
+    def test_row_angle_error_zero_vector(self):
+        ref = np.array([1.0, 0.0, 0.0])
+        cand = np.array([0, 0, 0])
+        err = self.gbm._GBMaker__row_angle_error_deg(ref, cand)
+        self.assertEqual(err, 180.0)
+
+    # __approximate_rotation_matrix_as_int - row error tolerance
+    def test_approx_matrix_sigma5_within_tolerance(self):
+        """Sigma5 [001] 36.87 - all rows must be within 0.5 of the float matrix."""
+        from scipy.spatial.transform import Rotation
+        theta = math.radians(36.869898)
+        R = Rotation.from_euler("z", theta).as_matrix()
+        approx = self.gbm._GBMaker__approximate_rotation_matrix_as_int(R)
+        for ref_row, approx_row in zip(R, approx.astype(float)):
+            err = self.gbm._GBMaker__row_angle_error_deg(ref_row, approx_row)
+            self.assertLessEqual(err, 0.5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Summary**

Replaces __approximate_rotation_matrix_as_int's dual-strategy implementation (fraction-based LCM scaling vs. ratio-based scaling with empirically tuned weights) with a simpler, physically motivated row-by-row angular search.

Each row of a rotation matrix represents an independent crystallographic direction, so searching each row independently is both correct and sufficient. The new approach scales each row by increasing integers k, rounds, GCD-reduces, and accepts the first candidate within 0.5° of the target direction. For CSL boundaries, k ≤ √Σ (typically ≤ 10), so the search exits in a handful of iterations.

**Changes:**
- Added __reduce_integer_row — GCD-reduces an integer vector
- Added __row_angle_error_deg — angular error in degrees between two vectors
- Added __approximate_rotation_row_as_int — row-level search (LLL lattice reduction was considered but rejected: it minimizes Euclidean length in R⁴, not angular error in R³, and misses integer combinations of basis rows)
- __approximate_rotation_matrix_as_int now delegates to the row search and derives max_scale from the precision parameter; the unreachable non-periodic boundary warning is removed
- Fixes a Python < 3.12 SyntaxError in write_lammps caused by subscript access inside a nested f-string
- Updates TestGBMaker and adds TestGBMakerIntRotationHelpers covering the three new helper methods; removes
  test_non_periodic_boundary_warning