### PR TITLE
Add Stage A scaffolding for boundary-spec API

### DIFF
--- a/GBOpt/BoundarySpec.py
+++ b/GBOpt/BoundarySpec.py
@@ -1,0 +1,54 @@
+# Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
+
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+ConstructionMode = Literal["exact", "prefer_exact", "approximate"]
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+class BoundarySpecError(Exception):
+    """Base class for all boundary-spec validation failures."""
+
+
+class BoundarySpecTypeError(BoundarySpecError, TypeError):
+    """Raised when a boundary-spec field has the wrong type."""
+
+
+class BoundarySpecValueError(BoundarySpecError, ValueError):
+    """Raised when a boundary-spec field has an invalid value."""
+
+
+# ---------------------------------------------------------------------------
+# Boundary-format dataclasses
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class FiveDOFSpec:
+    params: Sequence[float]
+
+
+@dataclass(frozen=True)
+class PQSpec:
+    P: Sequence[Sequence[int | float]]
+    Q: Sequence[Sequence[int | float]]
+
+
+@dataclass(frozen=True)
+class _CSLSpecBase:
+    axis: Sequence[int]
+    plane: Sequence[int]
+    sigma: int | None = None
+
+
+@dataclass(frozen=True)
+class CSLExactSpec(_CSLSpecBase):
+    quat: Sequence[int] = None  # required; integer quaternion
+
+
+@dataclass(frozen=True)
+class CSLApproxSpec(_CSLSpecBase):
+    angle_deg: float = None

--- a/GBOpt/BoundarySpec.py
+++ b/GBOpt/BoundarySpec.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass
 from typing import Literal, Sequence
 
+import numpy as np
+
 ConstructionMode = Literal["exact", "prefer_exact", "approximate"]
 
 
@@ -52,3 +54,26 @@ class CSLExactSpec(_CSLSpecBase):
 @dataclass(frozen=True)
 class CSLApproxSpec(_CSLSpecBase):
     angle_deg: float = None
+
+
+# ---------------------------------------------------------------------------
+# Internal canonical boundary embedding
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class BoundaryEmbedding:
+    """Canonical internal representation produced by every input adapter.
+
+    P and Q are the exact row-wise orientation matrices (None for
+    approximate-only paths). R_left and R_right are floating-point rotation
+    matrices matching GBMaker's internal convention. exact and coherent flag
+    the construction path and interface type. source names the originating
+    format ("pq", "csl", "five_dof").
+    """
+    P: np.ndarray | None
+    Q: np.ndarray | None
+    R_left: np.ndarray
+    R_right: np.ndarray
+    exact: bool
+    coherent: bool
+    source: str

--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -1355,6 +1355,11 @@ class GBMaker:
 
     # Additional getters for other class properties
     @property
+    def inplane_periodic(self) -> tuple:
+        """Read-only view of the in-plane periodicity flags (y, z)."""
+        return tuple(bool(v) for v in self.__inplane_periodic)
+
+    @property
     def box_dims(self) -> np.ndarray:
         return self.__box_dims
 

--- a/GBOpt/Utils/gb_exact.py
+++ b/GBOpt/Utils/gb_exact.py
@@ -8,8 +8,6 @@ Each stub raises NotImplementedError until its owning step is complete.
 
 import numpy as np
 
-from GBOpt.BoundarySpec import BoundarySpecError
-
 
 def validate_and_normalize_quaternion(quat: np.ndarray) -> np.ndarray:
     """Validate that quat is an integer quaternion and return its normalized form.
@@ -125,6 +123,12 @@ def canonicalize_pq(
 ) -> tuple[np.ndarray, np.ndarray]:
     """Return canonical forms of the P and Q orientation matrices.
 
+    This is the Step 4 hook for canonical P/Q reconstruction. Callers
+    (Stage B/C adapters) are responsible for assembling P and Q from
+    CSL solve outputs (boundary normal + reduced in-plane basis vectors)
+    before passing them here. This function applies only the final
+    canonicalization rules — it does not reconstruct P/Q from scratch.
+
     Canonicalization rules:
     - rows are integer or exact rational directions reduced by gcd
     - matrices are right-handed (positive determinant after normalization)
@@ -136,7 +140,8 @@ def canonicalize_pq(
     Parameters
     ----------
     P, Q : np.ndarray of shape (3, 3)
-        Row-wise orientation matrices for each grain.
+        Row-wise orientation matrices for each grain, assembled by the
+        caller from the outputs of solve_inplane_csl / reduce_2d_basis.
 
     Returns
     -------

--- a/GBOpt/Utils/gb_exact.py
+++ b/GBOpt/Utils/gb_exact.py
@@ -1,0 +1,179 @@
+# Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
+
+"""Exact-solver utilities for canonical P/Q bicrystal construction.
+
+Functions here are filled in incrementally across Stages B and C.
+Each stub raises NotImplementedError until its owning step is complete.
+"""
+
+import numpy as np
+
+from GBOpt.BoundarySpec import BoundarySpecError
+
+
+def validate_and_normalize_quaternion(quat: np.ndarray) -> np.ndarray:
+    """Validate that quat is an integer quaternion and return its normalized form.
+
+    Parameters
+    ----------
+    quat : array-like of shape (4,)
+        Candidate integer quaternion [a, b, c, d].
+
+    Returns
+    -------
+    np.ndarray of shape (4,) with dtype float
+        Normalized quaternion (unit length).
+
+    Raises
+    ------
+    BoundarySpecError
+        If any component is non-integer or the quaternion is zero.
+    """
+    raise NotImplementedError
+
+
+def quaternion_to_rotation_matrix(quat: np.ndarray) -> np.ndarray:
+    """Convert a normalized integer quaternion to an exact rotation matrix.
+
+    Parameters
+    ----------
+    quat : np.ndarray of shape (4,)
+        Normalized unit quaternion [a, b, c, d] (integer-origin).
+
+    Returns
+    -------
+    np.ndarray of shape (3, 3)
+        Exact rotation matrix corresponding to quat.
+    """
+    raise NotImplementedError
+
+
+def validate_sigma(quat: np.ndarray, sigma: int) -> None:
+    """Validate that sigma derived from quat matches the user-supplied value.
+
+    Sigma is derived from the integer quaternion as the norm-squared divided
+    by its largest power-of-2 factor, which is always an exact odd integer.
+    Validation is therefore an exact equality check with no tolerance.
+
+    Parameters
+    ----------
+    quat : np.ndarray of shape (4,)
+        Integer quaternion (unnormalized).
+    sigma : int
+        User-provided sigma value to validate against.
+
+    Raises
+    ------
+    BoundarySpecError
+        If the derived sigma does not exactly match the provided value.
+    """
+    raise NotImplementedError
+
+
+def solve_inplane_csl(
+    axis: np.ndarray,
+    plane: np.ndarray,
+    R: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Solve the exact in-plane CSL basis from rotation axis, boundary plane, and R.
+
+    Parameters
+    ----------
+    axis : np.ndarray of shape (3,)
+        Integer Miller rotation axis [u v w].
+    plane : np.ndarray of shape (3,)
+        Integer Miller boundary-plane normal [h k l].
+    R : np.ndarray of shape (3, 3)
+        Exact rotation matrix from quaternion_to_rotation_matrix.
+
+    Returns
+    -------
+    v1, v2 : np.ndarray of shape (3,)
+        Two in-plane CSL basis vectors (pre-reduction).
+
+    Raises
+    ------
+    BoundarySpecError
+        If no exact CSL reconstruction is found or the input is not a
+        rational CSL boundary.
+    """
+    raise NotImplementedError
+
+
+def reduce_2d_basis(
+    v1: np.ndarray,
+    v2: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Apply 2D lattice reduction to a pair of in-plane basis vectors.
+
+    Parameters
+    ----------
+    v1, v2 : np.ndarray of shape (3,)
+        In-plane basis vectors to reduce.
+
+    Returns
+    -------
+    r1, r2 : np.ndarray of shape (3,)
+        Reduced basis vectors in canonical (short, deterministic) form.
+    """
+    raise NotImplementedError
+
+
+def canonicalize_pq(
+    P: np.ndarray,
+    Q: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return canonical forms of the P and Q orientation matrices.
+
+    Canonicalization rules:
+    - rows are integer or exact rational directions reduced by gcd
+    - matrices are right-handed (positive determinant after normalization)
+    - row 0 is the boundary normal
+    - rows 1-2 form a deterministic reduced in-plane basis
+    - sign and ordering conventions are fixed so equivalent inputs
+      canonicalize identically
+
+    Parameters
+    ----------
+    P, Q : np.ndarray of shape (3, 3)
+        Row-wise orientation matrices for each grain.
+
+    Returns
+    -------
+    P_canon, Q_canon : np.ndarray of shape (3, 3)
+        Canonicalized orientation matrices.
+    """
+    raise NotImplementedError
+
+
+def exactify_five_dof(
+    params: np.ndarray,
+    max_exact_atoms: int = 10_000,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Attempt to rationalize a 5-DOF input to exact canonical P/Q.
+
+    Bounded search from floating 5-DOF [alpha, beta, gamma, theta, phi]
+    to the nearest cubic CSL boundary. Deferred — raises NotImplementedError
+    until Stage E.
+
+    Parameters
+    ----------
+    params : np.ndarray of shape (5,)
+        Five-DOF misorientation parameters in radians.
+    max_exact_atoms : int
+        Upper bound on commensurate cell size; raises BoundarySpecError
+        if the exact cell would exceed this limit.
+
+    Returns
+    -------
+    P_canon, Q_canon : np.ndarray of shape (3, 3)
+        Canonical orientation matrices for the nearest CSL boundary.
+
+    Raises
+    ------
+    NotImplementedError
+        Always, until Stage E is implemented.
+    BoundarySpecError
+        If no CSL boundary is found within max_exact_atoms.
+    """
+    raise NotImplementedError

--- a/tests/test_boundary_spec.py
+++ b/tests/test_boundary_spec.py
@@ -1,0 +1,127 @@
+# Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
+
+import pytest
+from GBOpt.BoundarySpec import (
+    FiveDOFSpec,
+    PQSpec,
+    CSLExactSpec,
+    CSLApproxSpec,
+    ConstructionMode,
+    BoundarySpecError,
+    BoundarySpecTypeError,
+    BoundarySpecValueError,
+    _CSLSpecBase,
+)
+
+
+class TestImports:
+    def test_all_public_names_importable(self):
+        # Acceptance criterion: imports succeed
+        assert FiveDOFSpec is not None
+        assert PQSpec is not None
+        assert CSLExactSpec is not None
+        assert CSLApproxSpec is not None
+        assert BoundarySpecError is not None
+
+    def test_construction_mode_values(self):
+        # ConstructionMode is a typing.Literal — check it exists and its args
+        import typing
+        args = typing.get_args(ConstructionMode)
+        assert set(args) == {"exact", "prefer_exact", "approximate"}
+
+
+class TestFiveDOFSpec:
+    def test_frozen(self):
+        spec = FiveDOFSpec(params=[0.1, 0.2, 0.3, 0.4, 0.5])
+        with pytest.raises((AttributeError, TypeError)):
+            spec.params = [1, 2, 3, 4, 5]
+
+    def test_stores_params(self):
+        p = [0.1, 0.2, 0.3, 0.4, 0.5]
+        spec = FiveDOFSpec(params=p)
+        assert list(spec.params) == p
+
+
+class TestPQSpec:
+    def test_frozen(self):
+        P = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        Q = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        spec = PQSpec(P=P, Q=Q)
+        with pytest.raises((AttributeError, TypeError)):
+            spec.P = [[2, 0, 0], [0, 2, 0], [0, 0, 2]]
+
+    def test_stores_p_and_q(self):
+        P = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        Q = [[0, 1, 0], [1, 0, 0], [0, 0, 1]]
+        spec = PQSpec(P=P, Q=Q)
+        assert spec.P == P
+        assert spec.Q == Q
+
+
+class TestCSLSpecBase:
+    def test_frozen(self):
+        spec = _CSLSpecBase(axis=[0, 0, 1], plane=[1, 0, 0])
+        with pytest.raises((AttributeError, TypeError)):
+            spec.axis = [1, 1, 0]
+
+    def test_sigma_defaults_to_none(self):
+        spec = _CSLSpecBase(axis=[0, 0, 1], plane=[1, 0, 0])
+        assert spec.sigma is None
+
+    def test_sigma_stored(self):
+        spec = _CSLSpecBase(axis=[0, 0, 1], plane=[1, 0, 0], sigma=5)
+        assert spec.sigma == 5
+
+
+class TestCSLExactSpec:
+    def test_frozen(self):
+        spec = CSLExactSpec(axis=[0, 0, 1], plane=[1, 0, 0], quat=[3, 1, 0, 0])
+        with pytest.raises((AttributeError, TypeError)):
+            spec.quat = [1, 0, 0, 0]
+
+    def test_stores_quat(self):
+        spec = CSLExactSpec(axis=[0, 0, 1], plane=[1, 0, 0], quat=[3, 1, 0, 0])
+        assert spec.quat == [3, 1, 0, 0]
+
+    def test_sigma_optional(self):
+        spec = CSLExactSpec(axis=[0, 0, 1], plane=[1, 0, 0], quat=[3, 1, 0, 0], sigma=5)
+        assert spec.sigma == 5
+
+    def test_inherits_base(self):
+        assert issubclass(CSLExactSpec, _CSLSpecBase)
+
+
+class TestCSLApproxSpec:
+    def test_frozen(self):
+        spec = CSLApproxSpec(axis=[0, 0, 1], plane=[1, 0, 0], angle_deg=36.87)
+        with pytest.raises((AttributeError, TypeError)):
+            spec.angle_deg = 45.0
+
+    def test_stores_angle_deg(self):
+        spec = CSLApproxSpec(axis=[0, 0, 1], plane=[1, 0, 0], angle_deg=36.87)
+        assert spec.angle_deg == 36.87
+
+    def test_inherits_base(self):
+        assert issubclass(CSLApproxSpec, _CSLSpecBase)
+
+
+class TestBoundarySpecErrorHierarchy:
+    def test_base_is_exception(self):
+        assert issubclass(BoundarySpecError, Exception)
+
+    def test_type_error_subclasses_base(self):
+        assert issubclass(BoundarySpecTypeError, BoundarySpecError)
+        assert issubclass(BoundarySpecTypeError, TypeError)
+
+    def test_value_error_subclasses_base(self):
+        assert issubclass(BoundarySpecValueError, BoundarySpecError)
+        assert issubclass(BoundarySpecValueError, ValueError)
+
+    def test_independent_from_gbmaker_errors(self):
+        from GBOpt.GBMaker import GBMakerError
+        assert not issubclass(BoundarySpecError, GBMakerError)
+        assert not issubclass(GBMakerError, BoundarySpecError)
+
+    def test_raise_and_catch_as_base(self):
+        with pytest.raises(BoundarySpecError):
+            raise BoundarySpecValueError("invalid field")

--- a/tests/test_boundary_spec.py
+++ b/tests/test_boundary_spec.py
@@ -1,5 +1,6 @@
 # Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
 
+import numpy as np
 import pytest
 from GBOpt.BoundarySpec import (
     FiveDOFSpec,
@@ -11,6 +12,7 @@ from GBOpt.BoundarySpec import (
     BoundarySpecTypeError,
     BoundarySpecValueError,
     _CSLSpecBase,
+    BoundaryEmbedding,
 )
 
 
@@ -125,3 +127,33 @@ class TestBoundarySpecErrorHierarchy:
     def test_raise_and_catch_as_base(self):
         with pytest.raises(BoundarySpecError):
             raise BoundarySpecValueError("invalid field")
+
+
+class TestBoundaryEmbedding:
+    def _make(self, P=None, Q=None, exact=True, coherent=True, source="pq"):
+        R = np.eye(3)
+        return BoundaryEmbedding(
+            P=P, Q=Q, R_left=R, R_right=R,
+            exact=exact, coherent=coherent, source=source,
+        )
+
+    def test_instantiate_with_arrays(self):
+        P = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        Q = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]], dtype=float)
+        emb = self._make(P=P, Q=Q)
+        assert np.array_equal(emb.P, P)
+        assert np.array_equal(emb.Q, Q)
+        assert np.array_equal(emb.R_left, np.eye(3))
+        assert np.array_equal(emb.R_right, np.eye(3))
+
+    def test_instantiate_with_none_pq(self):
+        emb = self._make(P=None, Q=None, exact=False, coherent=False, source="five_dof")
+        assert emb.P is None
+        assert emb.Q is None
+        assert emb.exact is False
+        assert emb.coherent is False
+        assert emb.source == "five_dof"
+
+    def test_source_stored(self):
+        emb = self._make(source="csl")
+        assert emb.source == "csl"

--- a/tests/test_boundary_spec.py
+++ b/tests/test_boundary_spec.py
@@ -28,6 +28,7 @@ class TestImports:
     def test_construction_mode_values(self):
         # ConstructionMode is a typing.Literal — check it exists and its args
         import typing
+
         args = typing.get_args(ConstructionMode)
         assert set(args) == {"exact", "prefer_exact", "approximate"}
 
@@ -41,7 +42,7 @@ class TestFiveDOFSpec:
     def test_stores_params(self):
         p = [0.1, 0.2, 0.3, 0.4, 0.5]
         spec = FiveDOFSpec(params=p)
-        assert list(spec.params) == p
+        np.testing.assert_allclose(list(spec.params), p, atol=1e-15, rtol=0)
 
 
 class TestPQSpec:
@@ -101,7 +102,7 @@ class TestCSLApproxSpec:
 
     def test_stores_angle_deg(self):
         spec = CSLApproxSpec(axis=[0, 0, 1], plane=[1, 0, 0], angle_deg=36.87)
-        assert spec.angle_deg == 36.87
+        np.testing.assert_allclose(spec.angle_deg, 36.87, atol=1e-12, rtol=0)
 
     def test_inherits_base(self):
         assert issubclass(CSLApproxSpec, _CSLSpecBase)
@@ -121,6 +122,7 @@ class TestBoundarySpecErrorHierarchy:
 
     def test_independent_from_gbmaker_errors(self):
         from GBOpt.GBMaker import GBMakerError
+
         assert not issubclass(BoundarySpecError, GBMakerError)
         assert not issubclass(GBMakerError, BoundarySpecError)
 
@@ -133,18 +135,23 @@ class TestBoundaryEmbedding:
     def _make(self, P=None, Q=None, exact=True, coherent=True, source="pq"):
         R = np.eye(3)
         return BoundaryEmbedding(
-            P=P, Q=Q, R_left=R, R_right=R,
-            exact=exact, coherent=coherent, source=source,
+            P=P,
+            Q=Q,
+            R_left=R,
+            R_right=R,
+            exact=exact,
+            coherent=coherent,
+            source=source,
         )
 
     def test_instantiate_with_arrays(self):
         P = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
         Q = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]], dtype=float)
         emb = self._make(P=P, Q=Q)
-        assert np.array_equal(emb.P, P)
-        assert np.array_equal(emb.Q, Q)
-        assert np.array_equal(emb.R_left, np.eye(3))
-        assert np.array_equal(emb.R_right, np.eye(3))
+        np.testing.assert_allclose(emb.P, P, atol=1e-15, rtol=0)
+        np.testing.assert_allclose(emb.Q, Q, atol=1e-15, rtol=0)
+        np.testing.assert_allclose(emb.R_left, np.eye(3), atol=1e-15, rtol=0)
+        np.testing.assert_allclose(emb.R_right, np.eye(3), atol=1e-15, rtol=0)
 
     def test_instantiate_with_none_pq(self):
         emb = self._make(P=None, Q=None, exact=False, coherent=False, source="five_dof")
@@ -157,3 +164,46 @@ class TestBoundaryEmbedding:
     def test_source_stored(self):
         emb = self._make(source="csl")
         assert emb.source == "csl"
+
+
+class TestGBExactSkeleton:
+    """Verify the gb_exact stub surface is present and raises NotImplementedError."""
+
+    def test_module_importable(self):
+        import GBOpt.Utils.gb_exact as gb_exact
+
+        assert gb_exact is not None
+
+    def test_expected_functions_present(self):
+        import GBOpt.Utils.gb_exact as gb_exact
+
+        expected = [
+            "validate_and_normalize_quaternion",
+            "quaternion_to_rotation_matrix",
+            "validate_sigma",
+            "solve_inplane_csl",
+            "reduce_2d_basis",
+            "canonicalize_pq",
+            "exactify_five_dof",
+        ]
+        for name in expected:
+            assert hasattr(gb_exact, name), f"gb_exact missing: {name}"
+
+    def test_stubs_raise_not_implemented(self):
+        import GBOpt.Utils.gb_exact as gb_exact
+
+        dummy = np.zeros(4)
+        dummy3 = np.zeros(3)
+        dummy33 = np.eye(3)
+        cases = [
+            lambda: gb_exact.validate_and_normalize_quaternion(dummy),
+            lambda: gb_exact.quaternion_to_rotation_matrix(dummy),
+            lambda: gb_exact.validate_sigma(dummy, 5),
+            lambda: gb_exact.solve_inplane_csl(dummy3, dummy3, dummy33),
+            lambda: gb_exact.reduce_2d_basis(dummy3, dummy3),
+            lambda: gb_exact.canonicalize_pq(dummy33, dummy33),
+            lambda: gb_exact.exactify_five_dof(np.zeros(5)),
+        ]
+        for fn in cases:
+            with pytest.raises(NotImplementedError):
+                fn()

--- a/tests/test_gbmaker.py
+++ b/tests/test_gbmaker.py
@@ -175,6 +175,17 @@ class TestGBMaker(unittest.TestCase):
         self.assertGreater(self.gbm.z_dim, 0)
         self.assertGreater(self.gbm.radius, 0)
 
+    def test_inplane_periodic_type_and_length(self):
+        result = self.gbm.inplane_periodic
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all(isinstance(v, bool) for v in result))
+
+    def test_inplane_periodic_fully_periodic_for_csl_boundary(self):
+        # Sigma5 [001] 36.87° boundary is a fully coherent CSL — both in-plane
+        # directions must be periodic.
+        self.assertEqual(self.gbm.inplane_periodic, (True, True))
+
     def test_box_dimensions(self):
         box_dims = self.gbm.box_dims
         self.assertTrue(isinstance(box_dims, np.ndarray))


### PR DESCRIPTION
## Stage A: Scaffolding for the boundary-spec API

Lays the groundwork for the new `from_boundary_spec` interface without changing any existing behavior.

- `GBMaker.inplane_periodic` — exposes the existing internal coherence flag as a read-only public property.
- `GBOpt/BoundarySpec.py` — new module with frozen dataclasses for the three supported input formats (`FiveDOFSpec`, `PQSpec`, `CSLExactSpec`/`CSLApproxSpec`), the `ConstructionMode` literal type, a `BoundarySpecError` exception hierarchy independent of `GBMakerError`, and the `BoundaryEmbedding` internal object that all future input adapters will produce.
- `GBOpt/Utils/gb_exact.py` — new module with typed, docstring-annotated stubs for all exact-solver functions (quaternion validation, rotation matrix conversion, sigma validation, in-plane CSL solve, 2D lattice reduction, `P`/`Q` canonicalization, and `five_dof` exactification). Each raises `NotImplementedError` until filled in by Stages B–E.

No existing tests are affected. Closes #45.
Requires #50 