### PR TITLE
Add triclinic simulation box support to write_lammps

### DIFF
--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -240,13 +240,13 @@ class GBMaker:
             threshold = self.__a0 * 15
 
         # approximate the rotation matrix as integers
-        R_left = self.__Rincl
-        R_right = np.dot(self.__Rmis, self.__Rincl)
+        self.__R_left = self.__Rincl
+        self.__R_right = np.dot(self.__Rmis, self.__Rincl)
         # # We store the approximate matrices as objects to allow for large numbers
-        R_left_approx = self.__approximate_rotation_matrix_as_int(R_left).astype(object)
-        R_right_approx = self.__approximate_rotation_matrix_as_int(R_right).astype(
-            object
-        )
+        self.__R_left_approx = self.__approximate_rotation_matrix_as_int(
+            self.__R_left).astype(object)
+        self.__R_right_approx = self.__approximate_rotation_matrix_as_int(
+            self.__R_right).astype(object)
 
         # The periodic distance in each direction is the lattice parameter multiplied by
         # norm of the Miller indices in that direction. This is determined using the
@@ -257,11 +257,11 @@ class GBMaker:
         # (a0**2/d**2)*d = a0**2/d --> spacing = a0 * sqrt(h**2+k**2+l**2)
         spacing_left = {
             axis: self.__a0 * np.linalg.norm(vec)
-            for axis, vec in zip(["x", "y", "z"], R_left_approx)
+            for axis, vec in zip(["x", "y", "z"], self.__R_left_approx)
         }
         spacing_right = {
             axis: self.__a0 * np.linalg.norm(vec)
-            for axis, vec in zip(["x", "y", "z"], R_right_approx)
+            for axis, vec in zip(["x", "y", "z"], self.__R_right_approx)
         }
 
         spacing = {"x": {"left": spacing_left["x"], "right": spacing_right["x"]}}
@@ -287,6 +287,47 @@ class GBMaker:
         warnings.simplefilter("default", UserWarning)
 
         return spacing
+
+    def __get_triclinic_params(self):
+        """
+        Computes the LAMMPS restricted-triclinic tilt factors. The y-period in the lab
+        frame is R_grain @ (g_y * a0). For an exact CSL boundary this is exactly
+        ||g_y|| * a0 * e_y; for non-CSL it has small x and z components. To satisfy
+        LAMMPS's restriction that the b-vector lies in the xy-plane, rotate everything
+        about the x-axis by theta = -atan2(A2[2], A2[1]).
+
+        :return: (xy, xz, yz, theta) - the three tilt scalars and the rotation angle to
+                                       apply to atom coordinates
+        """
+
+        # Use grain with larger y-period, consistent with how spacing["y"] is chosen
+        if np.linalg.norm(self.__R_left_approx[1]) >= np.linalg.norm(self.__R_right_approx[1]):
+            R_grain = self.__R_left
+            g_y = self.__R_left_approx[1].astype(float)
+            g_z = self.__R_left_approx[2].astype(float)
+        else:
+            R_grain = self.__R_right
+            g_y = self.__R_right_approx[1].astype(float)
+            g_z = self.__R_right_approx[2].astype(float)
+
+        # Lab-frame period vectors
+        A2_lab = R_grain @ (g_y * self.__a0)
+        A3_lab = R_grain @ (g_z * self.__a0)
+
+        # Rotate about x to bring A2 into the xy-plane (LAMMPS restricted-triclinic
+        # requires b-vector in the xy-plane). x-components are unaffected by this
+        # rotation
+        theta = -math.atan2(float(A2_lab[2]), float(A2_lab[1]))
+        ct, st = math.cos(theta), math.sin(theta)
+
+        # The x-rotation matrix is [[1,0,0],[0,ct,-st],[0,st,ct]]. The x-components of
+        # A2_lab and A3_lab are unchanged by it, so xy and xz can be read direcly from
+        # the pre-rotation vectors. yz requires the full rotation.
+        xy = float(A2_lab[0])
+        xz = float(A3_lab[0])
+        yz = float(ct * A3_lab[1] - st * A3_lab[2])
+
+        return xy, xz, yz, theta
 
     def __init_unit_cell(self, atom_types: str | Tuple[str, ...]) -> UnitCell:
         """
@@ -539,7 +580,8 @@ class GBMaker:
         *,
         type_as_int: bool = False,
         precision: int = 6,
-        charges: dict = None
+        charges: dict = None,
+        triclinic: bool = False
     ) -> None:
         """
         Writes the atom positions with the given box dimensions to a LAMMPS input file.
@@ -618,6 +660,13 @@ class GBMaker:
                 f'{box_sizes[1][0]:.{precision}f} {box_sizes[1][1]:.{precision}f} ylo yhi\n')
             fdata.write(
                 f'{box_sizes[2][0]:.{precision}f} {box_sizes[2][1]:.{precision}f} zlo zhi\n')
+            if triclinic:
+                xy, xz, yz, theta = self.__get_triclinic_params()
+                fdata.write(
+                    f'{xy:.{precision}f} {xz:.{precision}f} {yz:.{precision}f} xy xz yz\n'
+                )
+                ct, st = math.cos(theta), math.sin(theta)
+                Rx = np.array([[1, 0, 0], [0, ct, -st], [0, st, ct]])
 
             if not type_as_int:
                 fdata.write("\nAtom Type Labels\n\n")
@@ -633,6 +682,9 @@ class GBMaker:
                     charge = charges[name_to_int[name]]if type_as_int else charges[name]
                 else:
                     charge = None
+
+                if triclinic:
+                    pos = Rx @ np.array(pos, dtype=float)
                 fdata.write(format_atom_line(i + 1, name, pos, charge))
 
     # Properties with getters and setters. Automatic updates for related parameters are

--- a/GBOpt/GBManipulator.py
+++ b/GBOpt/GBManipulator.py
@@ -456,6 +456,9 @@ class Parent:
                     y_dims = [float(line_sp[0]), float(line_sp[1])]
                 elif "zlo zhi" in line:
                     z_dims = [float(line_sp[0]), float(line_sp[1])]
+                elif "xy xz yz" in line:
+                    tilt = [float(line_sp[0]), float(line_sp[1]), float(line_sp[2])]
+                    self.__tilt = tilt
                 elif line == "Atom Type Labels":
                     next(lines)  # Skip the blank line before the data
                     skiprows += 1

--- a/tests/test_gbmaker.py
+++ b/tests/test_gbmaker.py
@@ -2,6 +2,7 @@
 
 import filecmp
 import math
+import os
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -396,6 +397,51 @@ class TestGBMakerIntRotationHelpers(unittest.TestCase):
         for ref_row, approx_row in zip(R, approx.astype(float)):
             err = self.gbm._GBMaker__row_angle_error_deg(ref_row, approx_row)
             self.assertLessEqual(err, 0.5)
+
+
+class TestGBMakerTriclinic(unittest.TestCase):
+    def setUp(self):
+        a0 = 3.61
+        theta = math.radians(36.869898)
+        misorientation = np.array([theta, 0.0, 0.0, 0.0, -theta / 2.0])
+        self.gbm = GBMaker(a0, "fcc", 10.0, misorientation, "Cu",
+                           repeat_factor=6, x_dim_min=60.0, vacuum=10.0,
+                           interaction_distance=10)
+
+    def test_triclinic_writes_tilt_line(self):
+        with tempfile.NamedTemporaryFile(delete=True) as f:
+            self.gbm.write_lammps(f.name, triclinic=True)
+            with open(f.name) as fread:
+                content = fread.read()
+        self.assertIn("xy xz yz", content)
+
+    def test_non_triclinic_no_tilt_line(self):
+        with tempfile.NamedTemporaryFile(delete=True) as f:
+            self.gbm.write_lammps(f.name)
+            with open(f.name) as fread:
+                content = fread.read()
+        self.assertNotIn("xy xz yz", content)
+
+    def test_csl_boundary_zero_tilt(self):
+        # Sigma5 is a CSL boundary - period vectors lie exactly on axis directions, so
+        # all tilt factors should be negligibly small
+        xy, xz, yz, _ = self.gbm._GBMaker__get_triclinic_params()
+        self.assertAlmostEqual(xy, 0.0, places=3)
+        self.assertAlmostEqual(xz, 0.0, places=3)
+        self.assertAlmostEqual(yz, 0.0, places=3)
+
+    def test_triclinic_gbmanipulator_reads_back(self):
+        from GBOpt.GBManipulator import Parent
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".dat", mode="w") as f:
+            fname = f.name
+        try:
+            self.gbm.write_lammps(fname, triclinic=True)
+            # Should not raise - GBManipulator must parse the xy xz yz line cleanly
+            parent = Parent(fname, unit_cell=self.gbm.unit_cell,
+                            gb_thickness=self.gbm.gb_thickness)
+            self.assertIsNotNone(parent)
+        finally:
+            os.unlink(fname)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Summary**

Enables GBMaker.write_lammps() to write LAMMPS restricted-triclinic format (xy xz yz tilt factors) for grain boundary structures where the y- or z-period vectors are not axis-aligned — as occurs with non-CSL misorientations or general inclination angles.

**Changes in GBMaker.py:**
- write_lammps gains a triclinic: bool = False parameter
- New __get_triclinic_params method computes the LAMMPS tilt factors (xy, xz, yz) from the integer-approximated rotation matrices and lattice parameter, then derives the x-axis rotation θ needed to bring the b-vector into the xy-plane as required by the restricted-triclinic format
- Atom coordinates are rotated by Rₓ(θ) before writing when triclinic=True; CSL boundaries produce zero tilt factors, so the output is equivalent to the orthogonal case

**Changes in GBManipulator.py:**
- __init_from_lammps_data now parses the xy xz yz tilt line from LAMMPS data files, allowing triclinic structures written by GBMaker  to be read back correctly

**New tests (TestGBMakerTriclinic):**
- Verifies the tilt line is written when triclinic=True and absent by default
- Confirms CSL boundaries produce zero tilt factors
- Round-trips a triclinic structure through GBManipulator to verify read-back

Depends on #22 