### PR TITLE
Boundary-spec scaffolding, dataclasses, and exact P/Q construction

### DIFF
--- a/GBOpt/BoundarySpec.py
+++ b/GBOpt/BoundarySpec.py
@@ -1,0 +1,86 @@
+# Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
+
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+import numpy as np
+
+ConstructionMode = Literal["exact", "prefer_exact", "approximate"]
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+class BoundarySpecError(Exception):
+    """Base class for all boundary-spec validation failures."""
+
+
+class BoundarySpecTypeError(BoundarySpecError, TypeError):
+    """Raised when a boundary-spec field has the wrong type."""
+
+
+class BoundarySpecValueError(BoundarySpecError, ValueError):
+    """Raised when a boundary-spec field has an invalid value."""
+
+
+# ---------------------------------------------------------------------------
+# Boundary-format dataclasses
+# ---------------------------------------------------------------------------
+
+def _validate_pq_matrix(m, name: str) -> None:
+    """Raise BoundarySpecError if m is not a valid 3x3 non-singular finite matrix.
+
+    Called from PQSpec.__post_init__ for each of P and Q.
+    """
+    try:
+        arr = np.asarray(m, dtype=float)
+    except (ValueError, TypeError) as e:
+        raise BoundarySpecTypeError(
+            f"PQSpec.{name} cannot be converted to a numeric array: {e}"
+        ) from e
+    if arr.ndim != 2 or arr.shape != (3, 3):
+        raise BoundarySpecValueError(
+            f"PQSpec.{name} must be a 3x3 matrix; got shape {arr.shape}"
+        )
+    if not np.all(np.isfinite(arr)):
+        raise BoundarySpecValueError(
+            f"PQSpec.{name} contains non-finite entries (NaN or inf)"
+        )
+    if abs(np.linalg.det(arr)) < 1e-12:
+        raise BoundarySpecValueError(
+            f"PQSpec.{name} is singular (determinant ~= 0)"
+        )
+
+
+@dataclass(frozen=True)
+class PQSpec:
+    P: Sequence[Sequence[int | float]]
+    Q: Sequence[Sequence[int | float]]
+
+    def __post_init__(self):
+        _validate_pq_matrix(self.P, "P")
+        _validate_pq_matrix(self.Q, "Q")
+
+
+# ---------------------------------------------------------------------------
+# Internal canonical boundary embedding
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class BoundaryEmbedding:
+    """Canonical internal representation produced by every input adapter.
+
+    P and Q are the exact row-wise orientation matrices (None for
+    approximate-only paths). R_left and R_right are floating-point rotation
+    matrices matching GBMaker's internal convention. exact and coherent flag
+    the construction path and interface type. source names the originating
+    format ("pq", "csl", "five_dof").
+    """
+    P: np.ndarray | None
+    Q: np.ndarray | None
+    R_left: np.ndarray
+    R_right: np.ndarray
+    exact: bool
+    coherent: bool
+    source: str

--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -10,6 +10,8 @@ import numpy as np
 from scipy.spatial.transform import Rotation
 
 from GBOpt.UnitCell import UnitCell
+from GBOpt.BoundarySpec import PQSpec
+from GBOpt.Utils.gb_exact import pq_spec_to_embedding
 
 
 class GBMakerError(Exception):
@@ -77,6 +79,7 @@ class GBMaker:
 
     def __init__(self, a0: float, structure: str, gb_thickness: float,
                  misorientation: np.ndarray, atom_types: str | Tuple[str, ...], *,
+                 _embedding=None,
                  repeat_factor: Union[int, Sequence[int]] = 2, x_dim_min: float = 50,
                  vacuum: float = 10, interaction_distance: float = 15.0,
                  gb_id: int = 1, epsilon: float = 1e-10):
@@ -112,6 +115,7 @@ class GBMaker:
         )
         self.__id = self.__validate(gb_id, int, "id", positive=True)
         self.__inplane_periodic = (True, True)
+        self.__embedding = _embedding
 
         self.__unit_cell = self.__init_unit_cell(atom_types)
         self.__spacing = self.__calculate_periodic_spacing()  # periodic distances dict
@@ -119,6 +123,112 @@ class GBMaker:
 
         self.__radius = a0 * self.__unit_cell.radius  # atom radius
         self.__box_dims = self.__calculate_box_dimensions()
+
+    @classmethod
+    def _from_boundary_embedding(
+        cls,
+        embedding,
+        *,
+        a0: float,
+        structure: str,
+        atom_types,
+        gb_thickness: float = 0.0,
+        repeat_factor=2,
+        x_dim_min: float = 50,
+        vacuum: float = 10,
+        interaction_distance: float = 15.0,
+        gb_id: int = 1,
+    ) -> "GBMaker":
+        """Build a GBMaker from a BoundaryEmbedding.
+
+        :param embedding: A BoundaryEmbedding produced by an input adapter. When
+            ``embedding.exact`` is True and P/Q are present, the integer matrices are
+            used directly as the approx rotation matrices, bypassing
+            ``__approximate_rotation_matrix_as_int``. When ``embedding.exact`` is False,
+            R_left/R_right are used on the existing floating-point approximation path.
+            ``embedding.coherent`` sets ``inplane_periodic``.
+        :param a0: Crystal lattice parameter (Angstroms).
+        :param structure: Crystal structure string.
+        :param atom_types: Atom type string or tuple of strings.
+        :param gb_thickness: Width of the GB region (Angstroms), default 0.
+        :param repeat_factor: In-plane repeat factor(s), default 2.
+        :param x_dim_min: Minimum grain thickness in x (Angstroms), default 50.
+        :param vacuum: Vacuum thickness (Angstroms), default 10.
+        :param interaction_distance: Maximum atom interaction distance, default 15.
+        :param gb_id: Grain boundary identifier, default 1.
+        :return: Fully initialized GBMaker instance.
+        """
+        return cls(
+            a0, structure, gb_thickness, np.zeros(5), atom_types,
+            _embedding=embedding,
+            repeat_factor=repeat_factor,
+            x_dim_min=x_dim_min,
+            vacuum=vacuum,
+            interaction_distance=interaction_distance,
+            gb_id=gb_id,
+        )
+
+    @classmethod
+    def from_boundary_spec(
+        cls,
+        a0: float,
+        structure: str,
+        atom_types,
+        boundary,
+        mode: str = "exact",
+        *,
+        gb_thickness: float = 0.0,
+        repeat_factor=2,
+        x_dim_min: float = 50,
+        vacuum: float = 10,
+        interaction_distance: float = 15.0,
+        gb_id: int = 1,
+    ) -> "GBMaker":
+        """Public factory that builds a GBMaker from a boundary-spec dataclass.
+
+        :param a0: Crystal lattice parameter (Angstroms).
+        :param structure: Crystal structure string.
+        :param atom_types: Atom type string or tuple of strings.
+        :param boundary: A boundary-spec dataclass. Only ``PQSpec`` is supported;
+            all other types raise ``NotImplementedError``.
+        :param mode: Construction mode — one of ``"exact"``, ``"prefer_exact"``, or
+            ``"approximate"``. Only ``"exact"`` is supported for ``PQSpec``; the others
+            raise ``NotImplementedError``.
+        :param gb_thickness: Width of the GB region (Angstroms), default 0.
+        :param repeat_factor: In-plane repeat factor(s), default 2.
+        :param x_dim_min: Minimum grain thickness in x (Angstroms), default 50.
+        :param vacuum: Vacuum thickness (Angstroms), default 10.
+        :param interaction_distance: Maximum atom interaction distance, default 15.
+        :param gb_id: Grain boundary identifier, default 1.
+        :return: Fully initialized GBMaker instance.
+        :raises NotImplementedError: For any boundary spec type other than ``PQSpec``,
+            or for modes other than ``"exact"`` with ``PQSpec``.
+        """
+        if not isinstance(boundary, PQSpec):
+            raise NotImplementedError(
+                f"from_boundary_spec does not yet support {type(boundary).__name__}; "
+                f"only PQSpec is currently implemented."
+            )
+
+        if mode != "exact":
+            raise NotImplementedError(
+                f"Construction mode '{mode}' is not yet supported for PQSpec; "
+                f"only mode='exact' is currently implemented."
+            )
+
+        embedding = pq_spec_to_embedding(boundary)
+        return cls._from_boundary_embedding(
+            embedding,
+            a0=a0,
+            structure=structure,
+            atom_types=atom_types,
+            gb_thickness=gb_thickness,
+            repeat_factor=repeat_factor,
+            x_dim_min=x_dim_min,
+            vacuum=vacuum,
+            interaction_distance=interaction_distance,
+            gb_id=gb_id,
+        )
 
     @staticmethod
     def __reduce_integer_row(row: np.ndarray) -> np.ndarray:
@@ -160,7 +270,7 @@ class GBMaker:
         """
         Find the smallest-norm integer vector that points within *angle_tol_deg* of
         *row*. LLL lattice reduction was considered but not adopted: for CSL boundaries
-        the correct scale factor k equals ‖g‖ ≤ √Σ (typically < 10), so the loop exits
+        the correct scale factor k equals ||g|| <= √Sigma (typically < 10), so the loop exits
         in a handful of iterations. The LLL selection step also requires enumerating
         signed combinations of reduced basis rows — adding ~60 lines for no practical
         gain.
@@ -309,14 +419,33 @@ class GBMaker:
         if threshold is None:
             threshold = self.__a0 * 15
 
-        # approximate the rotation matrix as integers
-        self.__R_left = self.__Rincl
-        self.__R_right = np.dot(self.__Rincl, self.__Rmis)
-        # # We store the approximate matrices as objects to allow for large numbers
-        self.__R_left_approx = self.__approximate_rotation_matrix_as_int(
-            self.__R_left).astype(object)
-        self.__R_right_approx = self.__approximate_rotation_matrix_as_int(
-            self.__R_right).astype(object)
+        if self.__embedding is not None:
+            # Exact or approximate path driven by a BoundaryEmbedding.
+            self.__R_left = self.__embedding.R_left
+            self.__R_right = self.__embedding.R_right
+            if self.__embedding.exact and self.__embedding.P is not None:
+                # Use exact integer matrices directly; bypass approximation.
+                # Round first so float-valued canonical arrays (e.g. 4.0)
+                # become Python ints, then cast to object dtype so that large
+                # Miller indices don't overflow int64 in norm calculations.
+                self.__R_left_approx = np.round(
+                    self.__embedding.P).astype(int).astype(object)
+                self.__R_right_approx = np.round(
+                    self.__embedding.Q).astype(int).astype(object)
+            else:
+                self.__R_left_approx = self.__approximate_rotation_matrix_as_int(
+                    self.__R_left).astype(object)
+                self.__R_right_approx = self.__approximate_rotation_matrix_as_int(
+                    self.__R_right).astype(object)
+        else:
+            # Legacy path: derive rotation matrices from Euler angles.
+            self.__R_left = self.__Rincl
+            self.__R_right = np.dot(self.__Rincl, self.__Rmis)
+            # We store the approximate matrices as objects to allow for large numbers
+            self.__R_left_approx = self.__approximate_rotation_matrix_as_int(
+                self.__R_left).astype(object)
+            self.__R_right_approx = self.__approximate_rotation_matrix_as_int(
+                self.__R_right).astype(object)
 
         # The periodic distance in each direction is the lattice parameter multiplied by
         # norm of the Miller indices in that direction. This is determined using the
@@ -353,19 +482,25 @@ class GBMaker:
             }
         )
 
-        inplane_periodic = []
-        for key, val in spacing.items():
-            if key == 'x':
-                continue
-            is_periodic = val <= threshold
-            inplane_periodic.append(is_periodic)
-            if not is_periodic:
-                spacing[key] = threshold
-                warnings.warn(
-                    f"Required {key}-spacing {val:.4f} Å exceeds threshold "
-                    f"{threshold:.4f} Å; boundary is non-periodic along {key}."
-                )
-        self.__inplane_periodic = tuple(inplane_periodic)
+        if self.__embedding is not None:
+            # Trust the embedding's coherence flag directly; it is set by
+            # the input adapter and reflects the exact construction intent.
+            coherent = self.__embedding.coherent
+            self.__inplane_periodic = (coherent, coherent)
+        else:
+            inplane_periodic = []
+            for key, val in spacing.items():
+                if key == 'x':
+                    continue
+                is_periodic = val <= threshold
+                inplane_periodic.append(is_periodic)
+                if not is_periodic:
+                    spacing[key] = threshold
+                    warnings.warn(
+                        f"Required {key}-spacing {val:.4f} A exceeds threshold "
+                        f"{threshold:.4f} A; boundary is non-periodic along {key}."
+                    )
+            self.__inplane_periodic = tuple(inplane_periodic)
 
         return spacing
 
@@ -1295,6 +1430,9 @@ class GBMaker:
             Rotation.from_euler("z", misorientation[4])
             * Rotation.from_euler("y", misorientation[3])
         ).as_matrix()
+        # Discard any active embedding so update_spacing uses the new Euler
+        # angles rather than the stale embedding-derived rotation matrices.
+        self.__embedding = None
         self.update_spacing()
 
     @property

--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -1355,6 +1355,11 @@ class GBMaker:
 
     # Additional getters for other class properties
     @property
+    def inplane_periodic(self) -> tuple:
+        """Read-only view of the in-plane periodicity flags (y, z)."""
+        return tuple(bool(v) for v in self.__inplane_periodic)
+
+    @property
     def box_dims(self) -> np.ndarray:
         return self.__box_dims
 

--- a/GBOpt/Utils/gb_exact.py
+++ b/GBOpt/Utils/gb_exact.py
@@ -1,0 +1,217 @@
+# Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
+
+"""Exact-solver utilities for canonical P/Q bicrystal construction."""
+
+import math
+
+import numpy as np
+
+from GBOpt.BoundarySpec import BoundaryEmbedding, BoundarySpecError, PQSpec
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers for canonicalization
+# ---------------------------------------------------------------------------
+
+def _row_gcd_reduce(row: np.ndarray) -> np.ndarray:
+    """Divide an integer-valued row by the GCD of its absolute components."""
+    ints = np.round(row).astype(int)
+    running_gcd = 0
+    for component in ints:
+        running_gcd = math.gcd(running_gcd, int(abs(component)))
+    if running_gcd <= 1:
+        return ints.astype(float)
+    return (ints // running_gcd).astype(float)
+
+
+def _assert_integer_rows(M: np.ndarray, name: str) -> None:
+    """Raise BoundarySpecError if any row of M is not close to integer-valued."""
+    for i, row in enumerate(M):
+        if not np.allclose(row, np.round(row), atol=1e-9, rtol=0.0):
+            raise BoundarySpecError(
+                f"{name} row {i} {row} is not integer-valued. "
+                "P/Q rows must be integer Miller indices."
+            )
+
+
+def _first_nonzero_sign(row: np.ndarray) -> int:
+    """Return +1 if the first nonzero component of row is positive, -1 if negative, 0 if all zero."""
+    for v in row:
+        if v != 0:
+            return 1 if v > 0 else -1
+    return 0
+
+
+def _gauss_reduce_2d(
+    v1: np.ndarray, v2: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Gauss-Lagrange 2D lattice reduction using integer arithmetic; returns (shorter, longer).
+
+    Inputs are expected to be integer-valued (as produced by _row_gcd_reduce).
+    Integer dot products and integer rounding are used throughout to avoid
+    floating-point precision loss for large Miller indices.
+
+    .. note::
+        Shortness is measured by the Euclidean inner product, which assumes an
+        orthonormal basis. For non-cubic systems, pass vectors in Cartesian
+        coordinates; passing raw Miller-index vectors in a non-cubic cell will
+        give an incorrect reduced basis.
+    """
+    import warnings
+
+    a = np.round(v1).astype(int)
+    b = np.round(v2).astype(int)
+    for _ in range(200):
+        aa = int(np.dot(a, a))
+        bb = int(np.dot(b, b))
+        if bb < aa:
+            a, b = b, a
+            aa = bb
+        if aa == 0:
+            break
+        ab = int(np.dot(a, b))
+        t = (ab + aa // 2) // aa
+        if t == 0:
+            break
+        b = b - t * a
+    else:
+        warnings.warn(
+            "Gauss reduction did not converge in 200 iterations; result may be unreduced",
+            stacklevel=3,
+        )
+    return a, b
+
+
+def _canonicalize_matrix(M: np.ndarray) -> np.ndarray:
+    """Return the canonical form of a single 3x3 orientation matrix.
+
+    Sign convention:
+    - Row 0 (boundary normal): first nonzero component positive.
+      Compensating negation of row 2 preserves the determinant.
+    - Row 1 (first in-plane direction): first nonzero component positive.
+      Compensating negation of row 2 preserves the determinant.
+    - Row 2 sign: absorbs all compensating negations above, then a final
+      determinant check ensures right-handedness.  Row 2 is never given
+      an independent sign convention; its sign is fully derived.
+    """
+    # GCD-reduce each row
+    rows = [_row_gcd_reduce(M[i]) for i in range(3)]
+
+    # Gauss-reduce the in-plane rows (1 and 2), then GCD-reduce each.
+    # The reduction may swap rows, which can flip the determinant.
+    r1, r2 = _gauss_reduce_2d(rows[1], rows[2])
+    rows[1] = _row_gcd_reduce(r1)
+    rows[2] = _row_gcd_reduce(r2)
+
+    # Deterministic in-plane row ordering: put the row with the larger
+    # (norm_sq, canonical_sign_tuple) key into rows[1].  "Canonical sign"
+    # negates a row whose first nonzero component is negative so that the lex
+    # comparison is independent of sign convention.  Sorting here — before any
+    # sign fixing — ensures equivalent in-plane bases that differ only by row
+    # order produce the same canonical matrix.
+    def _inplane_key(row: np.ndarray) -> tuple:
+        rv = row.astype(int)
+        if _first_nonzero_sign(rv) < 0:
+            rv = -rv
+        return (int(np.dot(rv, rv)), tuple(rv.tolist()))
+
+    if _inplane_key(rows[1]) < _inplane_key(rows[2]):
+        rows[1], rows[2] = rows[2], rows[1]
+
+    # Fix row 0 sign: negate rows 0 AND 2 together so det is unchanged.
+    if _first_nonzero_sign(rows[0]) < 0:
+        rows[0] = -rows[0]
+        rows[2] = -rows[2]
+
+    # Fix row 1 sign: negate rows 1 AND 2 together so det is unchanged.
+    if _first_nonzero_sign(rows[1]) < 0:
+        rows[1] = -rows[1]
+        rows[2] = -rows[2]
+
+    # Final right-handedness check using integer triple product to avoid
+    # float comparison.  Gauss reduction may have swapped rows (flipping
+    # det), and the two compensating negations above may have cancelled.
+    det_sign = int(np.dot(
+        rows[0].astype(int),
+        np.cross(rows[1].astype(int), rows[2].astype(int)),
+    ))
+    if det_sign < 0:
+        rows[2] = -rows[2]
+
+    return np.array(rows, dtype=float)
+
+
+def canonicalize_pq(
+    P: np.ndarray,
+    Q: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return canonical forms of the P and Q orientation matrices.
+
+    Canonicalization rules:
+    - rows must be integer-valued (within 1e-9 absolute tolerance, rtol=0)
+    - each row is divided by the GCD of its absolute components
+    - matrices are right-handed (positive determinant after normalization)
+    - row 0 is the boundary normal
+    - rows 1-2 form a deterministic Gauss-reduced in-plane basis; the row
+      with the larger (norm_sq, canonical-sign lex) key is placed in row 1
+    - sign convention: first nonzero component of rows 0 and 1 is positive
+    - equivalent inputs (same directions, different scalings, sign flips, or
+      in-plane row ordering) canonicalize identically
+
+    :param P: Row-wise orientation matrix for the left grain, shape (3, 3).
+    :param Q: Row-wise orientation matrix for the right grain, shape (3, 3).
+    :returns: ``(P_canon, Q_canon)`` — canonicalized orientation matrices.
+    :raises BoundarySpecError: If any row of P or Q is not integer-valued, or
+        if canonicalization produces a zero row.
+    """
+    P = np.asarray(P, dtype=float)
+    Q = np.asarray(Q, dtype=float)
+    _assert_integer_rows(P, "P")
+    _assert_integer_rows(Q, "Q")
+    P_canon = _canonicalize_matrix(P)
+    Q_canon = _canonicalize_matrix(Q)
+    for name, M in [("P", P_canon), ("Q", Q_canon)]:
+        if any(not np.any(row) for row in M):
+            raise BoundarySpecError(
+                f"Canonical {name} contains a zero row; check that input rows "
+                "are nonzero integer Miller indices."
+            )
+    return P_canon, Q_canon
+
+
+def pq_spec_to_embedding(spec: PQSpec) -> BoundaryEmbedding:
+    """Convert a validated PQSpec to a BoundaryEmbedding.
+
+    :param spec: A validated PQSpec.
+    :returns: Canonical embedding with ``exact=True``, ``coherent=True``,
+        ``source="pq"``. P and Q are in canonical form. R_left and R_right
+        are derived by normalizing each row of canonical P and Q to unit length.
+        Equivalent PQSpecs (differing only by row scaling, sign convention, or
+        in-plane basis choice) always produce identical BoundaryEmbeddings.
+    :raises BoundarySpecError: If P or Q rows are not integer-valued, produce
+        a zero row after canonicalization, or do not form a proper rotation
+        matrix after row-normalization.
+    """
+    P_canon, Q_canon = canonicalize_pq(
+        np.asarray(spec.P, dtype=float),
+        np.asarray(spec.Q, dtype=float),
+    )
+    R_left = P_canon / np.linalg.norm(P_canon, axis=1, keepdims=True)
+    R_right = Q_canon / np.linalg.norm(Q_canon, axis=1, keepdims=True)
+    for r_name, R in [("R_left", R_left), ("R_right", R_right)]:
+        if not (np.allclose(R @ R.T, np.eye(3), atol=1e-10)
+                and abs(np.linalg.det(R) - 1.0) < 1e-10):
+            raise BoundarySpecError(
+                f"{r_name} derived from P/Q is not a proper rotation matrix "
+                "(R @ R.T != I or det != 1). Ensure P/Q rows are mutually "
+                "orthogonal integer Miller directions."
+            )
+    return BoundaryEmbedding(
+        P=P_canon,
+        Q=Q_canon,
+        R_left=R_left,
+        R_right=R_right,
+        exact=True,
+        coherent=True,
+        source="pq",
+    )

--- a/GBOpt/Utils/gb_params.py
+++ b/GBOpt/Utils/gb_params.py
@@ -172,7 +172,7 @@ def from_orientation_matrices(
     :param P: 3x3 orientation matrix for grain 1 (left grain).
     :param Q: 3x3 orientation matrix for grain 2 (right grain).
     :param boundary_normal: Optional override for the boundary normal. When
-        provided it must match ``P[0]`` within 1°; a warning is printed
+        provided it must match ``P[0]`` within 1 deg; a warning is printed
         otherwise.
     :return: 5-element array ``[alpha, beta, gamma, theta, phi]`` in radians.
     """
@@ -191,7 +191,7 @@ def from_orientation_matrices(
         if angle_err > 1.0:
             print(
                 f"WARNING: supplied --normal deviates from P[0] by "
-                f"{angle_err:.2f}° — using P[0] for inclination.",
+                f"{angle_err:.2f} deg — using P[0] for inclination.",
                 file=sys.stderr,
             )
 
@@ -256,14 +256,14 @@ def validate(
         mark = "✓" if matrix_err < 1e-10 and delta_deg < 1e-8 else "✗"
         checks.append(
             f"{mark} ZXZ reconstruction matches source rotation  "
-            f"(max matrix err = {matrix_err:.3e}, angle err = {delta_deg:.4f}°)"
+            f"(max matrix err = {matrix_err:.3e}, angle err = {delta_deg:.4f} deg)"
         )
 
     beta_deg = float(np.degrees(beta))
     if abs(beta_deg) < 1.0 or abs(abs(beta_deg) - 180.0) < 1.0:
         checks.append(
-            f"  WARNING: β = {beta_deg:.2f}° is near 0° or 180° "
-            f"(ZXZ gimbal lock — α and γ are not uniquely determined)"
+            f"  WARNING: beta = {beta_deg:.2f} deg is near 0 deg or 180 deg "
+            f"(ZXZ gimbal lock — alpha and gamma are not uniquely determined)"
         )
 
     if P_norm is not None and Q_norm is not None:
@@ -273,7 +273,7 @@ def validate(
         mark = "✓" if normal_angle < 1e-6 else "~"
         checks.append(
             f"{mark} GB boundary plane type: {gb_type}  "
-            f"(P[0] vs Q[0] angular diff = {normal_angle:.4f}°)"
+            f"(P[0] vs Q[0] angular diff = {normal_angle:.4f} deg)"
         )
 
         for name, mat in [("P", P_norm), ("Q", Q_norm)]:
@@ -293,7 +293,7 @@ def validate(
 
 def _symbolic(rad: float, tol: float = 1e-6) -> str:
     """Return a symbolic name for *rad* if it can be expressed as a rational
-    multiple of π (denominator ≤ 24) or as arctan/arccos/arcsin of a simple
+    multiple of pi (denominator <= 24) or as arctan/arccos/arcsin of a simple
     rational or square-root argument."""
 
     frac = Fraction(rad / np.pi).limit_denominator(24)
@@ -304,7 +304,7 @@ def _symbolic(rad: float, tol: float = 1e-6) -> str:
         sign = "-" if n < 0 else ""
         a = abs(n)
         coeff = "" if a == 1 else str(a)
-        return f"{sign}{coeff}π/{d}" if d != 1 else f"{sign}{coeff}π"
+        return f"{sign}{coeff}pi/{d}" if d != 1 else f"{sign}{coeff}pi"
 
     pos_args: list[tuple[float, str]] = []
     for d in range(1, 9):
@@ -339,7 +339,7 @@ def _symbolic(rad: float, tol: float = 1e-6) -> str:
 def _fmt_angle(rad: float) -> str:
     sym = _symbolic(rad)
     sym_str = f"  [{sym}]" if sym else ""
-    return f"{rad:+.6f} rad  ({np.degrees(rad):+8.2f}°){sym_str}"
+    return f"{rad:+.6f} rad  ({np.degrees(rad):+8.2f} deg){sym_str}"
 
 
 def format_output(
@@ -365,13 +365,13 @@ def format_output(
         f"Input:  {input_summary}",
         "",
         "Misorientation (ZXZ, crystal frame):",
-        f"  α = {_fmt_angle(alpha)}",
-        f"  β = {_fmt_angle(beta)}",
-        f"  γ = {_fmt_angle(gamma)}",
+        f"  alpha = {_fmt_angle(alpha)}",
+        f"  beta = {_fmt_angle(beta)}",
+        f"  gamma = {_fmt_angle(gamma)}",
         "",
         "Inclination:",
-        f"  θ = {_fmt_angle(theta)}",
-        f"  φ = {_fmt_angle(phi)}",
+        f"  theta = {_fmt_angle(theta)}",
+        f"  phi = {_fmt_angle(phi)}",
         "",
         "Validation:",
     ]
@@ -580,7 +580,7 @@ def main() -> None:
             axis / np.linalg.norm(axis) * np.radians(args.angle)
         ).as_matrix()
         input_summary = (
-            f"axis={axis.tolist()}  angle={args.angle}°  normal={normal.tolist()}"
+            f"axis={axis.tolist()}  angle={args.angle} deg  normal={normal.tolist()}"
         )
         P_norm = Q_norm = None
 

--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,7 @@ import warnings
 
 
 def pytest_runtest_makereport(item, call):
-    if "known_bug" in item.keywords:
+    if "known_bug" in item.keywords and call.when == "call":
         if call.excinfo is None:
             warnings.warn(
                 f"Test {item.name} passed but is marked as a known bug", UserWarning)

--- a/examples/density_optimization/scripts/extract_ga_data.py
+++ b/examples/density_optimization/scripts/extract_ga_data.py
@@ -42,8 +42,8 @@ PENALTY_THRESHOLD = 1.0e29
 # Candidate attribute names for per-candidate atom counts, tried in order.
 # The first one found on the GA object is used.
 # Each entry is either:
-#   - a string  → obj.<name>  is expected to be list[list[int]]
-#   - a tuple   → obj.<outer>.<inner>  (one level of nesting)
+#   - a string  -> obj.<name>  is expected to be list[list[int]]
+#   - a tuple   -> obj.<outer>.<inner>  (one level of nesting)
 # Add or reorder entries to match your GA class.
 ATOM_COUNT_ATTRS = [
     "atom_counts",      # e.g. obj.atom_counts
@@ -202,7 +202,7 @@ def extract(pkl_path: str, dry_run: bool = False):
 
     if dry_run:
         print(f"  would write: {out_path}")
-        print(f"    pkl={pkl_kb:.0f} KB  ->  json≈{json_kb:.0f} KB  "
+        print(f"    pkl={pkl_kb:.0f} KB  ->  json~={json_kb:.0f} KB  "
               f"({100 * json_kb / pkl_kb:.0f}% of original)")
         print(f"    atom_counts present: {atom_counts is not None}")
         return pkl_kb, json_kb

--- a/examples/density_optimization/scripts/find_local_minima.py
+++ b/examples/density_optimization/scripts/find_local_minima.py
@@ -121,7 +121,7 @@ all_special = np.unique(np.append(min_idx, global_min))
 print(
     f"\nFound {len(min_idx)} local minima + global minimum ({len(all_special)} unique):\n"
 )
-print(f"{'[n]':>8}  {'GBE (J/m²)':>12}  {'Gen':>6}  {'Dump file'}")
+print(f"{'[n]':>8}  {'GBE (J/m^2)':>12}  {'Gen':>6}  {'Dump file'}")
 print("-" * 80)
 
 for idx in sorted(all_special, key=lambda i: lx[i]):

--- a/examples/density_optimization/scripts/optimize.py
+++ b/examples/density_optimization/scripts/optimize.py
@@ -1,7 +1,7 @@
 """
 optimize.py
 -----------
-Maximize the density of GB core atoms for a Σ5[001]{310} GB using
+Maximize the density of GB core atoms for a Sigma5[001]{310} GB using
 GeneticAlgorithmMinimizer.
 
 Optimization metric  : raw GB core atom count (negated, so the GA minimizes)
@@ -449,7 +449,7 @@ def run_density_optimization(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Density optimization for a Σ5[001]{310} GB")
+        description="Density optimization for a Sigma5[001]{310} GB")
     parser.add_argument(
         "--material", required=True, choices=list(MATERIAL_PARAMS),
         help="Material to optimize (e.g. Fe, Ni)",

--- a/examples/density_optimization/scripts/plot_density.py
+++ b/examples/density_optimization/scripts/plot_density.py
@@ -7,7 +7,7 @@ Plot density-optimization progress using the Zhu et al. (2018) [n] metric:
     [n] = (n_gb_core / n_perfect) mod 1
 
 where n_gb_core is the number of atoms in the GB core slab and n_perfect = 45
-is the number of primitive 2D unit cells in the GB plane (5×9 supercell).
+is the number of primitive 2D unit cells in the GB plane (5x9 supercell).
 These values are stored directly in density_gbe_log.json as the `density`
 field (= n_gb_core / n_perfect); [n] is recovered at plot time via % 1.0.
 

--- a/examples/gb_optimization/scripts/extract_ga_data.py
+++ b/examples/gb_optimization/scripts/extract_ga_data.py
@@ -89,7 +89,7 @@ def extract(pkl_path, dry_run=False):
 
     if dry_run:
         print(f"  would write: {out_path}")
-        print(f"    pkl={pkl_kb:.0f} KB  ->  json≈{json_kb:.0f} KB  "
+        print(f"    pkl={pkl_kb:.0f} KB  ->  json~={json_kb:.0f} KB  "
               f"({100*json_kb/pkl_kb:.0f}% of original)")
         return pkl_kb, json_kb
 

--- a/examples/gb_optimization/scripts/find_min_gbe.py
+++ b/examples/gb_optimization/scripts/find_min_gbe.py
@@ -192,7 +192,7 @@ def main():
             sys.exit(f"Run directory not found: {run_dir}")
 
         gbe, gen, cand, dump = find_min_ga(run_dir, digits=args.digits, n_workers=args.workers)
-        print(f"Minimum GBE : {gbe:.6f} J/m²"
+        print(f"Minimum GBE : {gbe:.6f} J/m^2"
               + (f"  (compared at {args.digits} d.p.)" if args.digits is not None else ""))
         print(f"Found at    : generation {gen}, candidate {cand}")
         print(f"Structure   : {dump}")
@@ -209,7 +209,7 @@ def main():
             sys.exit(f"Run directory not found: {run_dir}")
 
         gbe, step, dump = find_min_mc(run_dir, digits=args.digits)
-        print(f"Minimum GBE : {gbe:.6f} J/m²"
+        print(f"Minimum GBE : {gbe:.6f} J/m^2"
               + (f"  (compared at {args.digits} d.p.)" if args.digits is not None else ""))
         print(f"Found at    : step {step}")
         print(f"Structure   : {dump}")

--- a/tests/test_boundary_spec.py
+++ b/tests/test_boundary_spec.py
@@ -1,0 +1,104 @@
+# Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
+
+import numpy as np
+import pytest
+from GBOpt.BoundarySpec import (
+    PQSpec,
+    ConstructionMode,
+    BoundarySpecError,
+    BoundaryEmbedding,
+)
+
+
+class TestImports:
+    def test_public_names_importable(self):
+        assert PQSpec is not None
+        assert BoundarySpecError is not None
+
+    def test_construction_mode_values(self):
+        import typing
+
+        args = typing.get_args(ConstructionMode)
+        assert set(args) == {"exact", "prefer_exact", "approximate"}
+
+
+class TestPQSpec:
+    def test_frozen(self):
+        P = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        Q = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        spec = PQSpec(P=P, Q=Q)
+        with pytest.raises((AttributeError, TypeError)):
+            spec.P = [[2, 0, 0], [0, 2, 0], [0, 0, 2]]
+
+    def test_stores_p_and_q(self):
+        P = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        Q = [[0, 1, 0], [1, 0, 0], [0, 0, 1]]
+        spec = PQSpec(P=P, Q=Q)
+        assert spec.P == P
+        assert spec.Q == Q
+
+    def test_valid_3x3_input_passes(self):
+        P = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        Q = [[0, 1, 0], [-1, 0, 0], [0, 0, 1]]
+        spec = PQSpec(P=P, Q=Q)
+        assert spec.P == P
+
+    def test_wrong_shape_raises(self):
+        P_bad = [[1, 0, 0], [0, 1, 0]]  # 2x3
+        Q = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        with pytest.raises(BoundarySpecError):
+            PQSpec(P=P_bad, Q=Q)
+
+    def test_nan_entry_raises(self):
+        P = [[1, 0, 0], [0, float("nan"), 0], [0, 0, 1]]
+        Q = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        with pytest.raises(BoundarySpecError):
+            PQSpec(P=P, Q=Q)
+
+    def test_inf_entry_raises(self):
+        P = [[1, 0, 0], [0, float("inf"), 0], [0, 0, 1]]
+        Q = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        with pytest.raises(BoundarySpecError):
+            PQSpec(P=P, Q=Q)
+
+    def test_singular_matrix_raises(self):
+        P_singular = [[1, 0, 0], [1, 0, 0], [0, 0, 1]]  # rows 0 and 1 identical
+        Q = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        with pytest.raises(BoundarySpecError):
+            PQSpec(P=P_singular, Q=Q)
+
+
+
+class TestBoundaryEmbedding:
+    def _make(self, P=None, Q=None, exact=True, coherent=True, source="pq"):
+        R = np.eye(3)
+        return BoundaryEmbedding(
+            P=P,
+            Q=Q,
+            R_left=R,
+            R_right=R,
+            exact=exact,
+            coherent=coherent,
+            source=source,
+        )
+
+    def test_instantiate_with_arrays(self):
+        P = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        Q = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]], dtype=float)
+        emb = self._make(P=P, Q=Q)
+        np.testing.assert_allclose(emb.P, P, atol=1e-15, rtol=0)
+        np.testing.assert_allclose(emb.Q, Q, atol=1e-15, rtol=0)
+        np.testing.assert_allclose(emb.R_left, np.eye(3), atol=1e-15, rtol=0)
+        np.testing.assert_allclose(emb.R_right, np.eye(3), atol=1e-15, rtol=0)
+
+    def test_instantiate_with_none_pq(self):
+        emb = self._make(P=None, Q=None, exact=False, coherent=False, source="five_dof")
+        assert emb.P is None
+        assert emb.Q is None
+        assert emb.exact is False
+        assert emb.coherent is False
+        assert emb.source == "five_dof"
+
+    def test_source_stored(self):
+        emb = self._make(source="csl")
+        assert emb.source == "csl"

--- a/tests/test_gb_exact.py
+++ b/tests/test_gb_exact.py
@@ -1,0 +1,436 @@
+# Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
+
+import warnings
+
+import numpy as np
+import pytest
+
+from unittest.mock import patch
+
+from GBOpt.BoundarySpec import BoundaryEmbedding, PQSpec
+from GBOpt.GBMaker import GBMaker
+from GBOpt.Utils.gb_exact import canonicalize_pq, pq_spec_to_embedding
+
+
+def _make_identity_pair():
+    I = np.eye(3, dtype=float)
+    return I.copy(), I.copy()
+
+
+class TestCanonicalizePQ:
+    # ------------------------------------------------------------------
+    # Idempotence
+    # ------------------------------------------------------------------
+
+    def test_idempotent_identity(self):
+        P, Q = _make_identity_pair()
+        P1, Q1 = canonicalize_pq(P, Q)
+        P2, Q2 = canonicalize_pq(P1, Q1)
+        np.testing.assert_array_equal(P1, P2)
+        np.testing.assert_array_equal(Q1, Q2)
+
+    def test_idempotent_sigma5_boundary(self):
+        # Sigma5 [001] tilt: P = identity, Q has rows [3,1,0]/[0,0,1]/[-1,3,0] (scaled)
+        P = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        Q = np.array([[3, 1, 0], [0, 0, 1], [-1, 3, 0]], dtype=float)
+        P1, Q1 = canonicalize_pq(P, Q)
+        P2, Q2 = canonicalize_pq(P1, Q1)
+        np.testing.assert_array_equal(P1, P2)
+        np.testing.assert_array_equal(Q1, Q2)
+
+    # ------------------------------------------------------------------
+    # Row scaling equivalence
+    # ------------------------------------------------------------------
+
+    def test_row_scaling_equivalent(self):
+        # Scaling individual rows by a positive integer describes the same direction.
+        P_base = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        P_scaled = np.array([[2, 0, 0], [0, 3, 0], [0, 0, 2]], dtype=float)
+        Q = np.eye(3, dtype=float)
+        P_canon_base, _ = canonicalize_pq(P_base, Q)
+        P_canon_scaled, _ = canonicalize_pq(P_scaled, Q)
+        np.testing.assert_array_equal(P_canon_base, P_canon_scaled)
+
+    # ------------------------------------------------------------------
+    # In-plane basis equivalence (Gauss reduction)
+    # ------------------------------------------------------------------
+
+    def test_inplane_basis_equivalent(self):
+        # Two P matrices whose in-plane rows span the same 2-D lattice.
+        # Original in-plane basis: [0,1,0] and [0,0,1].
+        # Equivalent basis: [0,1,0] and [0,1,1] (sum of the two).
+        P_a = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        P_b = np.array([[1, 0, 0], [0, 1, 0], [0, 1, 1]], dtype=float)
+        Q = np.eye(3, dtype=float)
+        Pa, _ = canonicalize_pq(P_a, Q)
+        Pb, _ = canonicalize_pq(P_b, Q)
+        np.testing.assert_array_equal(Pa, Pb)
+
+    def test_inplane_basis_longer_combination(self):
+        # Basis [0,1,0] and [0,2,1] (second = 2*v1 + v2 for v2=[0,0,1]).
+        P_a = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        P_b = np.array([[1, 0, 0], [0, 1, 0], [0, 2, 1]], dtype=float)
+        Q = np.eye(3, dtype=float)
+        Pa, _ = canonicalize_pq(P_a, Q)
+        Pb, _ = canonicalize_pq(P_b, Q)
+        np.testing.assert_array_equal(Pa, Pb)
+
+    # ------------------------------------------------------------------
+    # Sign convention equivalence
+    # ------------------------------------------------------------------
+
+    def test_inplane_row_sign_equivalent(self):
+        # Negating an in-plane row (and compensating to keep a valid orientation)
+        # should canonicalize to the same form.
+        P_a = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        # Negate row 1; compensate by negating row 2 to keep det > 0.
+        P_b = np.array([[1, 0, 0], [0, -1, 0], [0, 0, -1]], dtype=float)
+        Q = np.eye(3, dtype=float)
+        Pa, _ = canonicalize_pq(P_a, Q)
+        Pb, _ = canonicalize_pq(P_b, Q)
+        np.testing.assert_array_equal(Pa, Pb)
+
+    def test_boundary_normal_sign_equivalent(self):
+        # Negating the boundary normal (row 0) with a compensating row-2 negation
+        # (det-preserving) should canonicalize to the same form.
+        P_a = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        P_b = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, -1]], dtype=float)
+        Q = np.eye(3, dtype=float)
+        Pa, _ = canonicalize_pq(P_a, Q)
+        Pb, _ = canonicalize_pq(P_b, Q)
+        np.testing.assert_array_equal(Pa, Pb)
+
+    # ------------------------------------------------------------------
+    # Right-handedness (positive determinant)
+    # ------------------------------------------------------------------
+
+    def test_output_right_handed_identity(self):
+        P, Q = _make_identity_pair()
+        Pc, Qc = canonicalize_pq(P, Q)
+        assert np.linalg.det(Pc) > 0
+        assert np.linalg.det(Qc) > 0
+
+    def test_output_right_handed_sigma5(self):
+        P = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        Q = np.array([[3, 1, 0], [0, 0, 1], [-1, 3, 0]], dtype=float)
+        Pc, Qc = canonicalize_pq(P, Q)
+        assert np.linalg.det(Pc) > 0
+        assert np.linalg.det(Qc) > 0
+
+    def test_output_right_handed_after_sign_fixes(self):
+        # Start from a right-handed matrix whose signs all need fixing.
+        P = np.array([[-1, 0, 0], [0, -1, 0], [0, 0, 1]], dtype=float)
+        Q = np.eye(3, dtype=float)
+        Pc, _ = canonicalize_pq(P, Q)
+        assert np.linalg.det(Pc) > 0
+
+    # ------------------------------------------------------------------
+    # Deterministic ordering: swapped in-plane rows canonicalize identically
+    # ------------------------------------------------------------------
+
+    def test_swapped_inplane_rows_same_canonical(self):
+        # rows[1] and rows[2] swapped — same in-plane lattice, must give
+        # identical canonical form (Gauss reduction must be order-independent).
+        P_a = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        P_b = np.array([[1, 0, 0], [0, 0, 1], [0, 1, 0]], dtype=float)
+        Q = np.eye(3, dtype=float)
+        Pa, _ = canonicalize_pq(P_a, Q)
+        Pb, _ = canonicalize_pq(P_b, Q)
+        np.testing.assert_array_equal(Pa, Pb)
+
+    def test_swapped_sigma5_inplane_rows_same_canonical(self):
+        # Sigma5 Q with in-plane rows swapped must canonicalize to the same form.
+        P = np.eye(3, dtype=float)
+        Q_a = np.array([[3, 1, 0], [0, 0, 1], [-1, 3, 0]], dtype=float)
+        Q_b = np.array([[3, 1, 0], [-1, 3, 0], [0, 0, 1]], dtype=float)
+        _, Qa = canonicalize_pq(P, Q_a)
+        _, Qb = canonicalize_pq(P, Q_b)
+        np.testing.assert_array_equal(Qa, Qb)
+
+    # ------------------------------------------------------------------
+    # Rational (non-integer) rows must be rejected
+    # ------------------------------------------------------------------
+
+    def test_rational_row_raises(self):
+        from GBOpt.BoundarySpec import BoundarySpecError
+        P_rational = np.array([[0.5, 0, 0], [0, 0.5, 0], [0, 0, 0.5]], dtype=float)
+        Q = np.eye(3, dtype=float)
+        with pytest.raises(BoundarySpecError):
+            canonicalize_pq(P_rational, Q)
+
+    def test_mixed_rational_row_raises(self):
+        from GBOpt.BoundarySpec import BoundarySpecError
+        P_bad = np.array([[1, 0, 0], [0, 1.5, 0], [0, 0, 1]], dtype=float)
+        Q = np.eye(3, dtype=float)
+        with pytest.raises(BoundarySpecError):
+            canonicalize_pq(P_bad, Q)
+
+    def test_large_noninteger_row_raises(self):
+        # Regression: without rtol=0, np.allclose accepts 100000.4 because
+        # the default relative tolerance swamps the 0.4 absolute deviation.
+        from GBOpt.BoundarySpec import BoundarySpecError
+        P_large = np.array([[100000.4, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        Q = np.eye(3, dtype=float)
+        with pytest.raises(BoundarySpecError):
+            canonicalize_pq(P_large, Q)
+
+
+class TestPQSpecToEmbedding:
+    # ------------------------------------------------------------------
+    # Metadata flags
+    # ------------------------------------------------------------------
+
+    def test_flags_and_source(self):
+        spec = PQSpec(P=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                      Q=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        emb = pq_spec_to_embedding(spec)
+        assert isinstance(emb, BoundaryEmbedding)
+        assert emb.exact is True
+        assert emb.coherent is True
+        assert emb.source == "pq"
+
+    # ------------------------------------------------------------------
+    # Basic end-to-end smoke
+    # ------------------------------------------------------------------
+
+    def test_identity_r_left_r_right(self):
+        spec = PQSpec(P=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                      Q=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        emb = pq_spec_to_embedding(spec)
+        np.testing.assert_array_almost_equal(emb.R_left, np.eye(3))
+        np.testing.assert_array_almost_equal(emb.R_right, np.eye(3))
+
+    # ------------------------------------------------------------------
+    # Sigma5 [001] 36.87 deg tilt: R derives from canonical Q, not raw Q
+    # ------------------------------------------------------------------
+
+    def test_sigma5_r_right_matches_canonical(self):
+        # Q supplied with rows in a non-canonical order; the adapter must
+        # canonicalize first and derive R_right from the canonical form.
+        P_raw = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        Q_raw = np.array([[4, -3, 0], [3, 4, 0], [0, 0, 1]], dtype=float)
+        spec = PQSpec(P=P_raw.tolist(), Q=Q_raw.tolist())
+        emb = pq_spec_to_embedding(spec)
+        _, Q_c = canonicalize_pq(P_raw, Q_raw)
+        R_right_expected = Q_c / np.linalg.norm(Q_c, axis=1, keepdims=True)
+        np.testing.assert_array_almost_equal(emb.R_right, R_right_expected)
+
+    def test_sigma5_r_right_is_proper_rotation(self):
+        spec = PQSpec(P=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                      Q=[[4, -3, 0], [3, 4, 0], [0, 0, 1]])
+        emb = pq_spec_to_embedding(spec)
+        assert abs(np.linalg.det(emb.R_right) - 1.0) < 1e-12
+        np.testing.assert_array_almost_equal(
+            emb.R_right @ emb.R_right.T, np.eye(3))
+
+    # ------------------------------------------------------------------
+    # R_left and R_right rows are unit vectors
+    # ------------------------------------------------------------------
+
+    def test_row_norms_are_unit(self):
+        spec = PQSpec(P=[[2, 1, 0], [0, 0, 1], [1, -2, 0]],
+                      Q=[[2, -1, 0], [0, 0, 1], [-1, -2, 0]])
+        emb = pq_spec_to_embedding(spec)
+        np.testing.assert_allclose(
+            np.linalg.norm(emb.R_left, axis=1), np.ones(3), atol=1e-12)
+        np.testing.assert_allclose(
+            np.linalg.norm(emb.R_right, axis=1), np.ones(3), atol=1e-12)
+
+    # ------------------------------------------------------------------
+    # Non-orthogonal P/Q must be rejected
+    # ------------------------------------------------------------------
+
+    def test_non_orthogonal_pq_raises(self):
+        # [[1,0,0],[1,1,0],[0,0,1]] has rows that are not mutually orthogonal.
+        from GBOpt.BoundarySpec import BoundarySpecError
+        spec = PQSpec(P=[[1, 0, 0], [1, 1, 0], [0, 0, 1]],
+                      Q=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        with pytest.raises(BoundarySpecError):
+            pq_spec_to_embedding(spec)
+
+
+class TestFromBoundaryEmbedding:
+    # Common parameters shared by all sub-tests.
+    A0 = 3.615          # Cu lattice parameter
+    STRUCTURE = "fcc"
+    ATOM_TYPES = "Cu"
+    GB_THICKNESS = 5.0
+    REPEAT = 2
+    X_DIM_MIN = 30.0
+
+    def _legacy(self, misorientation):
+        return GBMaker(
+            self.A0, self.STRUCTURE, self.GB_THICKNESS, misorientation,
+            self.ATOM_TYPES,
+            repeat_factor=self.REPEAT, x_dim_min=self.X_DIM_MIN,
+        )
+
+    def _from_spec(self, P, Q):
+        spec = PQSpec(P=P, Q=Q)
+        emb = pq_spec_to_embedding(spec)
+        return GBMaker._from_boundary_embedding(
+            emb,
+            a0=self.A0, structure=self.STRUCTURE, atom_types=self.ATOM_TYPES,
+            gb_thickness=self.GB_THICKNESS,
+            repeat_factor=self.REPEAT, x_dim_min=self.X_DIM_MIN,
+        )
+
+    # ------------------------------------------------------------------
+    # Atom-array round-trip: Sigma5 [001] 36.87 deg tilt boundary.
+    # P and Q are chosen to exactly match what __approximate_rotation_matrix_as_int
+    # produces for this misorientation, so the row ordering is identical.
+    # ------------------------------------------------------------------
+
+    def test_sigma5_atom_array_matches_legacy(self):
+        import math
+        # Use the exact angle arctan(3/4) so scipy's rotation matrix is
+        # [[4/5,-3/5,0],[3/5,4/5,0],[0,0,1]] to within 1 ULP — close enough
+        # that atom coordinates agree to ~1e-14 A.
+        theta = math.atan2(3, 4)
+        misorientation = np.array([0.0, 0.0, theta, 0.0, 0.0])
+        gb_legacy = self._legacy(misorientation)
+
+        P = gb_legacy._GBMaker__R_left_approx.astype(int).tolist()
+        Q = gb_legacy._GBMaker__R_right_approx.astype(int).tolist()
+        gb_emb = self._from_spec(P, Q)
+
+        legacy_atoms = gb_legacy.whole_system
+        emb_atoms = gb_emb.whole_system
+        assert legacy_atoms.shape == emb_atoms.shape
+        numeric_fields = [
+            f for f in legacy_atoms.dtype.names
+            if np.issubdtype(legacy_atoms[f].dtype, np.number)
+        ]
+        for field in numeric_fields:
+            np.testing.assert_allclose(
+                emb_atoms[field], legacy_atoms[field], atol=1e-10,
+                err_msg=f"field '{field}' differs",
+            )
+
+    # ------------------------------------------------------------------
+    # Exact path bypasses __approximate_rotation_matrix_as_int.
+    # ------------------------------------------------------------------
+
+    def test_exact_path_skips_approximation(self):
+        spec = PQSpec(P=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                      Q=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        emb = pq_spec_to_embedding(spec)
+        assert emb.exact is True
+
+        # Patch without wraps: if the exact path correctly bypasses
+        # approximation, the mock is never called and the test passes.
+        spy_target = "_GBMaker__approximate_rotation_matrix_as_int"
+        with patch.object(GBMaker, spy_target) as spy:
+            GBMaker._from_boundary_embedding(
+                emb,
+                a0=self.A0, structure=self.STRUCTURE, atom_types=self.ATOM_TYPES,
+                gb_thickness=self.GB_THICKNESS,
+            )
+            spy.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # inplane_periodic reflects embedding.coherent.
+    # ------------------------------------------------------------------
+
+    def test_coherent_embedding_sets_inplane_periodic(self):
+        spec = PQSpec(P=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                      Q=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        emb = pq_spec_to_embedding(spec)
+        assert emb.coherent is True
+        gb = GBMaker._from_boundary_embedding(
+            emb,
+            a0=self.A0, structure=self.STRUCTURE, atom_types=self.ATOM_TYPES,
+            gb_thickness=self.GB_THICKNESS,
+        )
+        assert gb.inplane_periodic == (True, True)
+
+    # ------------------------------------------------------------------
+    # misorientation setter must discard the active embedding so that
+    # update_spacing() uses the new Euler angles, not the stale R matrices.
+    # ------------------------------------------------------------------
+
+    def test_misorientation_setter_clears_embedding(self):
+        import math
+        spec = PQSpec(P=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                      Q=[[4, -3, 0], [3, 4, 0], [0, 0, 1]])
+        emb = pq_spec_to_embedding(spec)
+        gb = GBMaker._from_boundary_embedding(
+            emb,
+            a0=self.A0, structure=self.STRUCTURE, atom_types=self.ATOM_TYPES,
+            gb_thickness=self.GB_THICKNESS,
+        )
+        # Embedding is active before mutation.
+        assert gb._GBMaker__embedding is not None
+
+        # After mutating misorientation the embedding must be gone.
+        theta = math.atan2(3, 4)
+        gb.misorientation = np.array([0.0, 0.0, theta, 0.0, 0.0])
+        assert gb._GBMaker__embedding is None
+
+        # R_left (via private attr) must reflect the Euler-angle inclination
+        # (identity matrix for zero inclination angles), not the old embedding.
+        np.testing.assert_array_almost_equal(gb._GBMaker__R_left, np.eye(3))
+
+
+class TestFromBoundarySpec:
+    A0 = 3.615
+    STRUCTURE = "fcc"
+    ATOM_TYPES = "Cu"
+    GB_THICKNESS = 5.0
+
+    def test_pqspec_exact_matches_embedding_path(self):
+        # from_boundary_spec must produce the same bicrystal as going
+        # through pq_spec_to_embedding + _from_boundary_embedding directly.
+        spec = PQSpec(P=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                      Q=[[4, -3, 0], [3, 4, 0], [0, 0, 1]])
+        gb_spec = GBMaker.from_boundary_spec(
+            self.A0, self.STRUCTURE, self.ATOM_TYPES, spec, mode="exact",
+            gb_thickness=self.GB_THICKNESS,
+        )
+        emb = pq_spec_to_embedding(spec)
+        gb_emb = GBMaker._from_boundary_embedding(
+            emb, a0=self.A0, structure=self.STRUCTURE,
+            atom_types=self.ATOM_TYPES, gb_thickness=self.GB_THICKNESS,
+        )
+        np.testing.assert_array_equal(
+            gb_spec.whole_system, gb_emb.whole_system)
+
+
+class TestFromBoundarySpecMultispecies:
+    """Step 9 acceptance: exact-PQ construction must preserve stoichiometry.
+
+    Monatomic tests cannot catch species-count failures.  These tests use
+    known exact Sigma5 [001] P/Q and assert the correct cation:anion ratio,
+    which also implies charge neutrality for these structures.
+    """
+
+    # Sigma5 [001] 36.87 deg tilt — orthogonal integer rows, verified proper rotation.
+    P = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+    Q = [[4, -3, 0], [3, 4, 0], [0, 0, 1]]
+
+    def _species_counts(self, a0, structure, atom_types):
+        spec = PQSpec(P=self.P, Q=self.Q)
+        gb = GBMaker.from_boundary_spec(
+            a0, structure, atom_types, spec, mode="exact", gb_thickness=2.0
+        )
+        ws = gb.whole_system
+        names, counts = np.unique(ws["name"], return_counts=True)
+        return {str(n): int(c) for n, c in zip(names, counts)}
+
+    def test_rocksalt_stoichiometric(self):
+        # NaCl: cation : anion must be 1 : 1.
+        counts = self._species_counts(4.0, "rocksalt", ("Na", "Cl"))
+        assert counts["Na"] == counts["Cl"], (
+            f"Rocksalt bicrystal is not stoichiometric: {counts}"
+        )
+
+    @pytest.mark.known_bug
+    def test_fluorite_stoichiometric(self):
+        # UO₂: anion : cation must be 2 : 1.
+        # Known bug: GBMaker produces 12 fewer O atoms than expected (e.g.
+        # 9492 O / 4752 U instead of 9504 O / 4752 U) on both the legacy and
+        # exact-PQ paths.  Confirmed pre-existing; not introduced by Stage B.
+        counts = self._species_counts(5.47, "fluorite", ("U", "O"))
+        assert counts["O"] == 2 * counts["U"], (
+            f"Fluorite bicrystal is not stoichiometric: {counts}"
+        )

--- a/tests/test_gbmaker.py
+++ b/tests/test_gbmaker.py
@@ -175,6 +175,17 @@ class TestGBMaker(unittest.TestCase):
         self.assertGreater(self.gbm.z_dim, 0)
         self.assertGreater(self.gbm.radius, 0)
 
+    def test_inplane_periodic_type_and_length(self):
+        result = self.gbm.inplane_periodic
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all(isinstance(v, bool) for v in result))
+
+    def test_inplane_periodic_fully_periodic_for_csl_boundary(self):
+        # Sigma5 [001] 36.87° boundary is a fully coherent CSL — both in-plane
+        # directions must be periodic.
+        self.assertEqual(self.gbm.inplane_periodic, (True, True))
+
     def test_box_dimensions(self):
         box_dims = self.gbm.box_dims
         self.assertTrue(isinstance(box_dims, np.ndarray))

--- a/tests/test_gbmaker.py
+++ b/tests/test_gbmaker.py
@@ -182,7 +182,7 @@ class TestGBMaker(unittest.TestCase):
         self.assertTrue(all(isinstance(v, bool) for v in result))
 
     def test_inplane_periodic_fully_periodic_for_csl_boundary(self):
-        # Sigma5 [001] 36.87° boundary is a fully coherent CSL — both in-plane
+        # Sigma5 [001] 36.87 deg boundary is a fully coherent CSL — both in-plane
         # directions must be periodic.
         self.assertEqual(self.gbm.inplane_periodic, (True, True))
 


### PR DESCRIPTION
### Summary
Establishes the full public API surface for structured boundary-spec inputs and delivers
the first working construction adapter. Combines three closely coupled stages: A1 (expose
`inplane_periodic`), A2 (define spec dataclasses and error hierarchy), and B (implement
exact P/Q construction). Merging A2 alone would leave stub-only code (`NotImplementedError`)
on `main`; grouping A1+A2+B delivers a complete, reviewable first story — expose the
metadata, define the public API surface, implement the first working adapter — with no
gold-fixture changes.

### Closes / References
Closes #44
Closes #45
Closes #46
Refs #42

The following PRs are closed in favor of a combined PR that addresses multiple issues without leaving stubs that raise `NotImplementedError`s
Closes #50 
Closes #51 