### PR TITLE
Fix/periodic boundary epsilon

### DIFF
--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -246,7 +246,7 @@ class GBMaker:
 
         # approximate the rotation matrix as integers
         self.__R_left = self.__Rincl
-        self.__R_right = np.dot(self.__Rmis, self.__Rincl)
+        self.__R_right = np.dot(self.__Rincl, self.__Rmis)
         # # We store the approximate matrices as objects to allow for large numbers
         self.__R_left_approx = self.__approximate_rotation_matrix_as_int(
             self.__R_left).astype(object)

--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -58,12 +58,14 @@ class GBMaker:
                  misorientation: np.ndarray, atom_types: str | Tuple[str, ...], *,
                  repeat_factor: Union[int, Sequence[int]] = 2, x_dim_min: float = 50,
                  vacuum: float = 10, interaction_distance: float = 15.0,
-                 gb_id: int = 1):
+                 gb_id: int = 1, epsilon: float = 1e-10):
         self.__a0 = self.__validate(a0, Number, "a0", positive=True)
         self.__structure = self.__validate(structure, str, "structure")
         self.__gb_thickness = self.__validate(
             gb_thickness, Number, "gb_thickness", positive=True
         )
+        self.__epsilon = self.__validate(
+            epsilon, Number, "epsilon", strictly_positive=True)
         self.__assign_orientations(
             self.__validate(
                 np.asarray(misorientation),
@@ -425,11 +427,10 @@ class GBMaker:
         # periodic boundary. For the x direction this doesn't matter as much because we
         # do not have periodic boundaries in this direction, but '<=' causes more atoms
         # to be placed.
-        eps = 1e-10
         inside_box = (
-            (atoms["x"] >= x_min - eps) & (atoms["x"] < x_max) &
-            (atoms["y"] >= y_min - eps) & (atoms["y"] < y_max) &
-            (atoms["z"] >= z_min - eps) & (atoms["z"] < z_max)
+            (atoms["x"] >= x_min - self.__epsilon) & (atoms["x"] < x_max) &
+            (atoms["y"] >= y_min - self.__epsilon) & (atoms["y"] < y_max) &
+            (atoms["z"] >= z_min - self.__epsilon) & (atoms["z"] < z_max)
         )
         return atoms[inside_box]
 
@@ -470,7 +471,8 @@ class GBMaker:
         parameter_name: str,
         *,
         positive: bool = False,
-        expected_length: int = None,
+        expected_length: int | None = None,
+        strictly_positive: bool = False
     ):
         """
         Private method for validating the values passed in using the setters.
@@ -483,6 +485,8 @@ class GBMaker:
             defaults to False.
         :param expected_length: Specific to sequences or arrays. The expected length of
             the sequence or array, optional, defaults to None.
+        :param strictly_positive: Supercedes `positive` by enforcing value > 0. Optional,
+            defaults to False.
         :raises GBMakerTypeError: Exception raised if the type of the value does not
             match the expected type(s).
         :raises GBMakerValueError: Exception raised when invalid values are given for
@@ -499,7 +503,16 @@ class GBMaker:
                 f"{parameter_name} must be of type {expected_type_names}."
             )
 
-        if positive and isinstance(value, Number) and value < 0:
+        if strictly_positive and isinstance(value, Number):
+            if value <= 0:
+                raise GBMakerValueError(f"{parameter_name} must be strictly positive")
+            if value < np.finfo(np.float64).eps:
+                warnings.warn(
+                    f"{parameter_name} ({value}) is below machine epsilon "
+                    f"({np.finfo(np.float64).eps:.2e}) and may not have any "
+                    "practical effect."
+                )
+        elif positive and isinstance(value, Number) and value < 0:
             raise GBMakerValueError(
                 f"{parameter_name} must be a positive value.")
 
@@ -710,6 +723,15 @@ class GBMaker:
         self.__a0 = self.__validate(value, float, "a0", positive=True)
         self.__unit_cell = self.__init_unit_cell(atom_types)
         self.update_spacing()
+
+    @property
+    def epsilon(self) -> float:
+        return self.__epsilon
+
+    @epsilon.setter
+    def epsilon(self, value: Number) -> None:
+        self.__epsilon = self.__validate(
+            value, Number, "epsilon", strictly_positive=True)
 
     @property
     def gb_thickness(self) -> float:

--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -425,10 +425,11 @@ class GBMaker:
         # periodic boundary. For the x direction this doesn't matter as much because we
         # do not have periodic boundaries in this direction, but '<=' causes more atoms
         # to be placed.
+        eps = 1e-10
         inside_box = (
-            (atoms["x"] >= x_min) & (atoms["x"] < x_max) &
-            (atoms["y"] >= y_min) & (atoms["y"] < y_max) &
-            (atoms["z"] >= z_min) & (atoms["z"] < z_max)
+            (atoms["x"] >= x_min - eps) & (atoms["x"] < x_max) &
+            (atoms["y"] >= y_min - eps) & (atoms["y"] < y_max) &
+            (atoms["z"] >= z_min - eps) & (atoms["z"] < z_max)
         )
         return atoms[inside_box]
 

--- a/GBOpt/GBManipulator.py
+++ b/GBOpt/GBManipulator.py
@@ -1448,10 +1448,9 @@ class GBManipulator:
                     continue
                 for idx in selected_central_indices:
                     neighbors = possible_sites_neighbor_list[idx]
+                    already_assigned = {idx for v in atoms_to_add.values() for idx in v}
                     # Only consider the indices that have not already been assigned
-                    available_neighbors = list(
-                        set(neighbors) - set(np.array(atoms_to_add.values()).flatten())
-                    )
+                    available_neighbors = list(set(neighbors) - already_assigned)
                     if len(available_neighbors) < ratio:
                         raise GBManipulatorValueError(
                             "Not enough sites to insert atoms into."

--- a/tests/test_gbmaker.py
+++ b/tests/test_gbmaker.py
@@ -59,6 +59,7 @@ class TestGBMaker(unittest.TestCase):
         self.assertIsNotNone(self.gbm.left_grain)
         self.assertIsNotNone(self.gbm.right_grain)
         self.assertEqual(len(self.gbm.whole_system[0]), 4)
+        self.assertEqual(self.gbm.epsilon, 1e-10)
         left_grain = self.gbm.left_grain
         right_grain = self.gbm.right_grain
         system = self.gbm.whole_system
@@ -73,6 +74,17 @@ class TestGBMaker(unittest.TestCase):
     def test_invalid_a0_value(self):
         with self.assertRaises(GBMakerValueError):
             self.gbm.a0 = -5.0
+
+    def test_invalid_epsilon_type(self):
+        with self.assertRaises(GBMakerTypeError):
+            self.gbm.epsilon = "invalid"
+
+    def test_invalid_epsilon_value(self):
+        with self.assertRaises(GBMakerValueError):
+            self.gbm.epsilon = -1e-10
+
+        with self.assertRaises(GBMakerValueError):
+            self.gbm.epsilon = 0.0
 
     def test_invalid_misorientation_length(self):
         with self.assertRaises(GBMakerValueError):
@@ -203,6 +215,15 @@ class TestGBMaker(unittest.TestCase):
         self.gbm.id = 2
         self.assertEqual(self.gbm.id, 2)
 
+    def test_epsilon_custom_init(self):
+        gbm = GBMaker(self.a0, self.structure, self.gb_thickness, self.misorientation,
+                      self.atom_types, epsilon=1e-5)
+        self.assertEqual(gbm.epsilon, 1e-5)
+
+    def test_epsilon_setter(self):
+        self.gbm.epsilon = 1e-8
+        self.assertEqual(self.gbm.epsilon, 1e-8)
+
     def test_thin_thick_box_dimensions(self):
         # Thin box
         self.gbm.x_dim_min = 5.0
@@ -234,7 +255,24 @@ class TestGBMaker(unittest.TestCase):
             self.assertEqual(self.gbm.spacing["y"], 10.0)
             self.assertEqual(self.gbm.spacing["z"], 15.0)
 
+    def test_epsilon_controls_boundary_atom_inclusion(self):
+        # An atom at x=0.0 with x_min=1e-12 straddles the lower boundary. With
+        # epsilon=1e-10: 0.0 >= 1e-12 - 1e-10 =-9.9e-11 -> included. With epsilon=1e-13:
+        # 0.0 <= 1e-12 - 1e-13 = 9e-13 -> excluded. Exercises the setter's effect on
+        # __get_points_inside_box directly.
+        boundary_atom = np.array([("Cu", 0.0, 5.0, 5.0)], dtype=Atom.atom_dtype)
+        box_dim = [1e-12, 0.0, 0.0, 10.0, 10.0, 10.0]
+
+        self.gbm.epsilon = 1e-10
+        result_large = self.gbm._GBMaker__get_points_inside_box(boundary_atom, box_dim)
+        self.assertEqual(len(result_large), 1)
+
+        self.gbm.epsilon = 1e-13  # too narrow; x=0.0 falls velow x_min - epsilon
+        result_small = self.gbm._GBMaker__get_points_inside_box(boundary_atom, box_dim)
+        self.assertEqual(len(result_small), 0)
+
     # Tests for warnings
+
     def test_repeat_factor_warning(self):
         with self.assertWarns(UserWarning):
             gbm = GBMaker(self.a0, self.structure, self.gb_thickness,

--- a/tests/test_gbmaker.py
+++ b/tests/test_gbmaker.py
@@ -3,6 +3,7 @@
 import filecmp
 import math
 import os
+import sys
 import tempfile
 import unittest
 import warnings
@@ -439,6 +440,327 @@ class TestGBMakerTriclinic(unittest.TestCase):
             self.assertIsNotNone(parent)
         finally:
             os.unlink(fname)
+
+
+class TestGBMakerNonCommutingBoundaries(unittest.TestCase):
+    """Regression tests for boundaries where R_incl and R_mis do not commute.
+
+    When R_incl = Rz(phi) @ Ry(theta) is a pure z-rotation (theta=0, as for [001]
+    or [110] boundary normals) and R_mis is also a z-rotation (e.g. symmetric tilt
+    about [001]), the two matrices commute and the order R_mis @ R_incl vs R_incl @
+    R_mis is irrelevant.  For boundaries whose normal has a nonzero z-component (e.g.
+    [111] or [112]), theta != 0 and the matrices generally do NOT commute.
+    """
+
+    def setUp(self):
+        self.a0 = 3.61
+        self.structure = "fcc"
+        self.atom_types = "Cu"
+        self.gb_thickness = self.a0
+
+        # Sigma3 (111) coherent twin boundary.
+        # Derived from orientation matrices (rows = crystal directions for lab x,y,z)
+        # as given by Olmsted et al. doi: 10.1016/j.actamat.2009.04.007.
+        #   P = [[2,2,2], [1,-1,0], [1,1,-2]]
+        #   Q = [[2,2,2], [-1,1,0], [-1,-1,2]]
+        # Misorientation: 180 deg rotation about [1,1,1] -> ZXZ = [3pi/4, arccos(-1/3), pi/4]
+        # Inclination: boundary normal [1,1,1]           -> theta=pi/4, phi=-arctan(1/sqrt(2))
+        self.sigma3_111_180deg = np.array(
+            [
+                3 * np.pi / 4,
+                np.arccos(-1 / 3),
+                np.pi / 4,
+                np.pi / 4,
+                -np.arctan(1 / np.sqrt(2)),
+            ]
+        )
+
+        # Same physical boundary, alternative representation: 60 deg about [1,1,1].
+        # ZXZ Euler angles for 60 deg rotation about [1,1,1]:
+        #   alpha=arctan(2), beta=arccos(2/3), gamma=arctan(-1/2)
+        self.sigma3_111_60deg = np.array(
+            [
+                np.arctan(2),
+                np.arccos(2 / 3),
+                np.arctan(-1 / 2),
+                np.pi / 4,
+                -np.arctan(1 / np.sqrt(2)),
+            ]
+        )
+
+        # Sigma7 (111) twist boundary.
+        # Rotation angle theta = 2*arctan(sqrt(3)/5); exact: cos(theta)=11/14, sin(theta)=5*sqrt(3)/14.
+        # R_mis = [[6/7,-2/7,3/7],[3/7,6/7,-2/7],[-2/7,3/7,6/7]]
+        # ZXZ Euler angles: alpha=arctan(3/2), beta=arccos(6/7), gamma=arctan(-2/3)
+        # Same boundary-plane inclination as Sigma3 (111): theta=pi/4, phi=-arctan(1/sqrt(2)).
+        # Note: the right-grain y-direction period (row [2,11,-13], norm=7*sqrt(6)~17.15*a0)
+        # exceeds the default 15*a0 threshold, so a non-periodic warning is expected.
+        self.sigma7_111 = np.array(
+            [
+                np.arctan(3 / 2),
+                np.arccos(6 / 7),
+                np.arctan(-2 / 3),
+                np.pi / 4,
+                -np.arctan(1 / np.sqrt(2)),
+            ]
+        )
+
+    def _make_gb(self, misorientation, **kwargs):
+        """Construct a small GB with fast defaults."""
+        defaults = dict(repeat_factor=2, x_dim_min=50, interaction_distance=5)
+        defaults.update(kwargs)
+        return GBMaker(
+            self.a0,
+            self.structure,
+            self.gb_thickness,
+            misorientation,
+            self.atom_types,
+            **defaults,
+        )
+
+    # ------------------------------------------------------------------
+    # Sigma3 (111) -- 180 deg misorientation representation
+    # ------------------------------------------------------------------
+
+    def test_sigma3_111_construction_succeeds(self):
+        """Regression: Sigma3 (111) must not raise ValueError during construction."""
+        gbm = self._make_gb(self.sigma3_111_180deg)
+        self.assertGreater(gbm.left_grain.shape[0], 0)
+        self.assertGreater(gbm.right_grain.shape[0], 0)
+        self.assertEqual(
+            gbm.left_grain.shape[0] + gbm.right_grain.shape[0],
+            gbm.whole_system.shape[0],
+        )
+
+    def test_sigma3_111_no_non_periodic_warning(self):
+        """Sigma3 (111) is a well-defined CSL: no non-periodic boundary warning."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self._make_gb(self.sigma3_111_180deg)
+        non_periodic = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning)
+            and "non-periodic" in w.message.args[0].lower()
+        ]
+        self.assertEqual(
+            len(non_periodic), 0, f"Unexpected non-periodic warning(s): {non_periodic}"
+        )
+
+    def test_sigma3_111_spacing(self):
+        """Sigma3 (111) spacings must match the expected (111) CSL periodicities."""
+        gbm = self._make_gb(self.sigma3_111_180deg)
+        s = gbm.spacing
+        # Boundary normal [1,1,1]:            period = a0*sqrt(3)
+        # In-plane direction [-1,2,-1]/[1,-2,1]: period = a0*sqrt(6)
+        # In-plane direction [-1,0,1]/[1,0,-1]:  period = a0*sqrt(2)
+        self.assertAlmostEqual(s["x"]["left"], self.a0 * np.sqrt(3), places=5)
+        self.assertAlmostEqual(s["x"]["right"], self.a0 * np.sqrt(3), places=5)
+        self.assertAlmostEqual(s["y"], self.a0 * np.sqrt(6), places=5)
+        self.assertAlmostEqual(s["z"], self.a0 * np.sqrt(2), places=5)
+
+    def test_sigma3_111_x_dim_reasonable(self):
+        """x_dim must follow from the CSL x-spacing, not be thousands of Angstroms."""
+        gbm = self._make_gb(self.sigma3_111_180deg, x_dim_min=50)
+        # With spacing_x = a0*sqrt(3) ~ 6.25 A and x_dim_min=50,
+        # each grain is ceil(50/6.25)*6.25 ~ 50 A, so x_dim ~ 100 A.
+        # Before the fix, right_x was thousands of Angstroms.
+        x_spacing = self.a0 * np.sqrt(3)
+        expected_grain_x = math.ceil(50 / x_spacing) * x_spacing
+        self.assertAlmostEqual(gbm.x_dim, 2 * expected_grain_x, places=5)
+
+    def test_sigma3_111_via_setter(self):
+        """Same regression applies when misorientation is changed via the setter."""
+        theta = math.radians(36.869898)
+        gbm = self._make_gb(
+            np.array([theta, 0.0, 0.0, 0.0, -theta / 2.0]), repeat_factor=(2, 3))
+        gbm.misorientation = self.sigma3_111_180deg
+        # Confirm the grain was actually rebuilt, not just the spacing dict updated.
+        self.assertGreater(gbm.left_grain.shape[0], 0)
+        self.assertGreater(gbm.right_grain.shape[0], 0)
+        s = gbm.spacing
+        self.assertAlmostEqual(s["x"]["left"], self.a0 * np.sqrt(3), places=5)
+        self.assertAlmostEqual(s["x"]["right"], self.a0 * np.sqrt(3), places=5)
+        self.assertAlmostEqual(s["y"], self.a0 * np.sqrt(6), places=5)
+        self.assertAlmostEqual(s["z"], self.a0 * np.sqrt(2), places=5)
+
+    # ------------------------------------------------------------------
+    # Sigma3 (111) -- 60 deg misorientation representation
+    # ------------------------------------------------------------------
+
+    def test_sigma3_111_60deg_construction_succeeds(self):
+        """Sigma3 (111) described as 60 deg about [111] must also construct cleanly."""
+        gbm = self._make_gb(self.sigma3_111_60deg)
+        self.assertGreater(gbm.left_grain.shape[0], 0)
+        self.assertGreater(gbm.right_grain.shape[0], 0)
+
+    def test_sigma3_111_60deg_no_non_periodic_warning(self):
+        """60 deg Sigma3 (111) representation: no non-periodic boundary warning."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self._make_gb(self.sigma3_111_60deg)
+        non_periodic = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning)
+            and "non-periodic" in w.message.args[0].lower()
+        ]
+        self.assertEqual(
+            len(non_periodic), 0, f"Unexpected non-periodic warning(s): {non_periodic}"
+        )
+
+    def test_sigma3_111_60deg_spacing(self):
+        """60 deg Sigma3 (111): spacings must match the same (111) CSL periodicities."""
+        gbm = self._make_gb(self.sigma3_111_60deg)
+        s = gbm.spacing
+        self.assertAlmostEqual(s["x"]["left"], self.a0 * np.sqrt(3), places=5)
+        self.assertAlmostEqual(s["x"]["right"], self.a0 * np.sqrt(3), places=5)
+        self.assertAlmostEqual(s["y"], self.a0 * np.sqrt(6), places=5)
+        self.assertAlmostEqual(s["z"], self.a0 * np.sqrt(2), places=5)
+
+    # ------------------------------------------------------------------
+    # Self-validating guards (Gap 1 & 2)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _Rz(a):
+        c, s = np.cos(a), np.sin(a)
+        return np.array([[c, -s, 0], [s, c, 0], [0, 0, 1]], dtype=float)
+
+    @staticmethod
+    def _Rx(a):
+        c, s = np.cos(a), np.sin(a)
+        return np.array([[1, 0, 0], [0, c, -s], [0, s, c]], dtype=float)
+
+    @staticmethod
+    def _Ry(a):
+        c, s = np.cos(a), np.sin(a)
+        return np.array([[c, 0, s], [0, 1, 0], [-s, 0, c]], dtype=float)
+
+    def _decompose(self, mis):
+        """Return (R_mis, R_incl) from a 5-element misorientation array."""
+        alpha, beta, gamma, theta, phi = mis
+        R_mis = self._Rz(alpha) @ self._Rx(beta) @ self._Rz(gamma)
+        R_incl = self._Rz(phi) @ self._Ry(theta)
+        return R_mis, R_incl
+
+    def test_matrices_do_not_commute(self):
+        """Guard: sigma3_111_180deg must produce genuinely non-commuting R_mis and R_incl.
+
+        If the two matrices happened to commute, the spacing tests would pass even
+        with the wrong multiplication order, defeating their value as regressions.
+        """
+        R_mis, R_incl = self._decompose(self.sigma3_111_180deg)
+        self.assertFalse(
+            np.allclose(R_mis @ R_incl, R_incl @ R_mis),
+            "sigma3_111_180deg R_mis and R_incl must not commute; "
+            "if they did, the wrong multiplication order would not be detected.",
+        )
+
+    def test_spacing_uses_correct_matrix_order(self):
+        """The right-grain periodic spacing must come from R_incl @ R_mis, not R_mis @ R_incl.
+
+        For Sigma3 (111), row 0 of R_incl @ R_mis is [1,1,1]/sqrt(3), giving
+        x-spacing a0*sqrt(3).  The reversed product R_mis @ R_incl has a different
+        row 0 with irrational mixing of sqrt(2)/sqrt(3)/sqrt(6), so it does NOT
+        simplify to [1,1,1]/sqrt(3).  This test documents the invariant directly,
+        independent of GBMaker internals.
+        """
+        R_mis, R_incl = self._decompose(self.sigma3_111_180deg)
+        correct_row0 = (R_incl @ R_mis)[0]
+        self.assertTrue(
+            np.allclose(correct_row0, np.array([1, 1, 1]) / np.sqrt(3)),
+            f"Row 0 of R_incl @ R_mis should be [1,1,1]/sqrt(3), got {correct_row0}",
+        )
+        wrong_row0 = (R_mis @ R_incl)[0]
+        self.assertFalse(
+            np.allclose(wrong_row0, np.array([1, 1, 1]) / np.sqrt(3)),
+            "Row 0 of R_mis @ R_incl must NOT equal [1,1,1]/sqrt(3); "
+            "if it did, the wrong order would be indistinguishable from the correct one.",
+        )
+
+    def test_decompose_matches_gbmaker(self):
+        """_decompose must mirror GBMaker's internal rotation construction.
+
+        Two independent checks, one per matrix:
+
+        R_incl: for (111) inclination, Rz(phi) @ Ry(theta) must place [1,1,1]/sqrt(3)
+        in row 0.  A wrong R_incl order (e.g. Ry @ Rz) would produce a different row.
+
+        R_mis: for 180-deg rotation about [111], ZXZ Euler [3pi/4, arccos(-1/3), pi/4]
+        must yield [[-1/3, 2/3, 2/3], ...].  A wrong Euler series (e.g. ZYZ) would
+        produce a different matrix and R_mis[0,0] would not equal -1/3.
+        """
+        R_mis, R_incl = self._decompose(self.sigma3_111_180deg)
+        # R_incl check: row 0 must be [1,1,1]/sqrt(3).
+        expected_row0 = np.array([1.0, 1.0, 1.0]) / np.sqrt(3)
+        self.assertTrue(
+            np.allclose(R_incl[0], expected_row0, atol=1e-10),
+            f"_decompose R_incl[0] = {R_incl[0]}; expected [1,1,1]/sqrt(3). "
+            "Wrong R_incl construction order would produce a different row.",
+        )
+        # R_mis check: R_mis[0,0] must be -1/3 for 180-deg rotation about [111].
+        self.assertAlmostEqual(
+            R_mis[0, 0],
+            -1 / 3,
+            places=5,
+            msg=f"R_mis[0,0]={R_mis[0, 0]}; expected -1/3. "
+            "Wrong Euler series in _decompose (e.g. ZYZ vs ZXZ) would produce a different value.",
+        )
+
+    # ------------------------------------------------------------------
+    # Sigma7 (111) -- different R_mis, same inclination (Gap 3)
+    # ------------------------------------------------------------------
+
+    def test_sigma7_111_construction_succeeds(self):
+        """Regression: Sigma7 (111) must construct without ValueError."""
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            gbm = self._make_gb(self.sigma7_111)
+        self.assertGreater(gbm.left_grain.shape[0], 0)
+        self.assertGreater(gbm.right_grain.shape[0], 0)
+
+    def test_sigma7_111_x_spacing_correct(self):
+        """Sigma7 (111): x-spacing (boundary normal [111]) must be a0*sqrt(3) for both grains."""
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            gbm = self._make_gb(self.sigma7_111)
+        s = gbm.spacing
+        self.assertAlmostEqual(s["x"]["left"], self.a0 * np.sqrt(3), places=5)
+        self.assertAlmostEqual(s["x"]["right"], self.a0 * np.sqrt(3), places=5)
+
+    def test_sigma7_111_non_periodic_warning_expected(self):
+        """Sigma7 (111) right-grain y-period (~17.15*a0) exceeds the default 15*a0 threshold.
+
+        The right-grain y-direction row is [2,11,-13] with norm 7*sqrt(6)~17.15*a0,
+        which exceeds the 15*a0 threshold.  The z-direction row [-3,-5,8] has norm
+        7*sqrt(2)~9.90*a0, which does not.  Exactly one non-periodic warning is expected.
+        A non-periodic UserWarning is therefore correct behaviour, not an error.
+        """
+        # GBMaker.__calculate_periodic_spacing calls warnings.simplefilter("once", ...)
+        # without a catch_warnings guard, which populates the per-module
+        # __warningregistry__.  catch_warnings restores warnings.filters on exit but
+        # does NOT clear __warningregistry__, so if another Sigma7 test ran first the
+        # "once" filter would suppress the warning here.  Clear it explicitly.
+        mod = sys.modules.get("GBOpt.GBMaker")
+        if mod is not None and hasattr(mod, "__warningregistry__"):
+            mod.__warningregistry__.clear()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self._make_gb(self.sigma7_111)
+        non_periodic = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning)
+            and "non-periodic" in w.message.args[0].lower()
+        ]
+        self.assertEqual(
+            len(non_periodic),
+            1,
+            f"Expected exactly 1 non-periodic UserWarning for Sigma7 (111), "
+            f"got {len(non_periodic)}: {non_periodic}",
+        )
 
 
 class TestGBMakerNonCommutingBoundaries(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Rotation matrix multiplication produces coordinates like z ≈ -1e-16 for atoms that should sit exactly on the z=0 periodic boundary. The strict `>= z_min` check in `__get_points_inside_box` excluded these atoms; simultaneously, their periodic images at z ≈ z_dim + δ were excluded by `< z_max`. With both copies missing, structural voids appear as non-FCC atoms at the y/z seams in CNA analysis.
- Adds `eps = 1e-10` to all three lower bounds. Upper bounds are left strict to prevent periodic duplicates from being included.

## Changes
- `GBMaker.__get_points_inside_box`: adds `eps = 1e-10` tolerance to the x, y, and z lower bounds

## Test plan
- [x] Construct a Σ3 ⟨111⟩ coherent twin and confirm no non-FCC atoms appear at the y/z seams in CNA analysis
<img width="282" height="105" alt="image" src="https://github.com/user-attachments/assets/2d1d30ca-33cd-4b25-968e-1a8d6492ba97" />

- [x] `pytest -m 'not known_bug and not slow'` passes cleanly
  - Failing test from unrelated issue.

Depends on `fix_right_grain_error` (fixes #15) and #22 (closes #20).
Closes #24