### PR TITLE
Expose inplane_periodic as a public property on GBMaker

### DIFF
--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -1355,6 +1355,11 @@ class GBMaker:
 
     # Additional getters for other class properties
     @property
+    def inplane_periodic(self) -> tuple:
+        """Read-only view of the in-plane periodicity flags (y, z)."""
+        return tuple(bool(v) for v in self.__inplane_periodic)
+
+    @property
     def box_dims(self) -> np.ndarray:
         return self.__box_dims
 

--- a/tests/test_gbmaker.py
+++ b/tests/test_gbmaker.py
@@ -175,6 +175,17 @@ class TestGBMaker(unittest.TestCase):
         self.assertGreater(self.gbm.z_dim, 0)
         self.assertGreater(self.gbm.radius, 0)
 
+    def test_inplane_periodic_type_and_length(self):
+        result = self.gbm.inplane_periodic
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all(isinstance(v, bool) for v in result))
+
+    def test_inplane_periodic_fully_periodic_for_csl_boundary(self):
+        # Sigma5 [001] 36.87° boundary is a fully coherent CSL — both in-plane
+        # directions must be periodic.
+        self.assertEqual(self.gbm.inplane_periodic, (True, True))
+
     def test_box_dimensions(self):
         box_dims = self.gbm.box_dims
         self.assertTrue(isinstance(box_dims, np.ndarray))


### PR DESCRIPTION
The internal __inplane_periodic tuple was already computed during construction but inaccessible to users, forcing them to intercept warnings to determine coherence programmatically.

Closes #44