### PR TITLE
FiveDOFSpec approximate mode, incoherent support, deprecation, and examples migration

### DIFF
--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -1651,6 +1651,9 @@ class GBMaker:
             # the input adapter and reflects the exact construction intent.
             coherent = self.__embedding.coherent
             self.__inplane_periodic = (coherent, coherent)
+            if not coherent:
+                for axis in ("y", "z"):
+                    spacing[axis] = min(spacing[axis], threshold)
         else:
             inplane_periodic = []
             for key, val in spacing.items():

--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -544,7 +544,7 @@ class GBMaker:
         a0: float,
         structure: str,
         atom_types: str | tuple[str, ...],
-        boundary: PQSpec | CSLExactSpec | CSLApproxSpec,
+        boundary: PQSpec | CSLExactSpec | CSLApproxSpec | FiveDOFSpec,
         mode: str = "exact",
         *,
         gb_thickness: float = 0.0,

--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -13,7 +13,13 @@ from typing import Any
 import numpy as np
 from scipy.spatial.transform import Rotation
 
-from GBOpt.BoundarySpec import BoundarySpecError, CSLApproxSpec, CSLExactSpec, PQSpec
+from GBOpt.BoundarySpec import (
+    BoundarySpecError,
+    CSLApproxSpec,
+    CSLExactSpec,
+    FiveDOFSpec,
+    PQSpec,
+)
 from GBOpt.crystallography import (
     csl_approx_spec_to_embedding,
     csl_exact_spec_to_embedding,
@@ -465,6 +471,7 @@ class GBMaker:
         a0: float,
         structure: str,
         atom_types,
+        misorientation=None,
         gb_thickness: float = 0.0,
         repeat_factor=2,
         x_dim_min: float = 50,
@@ -486,6 +493,8 @@ class GBMaker:
         :param a0: Crystal lattice parameter (Angstroms).
         :param structure: Crystal structure string.
         :param atom_types: Atom type string or tuple of strings.
+        :param misorientation: Optional legacy 5-DOF parameters to retain on
+            the constructed object. Exact embeddings default to zeros.
         :param gb_thickness: Width of the GB region (Angstroms), default 0.
         :param repeat_factor: In-plane repeat factor(s), default 2.
         :param x_dim_min: Minimum grain thickness in x (Angstroms), default 50.
@@ -503,8 +512,10 @@ class GBMaker:
             Keyword parameter, optional, defaults to ``"both"``.
         :return: Fully initialized GBMaker instance.
         """
+        if misorientation is None:
+            misorientation = np.zeros(5)
         return cls(
-            a0, structure, gb_thickness, np.zeros(5), atom_types,
+            a0, structure, gb_thickness, np.asarray(misorientation), atom_types,
             _embedding=embedding,
             _mismatch_tol=mismatch_tol,
             _mismatch_max_cells=mismatch_max_cells,
@@ -539,13 +550,14 @@ class GBMaker:
 
         Supported boundary types and currently implemented construction modes are:
 
-        ============= =========== ======================
-        Boundary type exact       approximate
-        ============= =========== ======================
-        PQSpec        yes         planned; raises
-        CSLExactSpec  yes         planned; raises
-        CSLApproxSpec no; raises  yes
-        ============= =========== ======================
+        ============= =========== ====================== ============
+        Boundary type exact       approximate            prefer_exact
+        ============= =========== ====================== ============
+        PQSpec        yes         planned; raises        yes
+        CSLExactSpec  yes         planned; raises        yes
+        CSLApproxSpec no; raises  yes                    warn -> yes
+        FiveDOFSpec   not yet     yes                    warn -> yes
+        ============= =========== ====================== ============
 
         When ``mismatch_tol`` is ``None``, the shared in-plane simulation box is set
         from ``repeat_factor`` and the larger left/right in-plane period along each
@@ -564,23 +576,26 @@ class GBMaker:
         :param a0: Crystal lattice parameter (Angstroms).
         :param structure: Crystal structure string.
         :param atom_types: Atom type string or tuple of atom type strings.
-        :param boundary: Boundary-spec dataclass. Currently supported values are
-            ``PQSpec``, ``CSLExactSpec``, and ``CSLApproxSpec``.
-        :param mode: Construction mode. ``"exact"`` uses exact integer P/Q matrices;
-            ``"approximate"`` uses floating-point rotation matrices. Optional, defaults
-            to ``"exact"``.
-        :param gb_thickness: Width of the grain-boundary region (Angstroms). Keyword
-            parameter, optional, defaults to ``0.0``.
+        :param boundary: A boundary-spec dataclass. Currently supported values are
+            ``PQSpec``, ``CSLExactSpec``, ``CSLApproxSpec``, or ``FiveDOFSpec``.
+        :param mode: Construction mode - ``"exact"`` uses exact integer P/Q matrices
+            (requires ``PQSpec`` or ``CSLExactSpec``); ``"approximate"`` uses
+            floating-point rotation matrices (required for ``CSLApproxSpec`` and
+            ``FiveDOFSpec``). ``"prefer_exact"`` uses exact construction when available
+            and warns before falling back to approximate construction otherwise.
+            Optional, defaults to ``"exact"``.
+        :param gb_thickness: Width of the GB region (Angstroms). Keyword parameter,
+            optional, defaults tp ``0.0``.
         :param repeat_factor: In-plane repeat factor or repeat factors. A single integer
             applies to both in-plane axes; a two-value sequence applies to y and z
             respectively. Keyword parameter, optional, defaults to ``2``.
-        :param x_dim_min: Minimum size of one grain in the x dimension (Angstroms).
+        :param x_dim_min: Minimum  size of one grain in the x dimension (Angstroms).
             Keyword parameter, optional, defaults to ``50``.
-        :param vacuum: Vacuum thickness around the grains in the x dimension
-            (Angstroms). Keyword parameter, optional, defaults to ``10``.
+        :param vacuum: Vacuum thickness around the grains the x dimension (Angstroms).
+            Keyword parameter, optional, defaults to ``10``.
         :param interaction_distance: Maximum atom interaction distance (Angstroms).
             Keyword parameter, optional, defaults to ``15.0``.
-        :param gb_id: Grain-boundary identifier. Keyword parameter, optional, defaults
+        :param gb_id: Grain boundary identifier. Keyword parameter, optional, defaults
             to ``1``.
         :param mismatch_tol: Maximum allowed relative mismatch for commensurate in-plane
             repeat search. ``None`` disables mismatch accommodation. For example,
@@ -611,18 +626,18 @@ class GBMaker:
         strain_grain = cls.__validate_strain_grain(strain_grain)
 
         if isinstance(boundary, PQSpec):
-            if mode != "exact":
+            if mode == "approximate":
                 raise NotImplementedError(
-                    f"Construction mode {mode!r} is not yet supported for PQSpec; "
-                    "only mode='exact' is currently implemented."
+                    f"Construction mode '{mode}' is not yet supported for PQSpec; "
+                    f"use mode='exact' or mode='prefer_exact'."
                 )
             embedding = pq_spec_to_embedding(boundary)
 
         elif isinstance(boundary, CSLExactSpec):
-            if mode != "exact":
+            if mode == "approximate":
                 raise NotImplementedError(
-                    f"Construction mode {mode!r} is not yet supported for "
-                    "CSLExactSpec; only mode='exact' is currently implemented."
+                    f"Construction mode '{mode}' is not yet supported for CSLExactSpec; "
+                    f"use mode='exact' or mode='prefer_exact'."
                 )
             embedding = csl_exact_spec_to_embedding(boundary)
 
@@ -633,25 +648,53 @@ class GBMaker:
                     "quaternion is available for exactification. Use CSLExactSpec "
                     "for an exact construction, or mode='approximate'."
                 )
-            if mode != "approximate":
-                raise NotImplementedError(
-                    f"Construction mode {mode!r} is not yet supported for "
-                    "CSLApproxSpec; only mode='approximate' is currently "
-                    "implemented."
+            if mode == "prefer_exact":
+                warnings.warn(
+                    "CSLApproxSpec cannot be exactified from a floating-point "
+                    "angle; falling back to mode='approximate'.",
+                    UserWarning,
+                    stacklevel=2,
                 )
             embedding = csl_approx_spec_to_embedding(boundary)
+
+        elif isinstance(boundary, FiveDOFSpec):
+            if mode == "exact":
+                try:
+                    P, Q = exactify_five_dof(np.asarray(boundary.params, dtype=float))
+                except NotImplementedError as exc:
+                    raise BoundarySpecError(
+                        "FiveDOFSpec exactification is not yet implemented; "
+                        "use mode='approximate' or mode='prefer_exact'."
+                    ) from exc
+                embedding = pq_spec_to_embedding(PQSpec(P=P, Q=Q))
+            elif mode == "prefer_exact":
+                try:
+                    P, Q = exactify_five_dof(np.asarray(boundary.params, dtype=float))
+                except (BoundarySpecError, NotImplementedError) as exc:
+                    warnings.warn(
+                        "FiveDOFSpec exactification failed; falling back to "
+                        f"mode='approximate'. Reason: {exc}",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                    embedding = five_dof_spec_to_embedding(boundary)
+                else:
+                    embedding = pq_spec_to_embedding(PQSpec(P=P, Q=Q))
+            else:
+                embedding = five_dof_spec_to_embedding(boundary)
 
         else:
             raise NotImplementedError(
                 "from_boundary_spec does not yet support boundary objects of type "
                 f"{type(boundary).__name__}."
             )
-
+        misorientation = boundary.params if isinstance(boundary, FiveDOFSpec) else None
         return cls._from_boundary_embedding(
             embedding,
             a0=a0,
             structure=structure,
             atom_types=atom_types,
+            misorientation=misorientation,
             gb_thickness=gb_thickness,
             repeat_factor=repeat_factor,
             x_dim_min=x_dim_min,
@@ -1603,7 +1646,7 @@ class GBMaker:
             }
         )
 
-        if self.__embedding is not None:
+        if self.__embedding is not None and self.__embedding.source != "five_dof":
             # Trust the embedding's coherence flag directly; it is set by
             # the input adapter and reflects the exact construction intent.
             coherent = self.__embedding.coherent

--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -32,6 +32,10 @@ from GBOpt.gbmaker_supercell import (
 )
 from GBOpt.UnitCell import UnitCell
 
+_LEGACY_CONSTRUCTOR_DEPRECATION = (
+    "GBMaker(...) is deprecated; use GBMaker.from_boundary_spec(...)."
+)
+
 
 class GBMakerError(Exception):
     """Base class for Exceptions in the GBMaker class."""
@@ -414,6 +418,13 @@ class GBMaker:
                  repeat_factor: int | Sequence[int] = 2, x_dim_min: float = 50,
                  vacuum: float = 10, interaction_distance: float = 15.0,
                  gb_id: int = 1, epsilon: float = 1e-10):
+        if _embedding is None:
+            warnings.warn(
+                _LEGACY_CONSTRUCTOR_DEPRECATION,
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         self.__a0 = self.__validate(a0, Number, "a0", positive=True)
         self.__structure = self.__validate(structure, str, "structure")
         self.__gb_thickness = self.__validate(

--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -1658,8 +1658,9 @@ class GBMaker:
         )
 
         if self.__embedding is not None and self.__embedding.source != "five_dof":
-            # Trust the embedding's coherence flag directly; it is set by
-            # the input adapter and reflects the exact construction intent.
+            # Trust non-legacy spec adapters directly. FiveDOFSpec keeps the
+            # legacy threshold heuristic below until exactification replaces
+            # its approximate-only embedding path.
             coherent = self.__embedding.coherent
             self.__inplane_periodic = (coherent, coherent)
             if not coherent:

--- a/GBOpt/Utils/gb_params.py
+++ b/GBOpt/Utils/gb_params.py
@@ -1,1060 +1,1049 @@
 # Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
-"""Utility to convert grain-boundary descriptions into GBOpt core formats.
 
-Usage
------
-    python GBOpt/Utils/gb_params.py axis_angle --axis 1 -1 0 --angle 70.53 --normal 1 1 1
-    python GBOpt/Utils/gb_params.py orientation --P 2 2 2 1 -1 0 1 1 -2 \
-                                                --Q 2 2 2 -1 1 0 -1 -1 2
-    python GBOpt/Utils/gb_params.py csl --axis 0 0 1 --plane 1 0 0 --quat 2 0 0 1
+"""Thin CLI for converting grain-boundary descriptions into GBOpt core formats.
+
+Boundary-spec dataclasses own core-format validation, and the crystallography package
+owns all domain conversion. This module is limited to tagged-JSON schema handling,
+human-readable reporting, command dispatch, and serialization.
+
+Examples
+--------
+Convert an axis-angle description to five-DOF JSON::
+
+    python GBOpt/Utils/gb_params.py axis_angle \
+        --axis 1 -1 0 --angle 70.53 --normal 1 1 1
+
+Convert row-wise orientation matrices to five-DOF JSON::
+
+    python GBOpt/Utils/gb_params.py orientation \
+        --P 2 2 2 1 -1 0 1 1 -2 \
+        --Q 2 2 2 -1 1 0 -1 -1 2
+
+Validate and emit an exact CSL specification::
+
+    python GBOpt/Utils/gb_params.py csl \
+        --axis 0 0 1 --plane 1 0 0 --quat 2 0 0 1
+
+Canonicalize exact integer P/Q matrices::
+
     python GBOpt/Utils/gb_params.py canonicalize --P ... --Q ...
-    python GBOpt/Utils/gb_params.py self_test
 """
+
 from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
+from collections.abc import Mapping, Sequence
 from fractions import Fraction
 from pathlib import Path
-from typing import Optional
+from typing import Any
 
 import numpy as np
-from scipy.spatial.transform import Rotation
 
-if __package__ in (None, ""):
-    repo_root = Path(__file__).resolve().parents[2]
-    if str(repo_root) not in sys.path:
-        sys.path.insert(0, str(repo_root))
-
-from GBOpt.BoundarySpec import (  # noqa: E402
+from GBOpt.BoundarySpec import (
+    BoundaryEmbedding,
     BoundarySpecError,
     CSLApproxSpec,
     CSLExactSpec,
     FiveDOFSpec,
     PQSpec,
 )
-from GBOpt.crystallography import (
-    canonicalize_pq,
+from GBOpt.crystallography.boundary import (
     csl_approx_spec_to_embedding,
     csl_exact_spec_to_embedding,
-    exactify_five_dof,
+    five_dof_spec_to_embedding,
+    pq_spec_to_embedding,
 )
+from GBOpt.crystallography.exactification import exactify_five_dof
+from GBOpt.crystallography.orientation import (
+    five_dof_from_axis_angle,
+    five_dof_from_orientation_matrices,
+    normalize_direction,
+    validate_orientation_matrix,
+)
+from GBOpt.crystallography.pq import canonicalize_pq_paired
+from GBOpt.crystallography.types import CrystallographyValueError
+
+if __package__ in (None, ""):
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+_JSON_ZERO_TOL = 5.0e-13
+_REPORT_TOL = 1.0e-10
 
 # ---------------------------------------------------------------------------
-# Core math helpers
+# Human-readable reporting
 # ---------------------------------------------------------------------------
 
 
-def normalize_rows(M: np.ndarray) -> np.ndarray:
-    """
-    Row-normalize a 3x3 matrix.
-
-    :param M: 3x3 matrix whose rows will be normalized.
-    :return: Row-normalized copy of M.
-    :raises ValueError: If any row has zero magnitude.
-    """
-    M = np.asarray(M, dtype=float)
-    norms = np.linalg.norm(M, axis=1)
-    if np.any(norms < 1e-14):
-        raise ValueError("Orientation matrix has a zero-length row.")
-    return M / norms[:, np.newaxis]
-
-
-def validate_orientation_matrix(
-    M: np.ndarray,
-    name: str,
+def _validation_report(
+    params: object,
+    boundary_normal: object,
     *,
-    tol: float = 1e-10,
-) -> np.ndarray:
-    """
-    Validate that *M* is a proper row-wise orientation matrix.
-
-    The rows must be non-zero, mutually orthonormal, and right-handed. A
-    normalized copy is returned.
-
-    :param M: Candidate 3x3 orientation matrix.
-    :param name: Label used in error messages.
-    :param tol: Numerical tolerance for orthonormality and handedness.
-    :return: Row-normalized, validated matrix.
-    :raises ValueError: If the matrix is not a proper orientation matrix.
-    """
-    M = np.asarray(M, dtype=float)
-    if M.shape != (3, 3):
-        raise ValueError(f"{name} must be a 3x3 matrix.")
-
-    M_norm = normalize_rows(M)
-    orth_err = float(np.max(np.abs(M_norm @ M_norm.T - np.eye(3))))
-    det = float(np.linalg.det(M_norm))
-
-    if orth_err > tol:
-        raise ValueError(
-            f"{name} rows must be mutually orthogonal after normalization "
-            f"(max err = {orth_err:.3e})."
-        )
-    if abs(det - 1.0) > tol:
-        raise ValueError(
-            f"{name} must be right-handed with det = +1 after normalization "
-            f"(det = {det:.6f})."
-        )
-
-    return M_norm
-
-
-def inclination_from_normal(n: np.ndarray) -> tuple[float, float]:
-    """
-    Compute GBMaker inclination angles (theta, phi) from a boundary normal.
-
-    GBMaker applies rotations to row-vector positions via ``x_lab = x_crystal @
-    Rincl.T``. Under that convention, the first row of
-    ``Rincl = Rz(phi) @ Ry(theta)`` is the crystal direction aligned with the
-    lab x-axis, i.e. the grain-1 boundary normal.
-
-    The first row of ``Rz(phi) @ Ry(theta)`` is
-    ``[cos(phi)*cos(theta), -sin(phi), cos(phi)*sin(theta)]``, so::
-
-        phi   = arcsin(-n_hat[1])
-        theta = arctan2(n_hat[2], n_hat[0])
-
-    :param n: Boundary normal direction as a 3-element array [h, k, l].
-    :return: ``(theta, phi)`` in radians.
-    :raises ValueError: If n is a zero vector.
-    """
-    n = np.asarray(n, dtype=float)
-    norm = np.linalg.norm(n)
-    if norm < 1e-14:
-        raise ValueError("Boundary normal must be a non-zero vector.")
-    n_hat = n / norm
-    nx, ny, nz = n_hat
-
-    phi = float(np.arcsin(np.clip(-ny, -1.0, 1.0)))
-
-    if abs(ny) >= 1.0 - 1e-10:
-        theta = 0.0
-    else:
-        theta = float(np.arctan2(nz, nx))
-
-    return theta, phi
-
-
-# ---------------------------------------------------------------------------
-# Public conversion functions
-# ---------------------------------------------------------------------------
-
-def from_axis_angle(
-    axis: np.ndarray,
-    angle_deg: float,
-    boundary_normal: np.ndarray,
-) -> np.ndarray:
-    """
-    Compute the GBMaker misorientation array from a rotation axis, angle,
-    and boundary normal.
-
-    :param axis: Rotation axis [u, v, w] in crystal coordinates (need not be
-        a unit vector).
-    :param angle_deg: Misorientation angle in degrees.
-    :param boundary_normal: Crystal direction [h, k, l] aligned with the GB
-        normal (lab x-axis).
-    :return: 5-element array ``[alpha, beta, gamma, theta, phi]`` in radians.
-    :raises ValueError: If axis is a zero vector.
-    """
-    axis = np.asarray(axis, dtype=float)
-    norm = np.linalg.norm(axis)
-    if norm < 1e-14:
-        raise ValueError("Rotation axis must be a non-zero vector.")
-    axis_hat = axis / norm
-    angle_rad = np.radians(angle_deg)
-
-    Rmis = Rotation.from_rotvec(axis_hat * angle_rad).as_matrix()
-    alpha, beta, gamma = Rotation.from_matrix(Rmis).as_euler("ZXZ")
-    theta, phi = inclination_from_normal(
-        np.asarray(boundary_normal, dtype=float)
-    )
-
-    return np.array([alpha, beta, gamma, theta, phi])
-
-
-def from_orientation_matrices(
-    P: np.ndarray,
-    Q: np.ndarray,
-    boundary_normal: Optional[np.ndarray] = None,
-) -> np.ndarray:
-    """
-    Compute the GBMaker misorientation array from P and Q orientation matrices.
-
-    Each matrix has **rows** equal to the crystal directions for the lab x, y,
-    and z axes of that grain. The boundary normal is taken from ``P[0]``; if
-    ``boundary_normal`` is supplied it is used only as a consistency check.
-
-    With GBMaker's row-vector convention, a grain orientation matrix satisfies
-    ``x_lab = x_crystal @ P_norm.T``. If grain 2 is misoriented from grain 1 by
-    ``Rmis`` in the crystal frame, then ``Q_norm = P_norm @ Rmis`` and thus::
-
-        Rmis = P_norm.T @ Q_norm
-
-    :param P: 3x3 orientation matrix for grain 1 (left grain).
-    :param Q: 3x3 orientation matrix for grain 2 (right grain).
-    :param boundary_normal: Optional override for the boundary normal. When
-        provided it must match ``P[0]`` within 1 deg; a warning is printed
-        otherwise.
-    :return: 5-element array ``[alpha, beta, gamma, theta, phi]`` in radians.
-    """
-    P_norm = validate_orientation_matrix(P, "P")
-    Q_norm = validate_orientation_matrix(Q, "Q")
-
-    Rmis = P_norm.T @ Q_norm
-    alpha, beta, gamma = Rotation.from_matrix(Rmis).as_euler("ZXZ")
-
-    normal_from_P = P_norm[0]
-    if boundary_normal is not None:
-        n = np.asarray(boundary_normal, dtype=float)
-        n_hat = n / np.linalg.norm(n)
-        cos_angle = np.clip(np.dot(normal_from_P, n_hat), -1.0, 1.0)
-        angle_err = np.degrees(np.arccos(cos_angle))
-        if angle_err > 1.0:
-            print(
-                f"WARNING: supplied --normal deviates from P[0] by "
-                f"{angle_err:.2f} deg — using P[0] for inclination.",
-                file=sys.stderr,
-            )
-
-    theta, phi = inclination_from_normal(normal_from_P)
-    return np.array([alpha, beta, gamma, theta, phi])
-
-
-# ---------------------------------------------------------------------------
-# Validation
-# ---------------------------------------------------------------------------
-
-def validate(
-    params: np.ndarray,
-    boundary_normal: np.ndarray,
-    P_norm: Optional[np.ndarray] = None,
-    Q_norm: Optional[np.ndarray] = None,
-    reference_Rmis: Optional[np.ndarray] = None,
+    P: object | None = None,
+    Q: object | None = None,
 ) -> list[str]:
-    """
-    Run sanity checks on the computed misorientation array.
+    """Build human-readable validation messages for five-DOF parameters.
 
-    :param params: 5-element array ``[alpha, beta, gamma, theta, phi]``.
-    :param boundary_normal: Boundary normal direction (need not be a unit
-        vector).
-    :param P_norm: Row-normalized P matrix (orientation mode only).
-    :param Q_norm: Row-normalized Q matrix (orientation mode only).
-    :param reference_Rmis: Optional reference misorientation matrix.
-    :return: List of result strings, each prefixed with '✓' or '✗'.
-    """
-    alpha, beta, gamma, theta, phi = params
-    checks = []
+    Domain conversion is delegated to :func:`five_dof_spec_to_embedding`, which applies
+    the package's authoritative five-DOF convention. The report then measures whether
+    the resulting left-grain frame reproduces the requested boundary normal and whether
+    the relative left-to-right frame is a proper rotation. Optional ``P`` and ``Q``
+    matrices add an informational comparison of their boundary-normal rows.
 
-    Rincl = (
-        Rotation.from_euler("z", phi) * Rotation.from_euler("y", theta)
-    ).as_matrix()
-    n_hat = boundary_normal / np.linalg.norm(boundary_normal)
-    normal_err = float(np.linalg.norm(Rincl[0, :] - n_hat))
-    mark = "✓" if normal_err < 1e-10 else "✗"
+    :param params: Five values ``[alpha, beta, gamma, theta, phi]`` in radians accepted
+        by :class:`FiveDOFSpec`.
+    :param boundary_normal: Array-like three-component boundary normal that the
+        inclination portion of ``params`` is expected to reproduce.
+    :param P: Optional left-grain row-orientation matrix. It must be supplied together
+        with ``Q`` and is normalized and validated before use. Keyword-only, optional,
+        defaults to ``None``.
+    :param Q: Optional right-grain row-orientation matrix. It must be supplied together
+        with ``P`` and is normalized and validated before use. Keyword-only, optional,
+        defaults to ``None``.
+    :return: Ordered list of formatted ``PASS``, ``FAIL``, ``NOTE``, and ``INFO``
+        messages suitable for inclusion in the human-readable report.
+    :raises ValueError: If exactly one of ``P`` and ``Q`` is supplied.
+    """
+    spec = FiveDOFSpec(params)
+    embedding = five_dof_spec_to_embedding(spec)
+    values = np.asarray(spec.params, dtype=np.float64)
+    beta = float(values[1])
+    checks: list[str] = []
+
+    expected_normal = normalize_direction(boundary_normal, "boundary normal")
+    normal_error = float(np.linalg.norm(embedding.R_left[0] - expected_normal))
+    mark = "PASS" if normal_error < _REPORT_TOL else "FAIL"
     checks.append(
-        f"{mark} Rincl[0,:] matches boundary normal  "
-        f"(err = {normal_err:.3e})"
+        f"{mark}: inclination reproduces the boundary normal (error={normal_error:.3e})"
     )
 
-    Rmis = Rotation.from_euler("ZXZ", [alpha, beta, gamma]).as_matrix()
-    det = float(np.linalg.det(Rmis))
-    ortho_err = float(np.max(np.abs(Rmis.T @ Rmis - np.eye(3))))
-    mark = "✓" if abs(det - 1.0) < 1e-10 and ortho_err < 1e-10 else "✗"
+    misorientation = embedding.R_left.T @ embedding.R_right
+    determinant = float(np.linalg.det(misorientation))
+    orthogonality_error = float(
+        np.max(np.abs(misorientation.T @ misorientation - np.eye(3)))
+    )
+    mark = (
+        "PASS"
+        if abs(determinant - 1.0) < _REPORT_TOL and orthogonality_error < _REPORT_TOL
+        else "FAIL"
+    )
     checks.append(
-        f"{mark} Rmis is proper rotation  "
-        f"(det = {det:.4f}, max col-ortho err = {ortho_err:.3e})"
+        f"{mark}: misorientation is a proper rotation "
+        f"(det={determinant:.12g}, orthogonality error={orthogonality_error:.3e})"
     )
 
-    if reference_Rmis is not None:
-        matrix_err = float(np.max(np.abs(Rmis - reference_Rmis)))
-        delta_deg = float(
-            np.degrees(
-                np.linalg.norm(
-                    Rotation.from_matrix(reference_Rmis.T @ Rmis).as_rotvec()
-                )
-            )
-        )
-        mark = "✓" if matrix_err < 1e-10 and delta_deg < 1e-8 else "✗"
-        checks.append(
-            f"{mark} ZXZ reconstruction matches source rotation  "
-            f"(max matrix err = {matrix_err:.3e}, angle err = {delta_deg:.4f} deg)"
-        )
-
-    beta_deg = float(np.degrees(beta))
+    beta_deg = math.degrees(beta)
     if abs(beta_deg) < 1.0 or abs(abs(beta_deg) - 180.0) < 1.0:
         checks.append(
-            f"  WARNING: beta = {beta_deg:.2f} deg is near 0 deg or 180 deg "
-            f"(ZXZ gimbal lock — alpha and gamma are not uniquely determined)"
+            "NOTE: beta is near a ZXZ singularity; alpha and gamma are not "
+            "individually unique."
         )
 
-    if P_norm is not None and Q_norm is not None:
-        cos_a = float(np.clip(np.dot(P_norm[0], Q_norm[0]), -1.0, 1.0))
-        normal_angle = float(np.degrees(np.arccos(cos_a)))
-        gb_type = "symmetric" if normal_angle < 1e-6 else "asymmetric"
-        mark = "✓" if normal_angle < 1e-6 else "~"
+    if P is not None or Q is not None:
+        if P is None or Q is None:
+            raise ValueError("P and Q must be supplied together.")
+        P_norm = validate_orientation_matrix(P, "P")
+        Q_norm = validate_orientation_matrix(Q, "Q")
+        cosine = float(np.clip(np.dot(P_norm[0], Q_norm[0]), -1.0, 1.0))
+        normal_angle_deg = math.degrees(math.acos(cosine))
         checks.append(
-            f"{mark} GB boundary plane type: {gb_type}  "
-            f"(P[0] vs Q[0] angular diff = {normal_angle:.4f} deg)"
+            "INFO: left/right crystal boundary normals differ by "
+            f"{normal_angle_deg:.6f} deg."
         )
-
-        for name, mat in [("P", P_norm), ("Q", Q_norm)]:
-            orth = float(np.max(np.abs(mat @ mat.T - np.eye(3))))
-            mark = "✓" if orth < 1e-10 else "✗"
-            checks.append(
-                f"{mark} {name}_norm rows are orthonormal  "
-                f"(max err = {orth:.3e})"
-            )
 
     return checks
 
 
-# ---------------------------------------------------------------------------
-# Output formatting
-# ---------------------------------------------------------------------------
+def _simple_symbolic_arguments() -> list[tuple[float, str]]:
+    """Generate candidate arguments for inverse-trigonometric angle formatting.
 
-def _symbolic(rad: float, tol: float = 1e-6) -> str:
-    """Return a symbolic name for *rad* if it can be expressed as a rational
-    multiple of pi (denominator <= 24) or as arctan/arccos/arcsin of a simple
-    rational or square-root argument."""
+    The candidates include small positive rational values and simple square-root
+    expressions. Labels are ASCII strings so report output is portable across terminals.
 
-    frac = Fraction(rad / np.pi).limit_denominator(24)
-    if abs(float(frac) * np.pi - rad) < tol:
-        n, d = frac.numerator, frac.denominator
-        if n == 0:
+    :return: A list of ``(value, label)`` pairs consumed by :func:`_symbolic`, where
+        ``value`` is the floating-point argument and ``label`` is its display
+        representation.
+    """
+    candidates: dict[str, float] = {}
+
+    for denominator in range(1, 9):
+        for numerator in range(1, 3 * denominator + 1):
+            label = str(numerator) if denominator == 1 else f"{numerator}/{denominator}"
+            candidates[label] = numerator / denominator
+
+    for root in range(2, 8):
+        square_root = math.sqrt(root)
+        for numerator in range(1, 9):
+            label = f"1/sqrt({root})" if numerator == 1 else f"{numerator}/sqrt({root})"
+            candidates[label] = numerator / square_root
+        for denominator in range(1, 9):
+            label = (
+                f"sqrt({root})" if denominator == 1 else f"sqrt({root})/{denominator}"
+            )
+            candidates[label] = square_root / denominator
+
+    return [(value, label) for label, value in candidates.items()]
+
+
+def _multiple_expression(
+    function_name: str,
+    argument_label: str,
+    multiplier: int,
+) -> str:
+    """Format a signed integer multiple of an inverse-trigonometric expression.
+
+    :param function_name: Function label, such as ``"arctan"``, ``"arccos"``, or
+        ``"arcsin"``.
+    :param argument_label: Preformatted symbolic argument inserted inside the function
+        call.
+    :param multiplier: Signed nonzero integer coefficient applied to the function value.
+    :return: A compact expression such as ``"arctan(1/5)"``, ``"-arcsin(1/2)"``, or
+        ``"2*arccos(1/3)"``.
+    """
+    base = f"{function_name}({argument_label})"
+    if multiplier == 1:
+        return base
+    if multiplier == -1:
+        return f"-{base}"
+    return f"{multiplier}*{base}"
+
+
+def _symbolic(rad: float, tol: float = 1.0e-6) -> str:
+    """Recognize a compact symbolic representation of an angle.
+
+    The search first considers rational multiples of pi with denominator at most 24. It
+    then considers signed integer multiples from -4 through 4 of ``arctan``, ``arccos``,
+    and ``arcsin`` values evaluated at the candidate arguments returned by
+    :func:`_simple_symbolic_arguments`.
+
+    :param rad: Angle in radians to match against the supported symbolic forms.
+    :param tol: Absolute matching tolerance in radians. Optional; defaults to ``1e-6``.
+    :return: The first matching symbolic expression, or the empty string when no
+        candidate is within ``tol``.
+    """
+    rad = float(rad)
+    fraction = Fraction(rad / math.pi).limit_denominator(24)
+    if abs(float(fraction) * math.pi - rad) < tol:
+        numerator = fraction.numerator
+        denominator = fraction.denominator
+        if numerator == 0:
             return "0"
-        sign = "-" if n < 0 else ""
-        a = abs(n)
-        coeff = "" if a == 1 else str(a)
-        return f"{sign}{coeff}pi/{d}" if d != 1 else f"{sign}{coeff}pi"
+        sign = "-" if numerator < 0 else ""
+        coefficient = "" if abs(numerator) == 1 else str(abs(numerator))
+        pi_term = f"{sign}{coefficient}pi"
+        return pi_term if denominator == 1 else f"{pi_term}/{denominator}"
 
-    pos_args: list[tuple[float, str]] = []
-    for d in range(1, 9):
-        for n in range(1, 3 * d + 1):
-            pos_args.append((n / d, f"{n}/{d}" if d != 1 else str(n)))
-    for k in range(2, 8):
-        sq = float(np.sqrt(k))
-        for n in range(1, 9):
-            pos_args.append((n / sq, f"{n}/sqrt({k})" if n != 1 else f"1/sqrt({k})"))
-        for d in range(1, 9):
-            pos_args.append((sq / d, f"sqrt({k})/{d}" if d != 1 else f"sqrt({k})"))
+    arguments = _simple_symbolic_arguments()
+    for argument, label in arguments:
+        values = (("arctan", math.atan(argument)),)
+        for function_name, value in values:
+            for multiplier in range(-4, 5):
+                if multiplier == 0:
+                    continue
+                if abs(rad - multiplier * value) < tol:
+                    return _multiple_expression(function_name, label, multiplier)
 
-    for arg, label in pos_args:
-        v = float(np.arctan(arg))
-        if abs(rad - v) < tol:
-            return f"arctan({label})"
-        if abs(rad + v) < tol:
-            return f"-arctan({label})"
-
-    for sign, s_lbl in [(1, ""), (-1, "-")]:
-        for arg, label in pos_args:
-            sarg = sign * arg
-            if abs(sarg) > 1.0:
+    for argument, label in arguments:
+        for signed_argument, signed_label in (
+            (argument, label),
+            (-argument, f"-{label}"),
+        ):
+            if abs(signed_argument) > 1.0:
                 continue
-            for fn, fn_name in [(np.arccos, "arccos"), (np.arcsin, "arcsin")]:
-                if abs(rad - float(fn(sarg))) < tol:
-                    return f"{fn_name}({s_lbl}{label})"
+            for function_name, function in (
+                ("arccos", math.acos),
+                ("arcsin", math.asin),
+            ):
+                value = function(signed_argument)
+                for multiplier in range(-4, 5):
+                    if multiplier == 0:
+                        continue
+                    if abs(rad - multiplier * value) < tol:
+                        return _multiple_expression(
+                            function_name,
+                            signed_label,
+                            multiplier,
+                        )
 
     return ""
 
 
-def _fmt_angle(rad: float) -> str:
-    sym = _symbolic(rad)
-    sym_str = f"  [{sym}]" if sym else ""
-    return f"{rad:+.6f} rad  ({np.degrees(rad):+8.2f} deg){sym_str}"
+def _format_angle(rad: float) -> str:
+    """Format one angle for the human-readable report.
+
+    :param rad: Angle in radians.
+    :return: A string containing signed radians, signed degrees, and, when recognized by
+        :func:`_symbolic`, a bracketed symbolic suffix.
+    """
+    symbolic = _symbolic(rad)
+    suffix = f" [{symbolic}]" if symbolic else ""
+    return f"{rad:+.6f} rad ({math.degrees(rad):+8.2f} deg){suffix}"
 
 
-def format_output(
-    params: np.ndarray,
+def format_human_output(
+    params: object,
     input_summary: str,
-    checks: list[str],
+    checks: Sequence[str],
 ) -> str:
-    """
-    Build the human-readable output string.
+    """Build the legacy human-readable five-DOF report.
 
-    :param params: 5-element misorientation array.
-    :param input_summary: One-line description of the inputs used.
-    :param checks: Validation result strings from :func:`validate`.
-    :return: Formatted output string ready for printing.
+    :param params: Five values ``[alpha, beta, gamma, theta, phi]`` in radians accepted
+        by :class:`FiveDOFSpec`.
+    :param input_summary: One-line description of the source values used to derive the
+        parameters.
+    :param checks: Ordered sequence of preformatted validation messages included under
+        the report's ``Validation`` heading.
+    :return: Complete multi-line report ready to write to standard output.
     """
-    alpha, beta, gamma, theta, phi = params
-    array_str = ", ".join(f"{v:.6f}" for v in params)
+    spec = FiveDOFSpec(params)
+    alpha, beta, gamma, theta, phi = np.asarray(
+        spec.params,
+        dtype=np.float64,
+    )
+    array_text = ", ".join(f"{value:.6f}" for value in spec.params)
 
     lines = [
         "",
         "=== GBOpt Misorientation Parameters ===",
         "",
-        f"Input:  {input_summary}",
+        f"Input: {input_summary}",
         "",
         "Misorientation (ZXZ, crystal frame):",
-        f"  alpha = {_fmt_angle(alpha)}",
-        f"  beta = {_fmt_angle(beta)}",
-        f"  gamma = {_fmt_angle(gamma)}",
+        f"  alpha = {_format_angle(float(alpha))}",
+        f"  beta  = {_format_angle(float(beta))}",
+        f"  gamma = {_format_angle(float(gamma))}",
         "",
         "Inclination:",
-        f"  theta = {_fmt_angle(theta)}",
-        f"  phi = {_fmt_angle(phi)}",
+        f"  theta = {_format_angle(float(theta))}",
+        f"  phi   = {_format_angle(float(phi))}",
         "",
         "Validation:",
     ]
-    lines.extend(f"  {c}" for c in checks)
-    lines += [
-        "",
-        f"misorientation = np.array([{array_str}])",
-        "",
-    ]
+    lines.extend(f"  {check}" for check in checks)
+    lines.extend(
+        [
+            "",
+            f"misorientation = np.array([{array_text}])",
+            "",
+        ]
+    )
     return "\n".join(lines)
 
 
-def _clean_float(value: float, tol: float = 5e-13) -> float:
-    """Return a JSON-friendly float with tiny signed zeros removed."""
-    value = float(value)
-    if abs(value) < tol:
-        return 0.0
-    return value
+# ---------------------------------------------------------------------------
+# Core-format parsing and serialization
+# ---------------------------------------------------------------------------
 
 
-def _array_to_float_list(values: np.ndarray) -> list[float]:
-    return [_clean_float(v) for v in np.asarray(values, dtype=float).ravel()]
+def _json_float(value: object, tol: float = _JSON_ZERO_TOL) -> float:
+    """Convert a validated numeric value to stable JSON floating-point output.
+
+    Core-domain validation occurs before this serializer is called, normally through a
+    boundary-spec dataclass. This helper performs only presentation normalization by
+    converting the value to a Python ``float`` and replacing tiny signed values with
+    positive ``0.0``.
+
+    :param value: Previously validated finite numeric scalar to serialize.
+    :param tol: Nonnegative magnitude threshold below which the result is replaced by
+        ``0.0``. Optional, defaults to ``_JSON_ZERO_TOL``.
+    :return: Python ``float`` suitable for JSON serialization.
+    :raises ValueError: If ``value`` converts to NaN or infinity, or if ``tol`` is
+        negative.
+    """
+    if tol < 0.0:
+        raise ValueError(f"tol must be nonnegative; got {tol!r}.")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"Expected a finite real number; got {value!r}.")
+    return 0.0 if abs(result) < tol else result
 
 
-def _json_number(value: float) -> int | float:
-    """Use ints in JSON when a value is effectively integer-valued."""
-    value = _clean_float(value)
-    rounded = round(value)
-    if abs(value - rounded) < 1e-9:
-        return int(rounded)
-    return value
+def _five_dof_payload(spec: FiveDOFSpec) -> dict[str, Any]:
+    """Serialize a validated five-DOF specification.
 
-
-def _matrix_to_json(M: np.ndarray) -> list[list[int | float]]:
-    arr = np.asarray(M, dtype=float)
-    if arr.shape != (3, 3):
-        raise ValueError(f"Expected a 3x3 matrix; got shape {arr.shape}.")
-    return [[_json_number(v) for v in row] for row in arr]
-
-
-def _int_vector(values, name: str, length: int) -> list[int]:
-    arr = np.asarray(values, dtype=float)
-    if arr.shape != (length,):
-        raise ValueError(f"{name} must have length {length}; got shape {arr.shape}.")
-    if not np.all(np.isfinite(arr)):
-        raise ValueError(f"{name} contains non-finite values.")
-    if not np.allclose(arr, np.round(arr), atol=1e-9, rtol=0.0):
-        raise ValueError(f"{name} must be integer-valued.")
-    return [int(v) for v in np.round(arr).astype(int)]
-
-
-def _five_dof_payload(params: np.ndarray | list[float]) -> dict:
-    spec = FiveDOFSpec(params)
+    :param spec: Validated :class:`FiveDOFSpec` whose parameters are expressed in
+        radians.
+    :return: JSON-safe dictionary with ``format="five_dof"``, normalized floating-point
+        ``params``, and ``units="radians"``.
+    :raises TypeError: If ``spec`` is not a :class:`FiveDOFSpec` instance.
+    """
+    if not isinstance(spec, FiveDOFSpec):
+        raise TypeError(f"spec must be FiveDOFSpec; got {type(spec).__name__}.")
     return {
         "format": "five_dof",
-        "params": _array_to_float_list(np.asarray(spec.params, dtype=float)),
+        "params": [_json_float(value) for value in spec.params],
         "units": "radians",
     }
 
 
-def _pq_payload(
-    P: np.ndarray,
-    Q: np.ndarray,
-    *,
-    basis_mode: str = "primitive",
-) -> dict:
-    payload = {
+def _pq_payload(spec: PQSpec) -> dict[str, Any]:
+    """Serialize a validated exact P/Q specification.
+
+    Exact-integer validation and nonsingularity checks are owned by :class:`PQSpec`,
+    which delegates to :mod:`GBOpt.Utils.integer_linalg`. This helper only converts the
+    immutable normalized tuples stored by the spec into JSON lists.
+
+    :param spec: Validated :class:`PQSpec` containing exact integer ``P`` and ``Q``
+        matrices and a normalized basis mode.
+    :return: JSON-safe dictionary with ``format="pq"``, nested integer ``P`` and ``Q``
+        rows, and the validated ``basis_mode``.
+    :raises TypeError: If ``spec`` is not a :class:`PQSpec` instance.
+    """
+    if not isinstance(spec, PQSpec):
+        raise TypeError(f"spec must be PQSpec; got {type(spec).__name__}.")
+    return {
         "format": "pq",
-        "P": _matrix_to_json(P),
-        "Q": _matrix_to_json(Q),
-        "basis_mode": basis_mode,
+        "P": [[int(value) for value in row] for row in spec.P],
+        "Q": [[int(value) for value in row] for row in spec.Q],
+        "basis_mode": spec.basis_mode,
     }
-    PQSpec(payload["P"], payload["Q"], basis_mode=basis_mode)
+
+
+def _csl_payload(spec: CSLExactSpec | CSLApproxSpec) -> dict[str, Any]:
+    """Serialize a validated exact or approximate CSL specification.
+
+    :param spec: Validated :class:`CSLExactSpec` or :class:`CSLApproxSpec` instance.
+    :return: JSON-safe tagged CSL dictionary. Exact specifications contain ``quat`` and
+        ``exact=true``; approximate specifications contain ``angle_deg`` and
+        ``exact=false``. ``sigma`` is included only when present on the spec.
+    :raises TypeError: If ``spec`` is neither a :class:`CSLExactSpec` nor a
+        :class:`CSLApproxSpec`.
+    """
+    payload: dict[str, Any] = {
+        "format": "csl",
+        "axis": [int(value) for value in spec.axis],
+        "plane": [int(value) for value in spec.plane],
+    }
+    if isinstance(spec, CSLExactSpec):
+        payload.update(
+            exact=True,
+            quat=[int(value) for value in spec.quat],
+        )
+    elif isinstance(spec, CSLApproxSpec):
+        payload.update(
+            exact=False,
+            angle_deg=_json_float(spec.angle_deg),
+        )
+    else:
+        raise TypeError(
+            f"spec must be CSLExactSpec or CSLApproxSpec; got {type(spec).__name__}."
+        )
+
+    if spec.sigma is not None:
+        payload["sigma"] = int(spec.sigma)
     return payload
 
 
-def _csl_payload(
-    axis,
-    plane,
+def _build_csl_spec(
+    axis: object,
+    plane: object,
     *,
-    quat=None,
-    angle_deg=None,
-    sigma=None,
-    max_exact_atoms: int = 10_000,
-) -> dict:
-    axis_int = _int_vector(axis, "axis", 3)
-    plane_int = _int_vector(plane, "plane", 3)
-    sigma_int = None if sigma is None else int(sigma)
-    if sigma is not None and sigma_int <= 0:
-        raise ValueError("sigma must be a positive integer.")
+    quat: object | None = None,
+    angle_deg: object | None = None,
+    sigma: object | None = None,
+) -> CSLExactSpec | CSLApproxSpec:
+    """Construct one validated exact or approximate CSL specification.
+
+    Exactly one of ``quat`` and ``angle_deg`` selects the CSL variant. All exact integer
+    shape, type, nonzero, quaternion-axis, and Sigma checks are delegated to the
+    boundary-spec dataclasses and ultimately to :mod:`GBOpt.Utils.integer_linalg`.
+
+    :param axis: Three-component exact integer rotation axis accepted by the CSL spec
+        dataclasses.
+    :param plane: Three-component exact integer boundary-plane normal accepted by the
+        CSL spec dataclasses.
+    :param quat: Optional four-component exact integer quaternion ``[w, x, y, z]`` for
+        an exact CSL. Keyword-only, mutually exclusive with ``angle_deg``, defaults to
+        ``None``.
+    :param angle_deg: Optional finite rotation angle in degrees for an approximate CSL.
+        Keyword-only, mutually exclusive with ``quat``, defaults to ``None``.
+    :param sigma: Optional positive exact integer Sigma value. Keyword-only, defaults to
+        ``None``.
+    :return: Validated :class:`CSLExactSpec` when ``quat`` is supplied, otherwise a
+        validated :class:`CSLApproxSpec`.
+    :raises ValueError: If both or neither of ``quat`` and ``angle_deg`` are supplied.
+    """
+    if (quat is None) == (angle_deg is None):
+        raise ValueError("csl requires exactly one of quat or angle_deg.")
 
     if quat is not None:
-        quat_int = _int_vector(quat, "quat", 4)
-        spec = CSLExactSpec(
-            axis=axis_int,
-            plane=plane_int,
-            sigma=sigma_int,
-            quat=quat_int,
-        )
-        csl_exact_spec_to_embedding(spec, max_exact_atoms=max_exact_atoms)
-        payload = {
-            "format": "csl",
-            "exact": True,
-            "axis": axis_int,
-            "plane": plane_int,
-            "quat": quat_int,
-        }
+        return CSLExactSpec(axis=axis, plane=plane, sigma=sigma, quat=quat)
+
+    return CSLApproxSpec(axis=axis, plane=plane, sigma=sigma, angle_deg=angle_deg)
+
+
+def _normalize_csl_payload(
+    payload: Mapping[str, object],
+) -> tuple[CSLExactSpec | CSLApproxSpec, dict[str, Any]]:
+    """Normalize and validate a CSL core-format mapping.
+
+    The ``exact`` discriminator must agree with the variant field: exact payloads
+    require ``quat`` and prohibit ``angle_deg``; approximate payloads require
+    ``angle_deg`` and prohibit ``quat``. For backward compatibility, ``exact`` may be
+    omitted when exactly one variant field makes the intended type unambiguous.
+
+    :param payload: Mapping containing ``axis``, ``plane``, optional ``sigma``, and a
+        consistent exactness discriminator plus exactly one of ``quat`` or
+        ``angle_deg``.
+    :return: Tuple ``(spec, normalized_payload)`` containing the validated exact or
+        approximate CSL specification followed by its JSON-safe dictionary.
+    :raises ValueError: If ``exact`` is non-boolean or the variant fields are missing or
+        contradictory.
+    """
+    has_quat = payload.get("quat") is not None
+    has_angle = payload.get("angle_deg") is not None
+    exact_value = payload.get("exact")
+
+    if exact_value is None:
+        if has_quat == has_angle:
+            raise ValueError(
+                "A csl payload without 'exact' must contain exactly one of 'quat' "
+                "or 'angle_deg'."
+            )
+        exact = has_quat
     else:
-        if angle_deg is None:
-            raise ValueError("csl requires either quat or angle_deg.")
-        angle = float(angle_deg)
-        spec = CSLApproxSpec(
-            axis=axis_int,
-            plane=plane_int,
-            sigma=sigma_int,
-            angle_deg=angle,
+        if not isinstance(exact_value, (bool, np.bool_)):
+            raise ValueError("csl field 'exact' must be boolean.")
+        exact = bool(exact_value)
+
+    if exact:
+        if not has_quat or has_angle:
+            raise ValueError(
+                "An exact csl payload requires 'quat' and must not contain 'angle_deg'."
+            )
+        spec = _build_csl_spec(
+            payload["axis"],
+            payload["plane"],
+            quat=payload["quat"],
+            sigma=payload.get("sigma"),
         )
-        csl_approx_spec_to_embedding(spec)
-        payload = {
-            "format": "csl",
-            "exact": False,
-            "axis": axis_int,
-            "plane": plane_int,
-            "angle_deg": _clean_float(angle),
-        }
-
-    if sigma_int is not None:
-        payload["sigma"] = sigma_int
-    return payload
-
-
-def _print_payload(payload: dict) -> None:
-    print(json.dumps(payload, indent=2, sort_keys=True))
-
-
-def _load_core_payload(args) -> dict:
-    if args.input_file is not None:
-        with open(args.input_file, encoding="utf-8") as stream:
-            payload = json.load(stream)
-    elif args.input_json is not None:
-        payload = json.loads(args.input_json)
     else:
-        payload = json.load(sys.stdin)
-    if not isinstance(payload, dict):
-        raise ValueError("Core-format input must be a JSON object.")
-    return payload
+        if not has_angle or has_quat:
+            raise ValueError(
+                "An approximate csl payload requires 'angle_deg' and must not contain "
+                "'quat'."
+            )
+        spec = _build_csl_spec(
+            payload["axis"],
+            payload["plane"],
+            angle_deg=payload["angle_deg"],
+            sigma=payload.get("sigma"),
+        )
+
+    return spec, _csl_payload(spec)
 
 
 def _normalize_core_payload(
-    payload: dict,
-    *,
-    max_exact_atoms: int = 10_000,
-) -> dict:
-    fmt = payload.get("format")
-    if fmt == "five_dof":
-        return _five_dof_payload(payload["params"])
-    if fmt == "pq":
-        return _pq_payload(
-            np.asarray(payload["P"], dtype=float),
-            np.asarray(payload["Q"], dtype=float),
-            basis_mode=payload.get("basis_mode", "primitive"),
+    payload: object,
+) -> tuple[
+    dict[str, Any],
+    FiveDOFSpec | PQSpec | CSLExactSpec | CSLApproxSpec,
+]:
+    """Normalize and validate any supported GBOpt core-format payload.
+
+    The CLI owns only tagged-JSON schema dispatch. Field validation is delegated to the
+    corresponding boundary-spec dataclass.
+
+    :param payload: Candidate mapping whose ``format`` field identifies ``"five_dof"``,
+        ``"pq"``, or ``"csl"`` data.
+    :return: Tuple ``(normalized_payload, spec)`` containing a JSON-safe dictionary and
+        its validated boundary-spec object.
+    :raises ValueError: If ``payload`` is not a mapping or names an unsupported format.
+    """
+    if not isinstance(payload, Mapping):
+        raise ValueError("Core-format input must be a JSON object.")
+
+    format_name = payload.get("format")
+    if format_name == "five_dof":
+        spec = FiveDOFSpec(payload["params"])  # type: ignore[arg-type]
+        return _five_dof_payload(spec), spec
+
+    if format_name == "pq":
+        basis_mode = payload.get("basis_mode", "primitive")
+        spec = PQSpec(
+            payload["P"],  # type: ignore[arg-type]
+            payload["Q"],  # type: ignore[arg-type]
+            basis_mode=basis_mode,  # type: ignore[arg-type]
         )
-    if fmt == "csl":
-        return _csl_payload(
-            payload["axis"],
-            payload["plane"],
-            quat=payload.get("quat"),
-            angle_deg=payload.get("angle_deg"),
-            sigma=payload.get("sigma"),
-            max_exact_atoms=max_exact_atoms,
-        )
+        return _pq_payload(spec), spec
+
+    if format_name == "csl":
+        spec, normalized = _normalize_csl_payload(payload)
+        return normalized, spec
+
     raise ValueError("Core-format input must have format 'five_dof', 'pq', or 'csl'.")
 
 
-def _csl_spec_from_payload(
-    payload: dict,
+def _embedding_from_spec(
+    spec: FiveDOFSpec | PQSpec | CSLExactSpec | CSLApproxSpec,
     *,
-    max_exact_atoms: int = 10_000,
-):
-    payload = _normalize_core_payload(payload, max_exact_atoms=max_exact_atoms)
-    if payload["format"] != "csl":
-        raise ValueError("Expected a csl payload.")
-    if payload["exact"]:
-        return CSLExactSpec(
-            axis=payload["axis"],
-            plane=payload["plane"],
-            sigma=payload.get("sigma"),
-            quat=payload["quat"],
+    max_exact_atoms: int,
+) -> BoundaryEmbedding:
+    """Convert a validated boundary specification to its package embedding.
+
+    :param spec: Validated five-DOF, P/Q, exact CSL, or approximate CSL specification.
+    :param max_exact_atoms: Exact-cell size bound forwarded only to exact CSL embedding
+        construction. Keyword-only.
+    :return: Boundary embedding produced by the corresponding crystallography adapter.
+    :raises TypeError: If ``spec`` has an unsupported type.
+    """
+    if isinstance(spec, FiveDOFSpec):
+        return five_dof_spec_to_embedding(spec)
+    if isinstance(spec, PQSpec):
+        return pq_spec_to_embedding(spec)
+    if isinstance(spec, CSLExactSpec):
+        return csl_exact_spec_to_embedding(
+            spec,
+            max_exact_atoms=max_exact_atoms,
         )
-    return CSLApproxSpec(
-        axis=payload["axis"],
-        plane=payload["plane"],
-        sigma=payload.get("sigma"),
-        angle_deg=payload["angle_deg"],
+    if isinstance(spec, CSLApproxSpec):
+        return csl_approx_spec_to_embedding(spec)
+    raise TypeError(f"Unsupported boundary spec type: {type(spec).__name__}.")
+
+
+def _five_dof_spec_from_embedding(embedding: BoundaryEmbedding) -> FiveDOFSpec:
+    """Recover a validated five-DOF specification from a boundary embedding.
+
+    Relative rotation and inclination recovery are delegated to
+    :func:`five_dof_from_orientation_matrices`; this CLI module does not duplicate the
+    row-orientation convention or Euler-angle extraction.
+
+    :param embedding: Boundary embedding whose ``R_left`` and ``R_right`` matrices
+        describe the left- and right-grain row orientations.
+    :return: Validated :class:`FiveDOFSpec` recovered from the embedding frames.
+    """
+    params = five_dof_from_orientation_matrices(
+        embedding.R_left,
+        embedding.R_right,
     )
-
-
-def _five_dof_from_embedding(embedding) -> dict:
-    Rmis = embedding.R_left.T @ embedding.R_right
-    alpha, beta, gamma = Rotation.from_matrix(Rmis).as_euler("ZXZ")
-    theta, phi = inclination_from_normal(embedding.R_left[0])
-    return _five_dof_payload(np.array([alpha, beta, gamma, theta, phi]))
+    return FiveDOFSpec(params)
 
 
 def _convert_payload(
-    payload: dict,
+    payload: object,
     target: str,
     *,
     max_exact_atoms: int = 10_000,
-) -> dict:
-    payload = _normalize_core_payload(payload, max_exact_atoms=max_exact_atoms)
-    source = payload["format"]
+) -> dict[str, Any]:
+    """Convert a supported core-format payload to another representation.
+
+    Tagged-JSON normalization is performed once. Domain conversion is then delegated to
+    boundary-spec embedding adapters, P/Q orientation conversion, or the exactification
+    hook. Exact CSL conversion constructs only one embedding per requested conversion.
+
+    :param payload: Input object in ``five_dof``, ``pq``, or ``csl`` core format.
+    :param target: Requested output format, currently ``"five_dof"`` or ``"pq"``.
+    :param max_exact_atoms: Exact-cell size bound forwarded to exact CSL embedding and
+        five-DOF exactification operations. Keyword-only, defaults to ``10_000``.
+    :return: Normalized JSON-safe payload in ``target`` format. If source and target are
+        equal, the normalized source payload is returned.
+    :raises ValueError: If ``target`` is unsupported, the requested conversion is
+        unavailable, or five-DOF exactification is not implemented.
+    """
+    normalized, spec = _normalize_core_payload(payload)
+    source = normalized["format"]
     if source == target:
-        return payload
+        return normalized
 
     if target == "five_dof":
-        if source == "pq":
-            params = from_orientation_matrices(
-                np.asarray(payload["P"], dtype=float),
-                np.asarray(payload["Q"], dtype=float),
-            )
-            return _five_dof_payload(params)
-        if source == "csl":
-            spec = _csl_spec_from_payload(
-                payload,
-                max_exact_atoms=max_exact_atoms,
-            )
-            if payload["exact"]:
-                embedding = csl_exact_spec_to_embedding(
-                    spec,
-                    max_exact_atoms=max_exact_atoms,
-                )
-            else:
-                embedding = csl_approx_spec_to_embedding(spec)
-            return _five_dof_from_embedding(embedding)
+        embedding = _embedding_from_spec(
+            spec,
+            max_exact_atoms=max_exact_atoms,
+        )
+        return _five_dof_payload(_five_dof_spec_from_embedding(embedding))
 
     if target == "pq":
-        if source == "csl" and payload["exact"]:
-            embedding = csl_exact_spec_to_embedding(
-                _csl_spec_from_payload(
-                    payload,
-                    max_exact_atoms=max_exact_atoms,
-                ),
+        if isinstance(spec, CSLExactSpec):
+            embedding = _embedding_from_spec(
+                spec,
                 max_exact_atoms=max_exact_atoms,
             )
-            return _pq_payload(embedding.P, embedding.Q, basis_mode="primitive")
-        if source == "five_dof":
+            if embedding.P is None or embedding.Q is None:
+                raise ValueError("Exact CSL embedding did not provide P/Q matrices.")
+            return _pq_payload(PQSpec(embedding.P, embedding.Q, basis_mode="primitive"))
+
+        if isinstance(spec, FiveDOFSpec):
             try:
                 P, Q = exactify_five_dof(
-                    np.asarray(payload["params"], dtype=float),
+                    np.asarray(spec.params, dtype=np.float64),
                     max_exact_atoms=max_exact_atoms,
                 )
             except NotImplementedError as exc:
                 raise ValueError(
                     "Conversion from 'five_dof' to 'pq' requires five_dof "
-                    "exactification, which is not yet implemented. Use the "
-                    "exactify subcommand to query the Stage E hook status."
+                    "exactification, which is not implemented."
                 ) from exc
-            return _pq_payload(P, Q, basis_mode="primitive")
+            return _pq_payload(PQSpec(P, Q, basis_mode="primitive"))
 
     raise ValueError(f"Conversion from {source!r} to {target!r} is not available.")
 
 
-def _assert_rotation_close(actual: np.ndarray, expected: np.ndarray) -> None:
-    """Raise AssertionError if two rotation matrices differ beyond tolerance."""
-    delta = Rotation.from_matrix(expected.T @ actual)
-    angle_err = np.linalg.norm(delta.as_rotvec())
-    if angle_err >= 1e-10:
-        raise AssertionError(
-            f"Rotation mismatch: angular error = {np.degrees(angle_err):.6e} deg"
-        )
+def _load_core_payload(args: argparse.Namespace) -> object:
+    """Load one JSON core-format payload from the CLI-selected input source.
 
+    Input precedence is ``input_file``, then ``input_json``, then standard input. The
+    parser's mutually exclusive options normally ensure that no more than one explicit
+    source is set.
 
-def _orientation_matrix(normal: np.ndarray, in_plane: np.ndarray) -> np.ndarray:
-    """Build a row-wise orientation matrix from a boundary normal and in-plane seed."""
-    x_dir = np.asarray(normal, dtype=float)
-    y_seed = np.asarray(in_plane, dtype=float)
-    x_dir /= np.linalg.norm(x_dir)
-    y_seed -= np.dot(y_seed, x_dir) * x_dir
-    y_seed /= np.linalg.norm(y_seed)
-    z_dir = np.cross(x_dir, y_seed)
-    return np.vstack((x_dir, y_seed, z_dir))
-
-
-def run_self_test() -> None:
+    :param args: Parsed :class:`argparse.Namespace` exposing ``input_file`` and
+        ``input_json`` attributes. Each attribute may be ``None``.
+    :return: The Python object decoded from the selected JSON source.
     """
-    Run standalone regression checks for representative boundary types.
-    """
-    cases: list[str] = []
+    if args.input_file is not None:
+        with open(args.input_file, encoding="utf-8") as stream:
+            return json.load(stream)
+    if args.input_json is not None:
+        return json.loads(args.input_json)
+    return json.load(sys.stdin)
 
-    angle_deg = 36.869898
-    normal = np.array([3.0, 1.0, 0.0])
-    params = from_axis_angle([0.0, 0.0, 1.0], angle_deg, normal)
-    expected = np.array(
-        [
-            np.radians(angle_deg),
-            0.0,
-            0.0,
-            0.0,
-            -np.arctan(1.0 / 3.0),
-        ]
+
+def _print_payload(payload: Mapping[str, object]) -> None:
+    """Serialize and print one core-format payload as formatted JSON.
+
+    :param payload: Mapping to encode using two-space indentation and lexicographically
+        sorted keys.
+    """
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+# ---------------------------------------------------------------------------
+# Command handlers
+# ---------------------------------------------------------------------------
+
+
+def _command_axis_angle(args: argparse.Namespace) -> int:
+    """Handle the ``axis_angle`` CLI subcommand.
+
+    :param args: Parsed :class:`argparse.Namespace` exposing ``axis``, ``angle``,
+        ``normal``, and ``format``. The axis and normal each contain three numeric
+        components, the angle is measured in degrees, and the format is ``"json"`` or
+        ``"human"``.
+    :return: Process status code ``0`` after writing the selected output format.
+    """
+    axis = np.asarray(args.axis, dtype=np.float64)
+    normal = np.asarray(args.normal, dtype=np.float64)
+    spec = FiveDOFSpec(five_dof_from_axis_angle(axis, args.angle, normal))
+
+    if args.format == "json":
+        _print_payload(_five_dof_payload(spec))
+        return 0
+
+    checks = _validation_report(spec.params, normal)
+    summary = f"axis={axis.tolist()} angle={args.angle} deg normal={normal.tolist()}"
+    print(format_human_output(spec.params, summary, checks))
+    return 0
+
+
+def _command_orientation(args: argparse.Namespace) -> int:
+    """Handle the ``orientation`` CLI subcommand.
+
+    :param args: Parsed :class:`argparse.Namespace` exposing row-major ``P`` and ``Q``
+        sequences of nine numeric values, optional three-component ``normal``, and
+        ``format`` equal to ``"json"`` or ``"human"``.
+    :return: Process status code ``0`` after writing the selected output format.
+    """
+    P = np.asarray(args.P, dtype=np.float64).reshape(3, 3)
+    Q = np.asarray(args.Q, dtype=np.float64).reshape(3, 3)
+    normal = None if args.normal is None else np.asarray(args.normal, dtype=np.float64)
+    spec = FiveDOFSpec(five_dof_from_orientation_matrices(P, Q, normal))
+
+    if args.format == "json":
+        _print_payload(_five_dof_payload(spec))
+        return 0
+
+    P_norm = validate_orientation_matrix(P, "P")
+    Q_norm = validate_orientation_matrix(Q, "Q")
+    checks = _validation_report(
+        spec.params,
+        P_norm[0],
+        P=P_norm,
+        Q=Q_norm,
     )
-    np.testing.assert_allclose(params, expected, atol=1e-8)
-    Rincl = (
-        Rotation.from_euler("z", params[4]) * Rotation.from_euler("y", params[3])
-    ).as_matrix()
-    np.testing.assert_allclose(Rincl[0, :], normal / np.linalg.norm(normal), atol=1e-10)
-    cases.append("Sigma5 symmetric tilt")
+    summary = f"P={P.tolist()} Q={Q.tolist()}"
+    print(format_human_output(spec.params, summary, checks))
+    return 0
 
-    P = _orientation_matrix([2.0, 1.0, 0.0], [0.0, 0.0, 1.0])
-    Rmis_expected = Rotation.from_rotvec(
-        np.array([0.0, 0.0, np.radians(angle_deg)])
-    ).as_matrix()
-    Q = P @ Rmis_expected
-    params = from_orientation_matrices(P, Q)
-    Rmis = Rotation.from_euler("ZXZ", params[:3]).as_matrix()
-    Rincl = (
-        Rotation.from_euler("z", params[4]) * Rotation.from_euler("y", params[3])
-    ).as_matrix()
-    _assert_rotation_close(Rmis, Rmis_expected)
-    np.testing.assert_allclose(Rincl[0, :], P[0], atol=1e-10)
-    cases.append("Asymmetric tilt")
 
-    angle_deg = 45.0
-    axis = np.array([0.0, 0.0, 1.0])
-    normal = np.array([0.0, 0.0, 1.0])
-    params = from_axis_angle(axis, angle_deg, normal)
-    Rmis = Rotation.from_euler("ZXZ", params[:3]).as_matrix()
-    Rmis_expected = Rotation.from_rotvec(axis * np.radians(angle_deg)).as_matrix()
-    Rincl = (
-        Rotation.from_euler("z", params[4]) * Rotation.from_euler("y", params[3])
-    ).as_matrix()
-    _assert_rotation_close(Rmis, Rmis_expected)
-    np.testing.assert_allclose(Rincl[0, :], normal, atol=1e-10)
-    cases.append("Twist")
+def _command_csl(args: argparse.Namespace) -> int:
+    """Handle the ``csl`` CLI subcommand.
 
-    angle_deg = 60.0
-    axis = np.array([1.0, 1.0, 1.0])
-    axis /= np.linalg.norm(axis)
-    normal = np.array([1.0, 1.0, 1.0])
-    params = from_axis_angle(axis, angle_deg, normal)
-    Rmis = Rotation.from_euler("ZXZ", params[:3]).as_matrix()
-    Rmis_expected = Rotation.from_rotvec(axis * np.radians(angle_deg)).as_matrix()
-    Rincl = (
-        Rotation.from_euler("z", params[4]) * Rotation.from_euler("y", params[3])
-    ).as_matrix()
-    _assert_rotation_close(Rmis, Rmis_expected)
-    np.testing.assert_allclose(Rincl[0, :], normal / np.linalg.norm(normal), atol=1e-10)
-    cases.append("Sigma3 coherent twin")
+    The handler delegates field validation to a CSL boundary-spec dataclass, constructs
+    the corresponding embedding as a feasibility check, and emits the normalized spec.
 
-    print("Standalone regression checks passed:")
-    for case in cases:
-        print(f"  - {case}")
+    :param args: Parsed :class:`argparse.Namespace` exposing integer ``axis`` and
+        ``plane`` vectors, exactly one of ``quat`` or ``angle``, optional ``sigma``, and
+        the ``max_exact_atoms`` bound.
+    :return: Process status code ``0`` after successful validation and JSON emission.
+    """
+    spec = _build_csl_spec(
+        args.axis,
+        args.plane,
+        quat=args.quat,
+        angle_deg=args.angle,
+        sigma=args.sigma,
+    )
+    _embedding_from_spec(spec, max_exact_atoms=args.max_exact_atoms)
+    _print_payload(_csl_payload(spec))
+    return 0
+
+
+def _command_convert(args: argparse.Namespace) -> int:
+    """Handle the ``convert`` CLI subcommand.
+
+    :param args: Parsed :class:`argparse.Namespace` exposing ``input_file``,
+        ``input_json``, target format ``to``, and ``max_exact_atoms``.
+    :return: Process status code ``0`` after printing the converted JSON payload.
+    """
+    payload = _load_core_payload(args)
+    _print_payload(
+        _convert_payload(
+            payload,
+            args.to,
+            max_exact_atoms=args.max_exact_atoms,
+        )
+    )
+    return 0
+
+
+def _command_exactify(args: argparse.Namespace) -> int:
+    """Handle the ``exactify`` CLI subcommand.
+
+    :param args: Parsed :class:`argparse.Namespace` exposing five floating-point
+        ``params`` in radians and the ``max_exact_atoms`` bound.
+    :return: Process status code ``0`` after printing the exact P/Q payload.
+    :raises ValueError: If parameters cannot be converted to floating point or
+        exactification is not implemented.
+    """
+    five_dof = FiveDOFSpec(args.params)
+    try:
+        P, Q = exactify_five_dof(
+            np.asarray(five_dof.params, dtype=np.float64),
+            max_exact_atoms=args.max_exact_atoms,
+        )
+    except NotImplementedError as exc:
+        raise ValueError("five_dof exactification is not implemented.") from exc
+
+    _print_payload(_pq_payload(PQSpec(P, Q, basis_mode="primitive")))
+    return 0
+
+
+def _command_canonicalize(args: argparse.Namespace) -> int:
+    """Handle the ``canonicalize`` CLI subcommand.
+
+    :param args: Parsed :class:`argparse.Namespace` exposing row-major exact integer
+        ``P`` and ``Q`` sequences, each containing nine components.
+    :return: Process status code ``0`` after printing the paired canonical P/Q payload.
+    """
+    P = np.asarray(args.P, dtype=object).reshape(3, 3)
+    Q = np.asarray(args.Q, dtype=object).reshape(3, 3)
+    P_canon, Q_canon = canonicalize_pq_paired(P, Q)
+    _print_payload(_pq_payload(PQSpec(P_canon, Q_canon, basis_mode="primitive")))
+    return 0
 
 
 # ---------------------------------------------------------------------------
-# CLI
+# CLI construction
 # ---------------------------------------------------------------------------
+
+
+def _add_output_format(parser: argparse.ArgumentParser) -> None:
+    """Add the shared output-format option to a subcommand parser.
+
+    :param parser: :class:`argparse.ArgumentParser` for a subcommand supporting JSON and
+        legacy human-readable output. The parser is modified in place by adding a
+        ``--format`` option whose default is ``"json"``.
+    """
+    parser.add_argument(
+        "--format",
+        choices=("json", "human"),
+        default="json",
+        help="Output JSON by default; use human for the legacy report.",
+    )
+
 
 def _build_parser() -> argparse.ArgumentParser:
+    """Construct the complete ``gb_params`` command-line parser.
+
+    :return: Configured top-level :class:`argparse.ArgumentParser` containing the
+        ``axis_angle``, ``orientation``, ``csl``, ``convert``, ``exactify``, and
+        ``canonicalize`` subcommands, their options, and their registered handler
+        functions.
+    """
     parser = argparse.ArgumentParser(
         description=(
-            "Convert grain boundary crystallographic descriptions into GBOpt "
-            "core formats (five_dof, pq, csl)."
+            "Convert grain-boundary crystallographic descriptions into GBOpt core "
+            "formats."
         )
     )
-    sub = parser.add_subparsers(dest="mode", required=True)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
 
-    aa = sub.add_parser(
+    axis_angle = subparsers.add_parser(
         "axis_angle",
-        help="Convert rotation axis, angle, and boundary normal to five_dof.",
+        help="Convert a rotation axis, angle, and boundary normal to five_dof.",
     )
-    aa.add_argument(
+    axis_angle.add_argument(
         "--axis",
         nargs=3,
         type=float,
         metavar=("U", "V", "W"),
         required=True,
-        help="Rotation axis [u v w] in crystal coordinates.",
     )
-    aa.add_argument(
+    axis_angle.add_argument(
         "--angle",
         type=float,
-        required=True,
         metavar="DEG",
-        help="Misorientation angle in degrees.",
+        required=True,
     )
-    aa.add_argument(
+    axis_angle.add_argument(
         "--normal",
         nargs=3,
         type=float,
         metavar=("H", "K", "L"),
         required=True,
-        help="Boundary normal direction [h k l] in crystal coordinates.",
     )
-    aa.add_argument(
-        "--format",
-        choices=("json", "human"),
-        default="json",
-        help="Output JSON core format by default; use human for the legacy report.",
-    )
+    _add_output_format(axis_angle)
+    axis_angle.set_defaults(handler=_command_axis_angle)
 
-    ori = sub.add_parser(
+    orientation = subparsers.add_parser(
         "orientation",
-        help=(
-            "Convert P and Q orientation matrices "
-            "(rows = crystal directions for lab x/y/z axes)."
-        ),
+        help="Convert row-wise P and Q orientation matrices to five_dof.",
     )
-    ori.add_argument(
+    orientation.add_argument(
         "--P",
         nargs=9,
         type=float,
         metavar="V",
         required=True,
-        help=(
-            "Grain 1 orientation matrix, 9 values row-major "
-            "(e.g. --P 2 2 2  1 -1 0  1 1 -2)."
-        ),
+        help="Left-grain orientation matrix, nine row-major values.",
     )
-    ori.add_argument(
+    orientation.add_argument(
         "--Q",
         nargs=9,
         type=float,
         metavar="V",
         required=True,
-        help="Grain 2 orientation matrix, 9 values row-major.",
+        help="Right-grain orientation matrix, nine row-major values.",
     )
-    ori.add_argument(
+    orientation.add_argument(
         "--normal",
         nargs=3,
         type=float,
         metavar=("H", "K", "L"),
         default=None,
-        help=(
-            "Optional boundary normal override for consistency check. "
-            "If omitted, P[0] is used."
-        ),
+        help="Optional boundary-normal consistency check; P[0] remains authoritative.",
     )
-    ori.add_argument(
-        "--target",
-        choices=("five_dof", "pq"),
-        default="five_dof",
-        help="Core output format. five_dof preserves the legacy conversion behavior.",
-    )
-    ori.add_argument(
-        "--format",
-        choices=("json", "human"),
-        default="json",
-        help="Output JSON core format by default; use human for the legacy report.",
-    )
+    _add_output_format(orientation)
+    orientation.set_defaults(handler=_command_orientation)
 
-    csl = sub.add_parser(
+    csl = subparsers.add_parser(
         "csl",
         help="Validate and emit an exact or approximate CSL core-format spec.",
     )
-    csl.add_argument("--axis", nargs=3, type=int,
-                     metavar=("U", "V", "W"), required=True)
-    csl.add_argument("--plane", nargs=3, type=int,
-                     metavar=("H", "K", "L"), required=True)
+    csl.add_argument(
+        "--axis",
+        nargs=3,
+        type=int,
+        metavar=("U", "V", "W"),
+        required=True,
+    )
+    csl.add_argument(
+        "--plane",
+        nargs=3,
+        type=int,
+        metavar=("H", "K", "L"),
+        required=True,
+    )
     csl_kind = csl.add_mutually_exclusive_group(required=True)
     csl_kind.add_argument(
         "--quat",
         nargs=4,
         type=int,
         metavar=("W", "X", "Y", "Z"),
-        help="Integer quaternion [w x y z] for an exact CSL spec.",
     )
-    csl_kind.add_argument(
-        "--angle",
-        type=float,
-        metavar="DEG",
-        help="Approximate misorientation angle in degrees.",
-    )
-    csl.add_argument("--sigma", type=int, default=None, help="Optional positive sigma.")
-    csl.add_argument(
-        "--max-exact-atoms",
-        type=int,
-        default=10_000,
-        help="Exact CSL cell-size guard used while validating --quat input.",
-    )
+    csl_kind.add_argument("--angle", type=float, metavar="DEG")
+    csl.add_argument("--sigma", type=int, default=None)
+    csl.add_argument("--max-exact-atoms", type=int, default=10_000)
+    csl.set_defaults(handler=_command_csl)
 
-    conv = sub.add_parser(
+    convert = subparsers.add_parser(
         "convert",
-        help="Convert a JSON core-format spec to another supported core format.",
+        help="Convert a JSON core-format spec to another supported format.",
     )
-    conv_in = conv.add_mutually_exclusive_group()
-    conv_in.add_argument("--input-json", help="Input core-format JSON object.")
-    conv_in.add_argument("--input-file", help="Path to an input core-format JSON file.")
-    conv.add_argument(
-        "--to",
-        choices=("five_dof", "pq"),
-        required=True,
-        help="Target core format.",
-    )
-    conv.add_argument(
-        "--max-exact-atoms",
-        type=int,
-        default=10_000,
-        help="Exact CSL/exactification cell-size guard.",
-    )
+    convert_input = convert.add_mutually_exclusive_group()
+    convert_input.add_argument("--input-json")
+    convert_input.add_argument("--input-file")
+    convert.add_argument("--to", choices=("five_dof", "pq"), required=True)
+    convert.add_argument("--max-exact-atoms", type=int, default=10_000)
+    convert.set_defaults(handler=_command_convert)
 
-    exact = sub.add_parser(
+    exactify = subparsers.add_parser(
         "exactify",
-        help="Exactify five_dof parameters through the Stage E hook.",
+        help="Exactify five_dof parameters through the exactification hook.",
     )
-    exact.add_argument(
+    exactify.add_argument(
         "--params",
         nargs=5,
         type=float,
         metavar=("ALPHA", "BETA", "GAMMA", "THETA", "PHI"),
         required=True,
-        help="five_dof parameters in radians.",
     )
-    exact.add_argument(
-        "--max-exact-atoms",
-        type=int,
-        default=10_000,
-        help="Exactification cell-size guard.",
-    )
+    exactify.add_argument("--max-exact-atoms", type=int, default=10_000)
+    exactify.set_defaults(handler=_command_exactify)
 
-    canon = sub.add_parser(
+    canonicalize = subparsers.add_parser(
         "canonicalize",
-        help="Canonicalize exact P/Q matrices using GBOpt's canonicalize_pq routine.",
+        help="Canonicalize paired exact integer P/Q matrices.",
     )
-    canon.add_argument(
+    canonicalize.add_argument(
         "--P",
         nargs=9,
-        type=float,
+        type=int,
         metavar="V",
         required=True,
-        help="Grain 1 orientation matrix, 9 row-major values.",
     )
-    canon.add_argument(
+    canonicalize.add_argument(
         "--Q",
         nargs=9,
-        type=float,
+        type=int,
         metavar="V",
         required=True,
-        help="Grain 2 orientation matrix, 9 row-major values.",
     )
-
-    sub.add_parser(
-        "self_test",
-        help="Run standalone regression checks for representative GB types.",
-    )
+    canonicalize.set_defaults(handler=_command_canonicalize)
 
     return parser
 
 
-def main() -> int:
-    """Entry point for the command-line interface."""
-    parser = _build_parser()
-    args = parser.parse_args()
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the ``gb_params`` command-line interface.
 
-    if args.mode == "self_test":
-        run_self_test()
-        return 0
+    The selected handler returns an integer process status. Expected domain, payload,
+    I/O, and conversion failures are converted to :mod:`argparse` errors so command-line
+    callers receive a diagnostic and exit status ``2``.
+
+    :param argv: Optional argument sequence excluding the executable name. When
+        ``None``, :mod:`argparse` reads from ``sys.argv``. Defaults to ``None``.
+    :return: Process status ``0`` when the selected command succeeds. The trailing ``2``
+        is a defensive return for static analysis because :meth:`ArgumentParser.error`
+        raises ``SystemExit``.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
 
     try:
-        if args.mode == "axis_angle":
-            axis = np.array(args.axis)
-            normal = np.array(args.normal)
-            params = from_axis_angle(axis, args.angle, normal)
-            if args.format == "json":
-                _print_payload(_five_dof_payload(params))
-                return 0
-
-            reference_Rmis = Rotation.from_rotvec(
-                axis / np.linalg.norm(axis) * np.radians(args.angle)
-            ).as_matrix()
-            input_summary = (
-                f"axis={axis.tolist()}  angle={args.angle} deg  normal={normal.tolist()}"
-            )
-            checks = validate(params, normal, None, None, reference_Rmis)
-            print(format_output(params, input_summary, checks))
-            return 0
-
-        if args.mode == "orientation":
-            P = np.array(args.P).reshape(3, 3)
-            Q = np.array(args.Q).reshape(3, 3)
-            normal_arg = (
-                np.array(args.normal) if args.normal is not None else None
-            )
-            if args.target == "pq":
-                if args.format == "human":
-                    parser.error(
-                        "--format human is only supported with --target five_dof.")
-                _print_payload(_pq_payload(P, Q))
-                return 0
-
-            params = from_orientation_matrices(P, Q, normal_arg)
-            if args.format == "json":
-                _print_payload(_five_dof_payload(params))
-                return 0
-
-            P_norm = normalize_rows(P)
-            Q_norm = normalize_rows(Q)
-            reference_Rmis = P_norm.T @ Q_norm
-            normal = P_norm[0]
-            input_summary = f"P={P.tolist()}  Q={Q.tolist()}"
-            checks = validate(params, normal, P_norm, Q_norm, reference_Rmis)
-            print(format_output(params, input_summary, checks))
-            return 0
-
-        if args.mode == "csl":
-            _print_payload(
-                _csl_payload(
-                    args.axis,
-                    args.plane,
-                    quat=args.quat,
-                    angle_deg=args.angle,
-                    sigma=args.sigma,
-                    max_exact_atoms=args.max_exact_atoms,
-                )
-            )
-            return 0
-
-        if args.mode == "convert":
-            payload = _load_core_payload(args)
-            _print_payload(
-                _convert_payload(
-                    payload,
-                    args.to,
-                    max_exact_atoms=args.max_exact_atoms,
-                )
-            )
-            return 0
-
-        if args.mode == "exactify":
-            try:
-                P, Q = exactify_five_dof(
-                    np.asarray(args.params, dtype=float),
-                    max_exact_atoms=args.max_exact_atoms,
-                )
-            except NotImplementedError:
-                _print_payload(
-                    {
-                        "status": "not_implemented",
-                        "message": (
-                            "five_dof exactification is not yet implemented; "
-                            "this is the Stage E hook."
-                        ),
-                    }
-                )
-                return 0
-            _print_payload(_pq_payload(P, Q, basis_mode="primitive"))
-            return 0
-
-        if args.mode == "canonicalize":
-            P = np.array(args.P).reshape(3, 3)
-            Q = np.array(args.Q).reshape(3, 3)
-            P_canon, Q_canon = canonicalize_pq(P, Q)
-            _print_payload(_pq_payload(P_canon, Q_canon, basis_mode="primitive"))
-            return 0
-
-    except (BoundarySpecError, ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
+        return int(args.handler(args))
+    except (
+        BoundarySpecError,
+        CrystallographyValueError,
+        KeyError,
+        OSError,
+        ValueError,
+    ) as exc:
         parser.error(str(exc))
 
-    parser.error(f"Unhandled mode: {args.mode}")
     return 2
 
 

--- a/GBOpt/Utils/gb_params.py
+++ b/GBOpt/Utils/gb_params.py
@@ -1,27 +1,49 @@
 # Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
-"""Utility to convert grain boundary crystallographic descriptions into the
-5-element misorientation array expected by GBOpt's GBMaker class.
+"""Utility to convert grain-boundary descriptions into GBOpt core formats.
 
 Usage
 -----
     python GBOpt/Utils/gb_params.py axis_angle --axis 1 -1 0 --angle 70.53 --normal 1 1 1
     python GBOpt/Utils/gb_params.py orientation --P 2 2 2 1 -1 0 1 1 -2 \
                                                 --Q 2 2 2 -1 1 0 -1 -1 2
+    python GBOpt/Utils/gb_params.py csl --axis 0 0 1 --plane 1 0 0 --quat 2 0 0 1
+    python GBOpt/Utils/gb_params.py canonicalize --P ... --Q ...
     python GBOpt/Utils/gb_params.py self_test
 """
 
 import argparse
+import json
 import sys
 from fractions import Fraction
+from pathlib import Path
 from typing import Optional
 
 import numpy as np
 from scipy.spatial.transform import Rotation
 
+if __package__ in (None, ""):
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+from GBOpt.BoundarySpec import (  # noqa: E402
+    BoundarySpecError,
+    CSLApproxSpec,
+    CSLExactSpec,
+    FiveDOFSpec,
+    PQSpec,
+)
+from GBOpt.Utils.gb_exact import (  # noqa: E402
+    canonicalize_pq,
+    csl_approx_spec_to_embedding,
+    csl_spec_to_embedding,
+    exactify_five_dof,
+)
 
 # ---------------------------------------------------------------------------
 # Core math helpers
 # ---------------------------------------------------------------------------
+
 
 def normalize_rows(M: np.ndarray) -> np.ndarray:
     """
@@ -384,6 +406,250 @@ def format_output(
     return "\n".join(lines)
 
 
+def _clean_float(value: float, tol: float = 5e-13) -> float:
+    """Return a JSON-friendly float with tiny signed zeros removed."""
+    value = float(value)
+    if abs(value) < tol:
+        return 0.0
+    return value
+
+
+def _array_to_float_list(values: np.ndarray) -> list[float]:
+    return [_clean_float(v) for v in np.asarray(values, dtype=float).ravel()]
+
+
+def _json_number(value: float) -> int | float:
+    """Use ints in JSON when a value is effectively integer-valued."""
+    value = _clean_float(value)
+    rounded = round(value)
+    if abs(value - rounded) < 1e-9:
+        return int(rounded)
+    return value
+
+
+def _matrix_to_json(M: np.ndarray) -> list[list[int | float]]:
+    arr = np.asarray(M, dtype=float)
+    if arr.shape != (3, 3):
+        raise ValueError(f"Expected a 3x3 matrix; got shape {arr.shape}.")
+    return [[_json_number(v) for v in row] for row in arr]
+
+
+def _int_vector(values, name: str, length: int) -> list[int]:
+    arr = np.asarray(values, dtype=float)
+    if arr.shape != (length,):
+        raise ValueError(f"{name} must have length {length}; got shape {arr.shape}.")
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(f"{name} contains non-finite values.")
+    if not np.allclose(arr, np.round(arr), atol=1e-9, rtol=0.0):
+        raise ValueError(f"{name} must be integer-valued.")
+    return [int(v) for v in np.round(arr).astype(int)]
+
+
+def _five_dof_payload(params: np.ndarray | list[float]) -> dict:
+    spec = FiveDOFSpec(params)
+    return {
+        "format": "five_dof",
+        "params": _array_to_float_list(np.asarray(spec.params, dtype=float)),
+        "units": "radians",
+    }
+
+
+def _pq_payload(
+    P: np.ndarray,
+    Q: np.ndarray,
+    *,
+    basis_mode: str = "primitive",
+) -> dict:
+    payload = {
+        "format": "pq",
+        "P": _matrix_to_json(P),
+        "Q": _matrix_to_json(Q),
+        "basis_mode": basis_mode,
+    }
+    PQSpec(payload["P"], payload["Q"], basis_mode=basis_mode)
+    return payload
+
+
+def _csl_payload(
+    axis,
+    plane,
+    *,
+    quat=None,
+    angle_deg=None,
+    sigma=None,
+    max_exact_atoms: int = 10_000,
+) -> dict:
+    axis_int = _int_vector(axis, "axis", 3)
+    plane_int = _int_vector(plane, "plane", 3)
+    sigma_int = None if sigma is None else int(sigma)
+    if sigma is not None and sigma_int <= 0:
+        raise ValueError("sigma must be a positive integer.")
+
+    if quat is not None:
+        quat_int = _int_vector(quat, "quat", 4)
+        spec = CSLExactSpec(
+            axis=axis_int,
+            plane=plane_int,
+            sigma=sigma_int,
+            quat=quat_int,
+        )
+        csl_spec_to_embedding(spec, max_exact_atoms=max_exact_atoms)
+        payload = {
+            "format": "csl",
+            "exact": True,
+            "axis": axis_int,
+            "plane": plane_int,
+            "quat": quat_int,
+        }
+    else:
+        if angle_deg is None:
+            raise ValueError("csl requires either quat or angle_deg.")
+        angle = float(angle_deg)
+        spec = CSLApproxSpec(
+            axis=axis_int,
+            plane=plane_int,
+            sigma=sigma_int,
+            angle_deg=angle,
+        )
+        csl_approx_spec_to_embedding(spec)
+        payload = {
+            "format": "csl",
+            "exact": False,
+            "axis": axis_int,
+            "plane": plane_int,
+            "angle_deg": _clean_float(angle),
+        }
+
+    if sigma_int is not None:
+        payload["sigma"] = sigma_int
+    return payload
+
+
+def _print_payload(payload: dict) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _load_core_payload(args) -> dict:
+    if args.input_file is not None:
+        with open(args.input_file, encoding="utf-8") as stream:
+            payload = json.load(stream)
+    elif args.input_json is not None:
+        payload = json.loads(args.input_json)
+    else:
+        payload = json.load(sys.stdin)
+    if not isinstance(payload, dict):
+        raise ValueError("Core-format input must be a JSON object.")
+    return payload
+
+
+def _normalize_core_payload(
+    payload: dict,
+    *,
+    max_exact_atoms: int = 10_000,
+) -> dict:
+    fmt = payload.get("format")
+    if fmt == "five_dof":
+        return _five_dof_payload(payload["params"])
+    if fmt == "pq":
+        return _pq_payload(
+            np.asarray(payload["P"], dtype=float),
+            np.asarray(payload["Q"], dtype=float),
+            basis_mode=payload.get("basis_mode", "primitive"),
+        )
+    if fmt == "csl":
+        return _csl_payload(
+            payload["axis"],
+            payload["plane"],
+            quat=payload.get("quat"),
+            angle_deg=payload.get("angle_deg"),
+            sigma=payload.get("sigma"),
+            max_exact_atoms=max_exact_atoms,
+        )
+    raise ValueError("Core-format input must have format 'five_dof', 'pq', or 'csl'.")
+
+
+def _csl_spec_from_payload(
+    payload: dict,
+    *,
+    max_exact_atoms: int = 10_000,
+):
+    payload = _normalize_core_payload(payload, max_exact_atoms=max_exact_atoms)
+    if payload["format"] != "csl":
+        raise ValueError("Expected a csl payload.")
+    if payload["exact"]:
+        return CSLExactSpec(
+            axis=payload["axis"],
+            plane=payload["plane"],
+            sigma=payload.get("sigma"),
+            quat=payload["quat"],
+        )
+    return CSLApproxSpec(
+        axis=payload["axis"],
+        plane=payload["plane"],
+        sigma=payload.get("sigma"),
+        angle_deg=payload["angle_deg"],
+    )
+
+
+def _five_dof_from_embedding(embedding) -> dict:
+    Rmis = embedding.R_left.T @ embedding.R_right
+    alpha, beta, gamma = Rotation.from_matrix(Rmis).as_euler("ZXZ")
+    theta, phi = inclination_from_normal(embedding.R_left[0])
+    return _five_dof_payload(np.array([alpha, beta, gamma, theta, phi]))
+
+
+def _convert_payload(
+    payload: dict,
+    target: str,
+    *,
+    max_exact_atoms: int = 10_000,
+) -> dict:
+    payload = _normalize_core_payload(payload, max_exact_atoms=max_exact_atoms)
+    source = payload["format"]
+    if source == target:
+        return payload
+
+    if target == "five_dof":
+        if source == "pq":
+            params = from_orientation_matrices(
+                np.asarray(payload["P"], dtype=float),
+                np.asarray(payload["Q"], dtype=float),
+            )
+            return _five_dof_payload(params)
+        if source == "csl":
+            spec = _csl_spec_from_payload(
+                payload,
+                max_exact_atoms=max_exact_atoms,
+            )
+            if payload["exact"]:
+                embedding = csl_spec_to_embedding(
+                    spec,
+                    max_exact_atoms=max_exact_atoms,
+                )
+            else:
+                embedding = csl_approx_spec_to_embedding(spec)
+            return _five_dof_from_embedding(embedding)
+
+    if target == "pq":
+        if source == "csl" and payload["exact"]:
+            embedding = csl_spec_to_embedding(
+                _csl_spec_from_payload(
+                    payload,
+                    max_exact_atoms=max_exact_atoms,
+                ),
+                max_exact_atoms=max_exact_atoms,
+            )
+            return _pq_payload(embedding.P, embedding.Q, basis_mode="primitive")
+        if source == "five_dof":
+            P, Q = exactify_five_dof(
+                np.asarray(payload["params"], dtype=float),
+                max_exact_atoms=max_exact_atoms,
+            )
+            return _pq_payload(P, Q, basis_mode="primitive")
+
+    raise ValueError(f"Conversion from {source!r} to {target!r} is not available.")
+
+
 def _assert_rotation_close(actual: np.ndarray, expected: np.ndarray) -> None:
     """Raise AssertionError if two rotation matrices differ beyond tolerance."""
     delta = Rotation.from_matrix(expected.T @ actual)
@@ -483,15 +749,15 @@ def run_self_test() -> None:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Convert grain boundary crystallographic descriptions into the "
-            "5-element misorientation array for GBOpt's GBMaker."
+            "Convert grain boundary crystallographic descriptions into GBOpt "
+            "core formats (five_dof, pq, csl)."
         )
     )
     sub = parser.add_subparsers(dest="mode", required=True)
 
     aa = sub.add_parser(
         "axis_angle",
-        help="Derive parameters from rotation axis, angle, and boundary normal.",
+        help="Convert rotation axis, angle, and boundary normal to five_dof.",
     )
     aa.add_argument(
         "--axis",
@@ -516,11 +782,17 @@ def _build_parser() -> argparse.ArgumentParser:
         required=True,
         help="Boundary normal direction [h k l] in crystal coordinates.",
     )
+    aa.add_argument(
+        "--format",
+        choices=("json", "human"),
+        default="json",
+        help="Output JSON core format by default; use human for the legacy report.",
+    )
 
     ori = sub.add_parser(
         "orientation",
         help=(
-            "Derive parameters from P and Q orientation matrices "
+            "Convert P and Q orientation matrices "
             "(rows = crystal directions for lab x/y/z axes)."
         ),
     )
@@ -554,6 +826,108 @@ def _build_parser() -> argparse.ArgumentParser:
             "If omitted, P[0] is used."
         ),
     )
+    ori.add_argument(
+        "--target",
+        choices=("five_dof", "pq"),
+        default="five_dof",
+        help="Core output format. five_dof preserves the legacy conversion behavior.",
+    )
+    ori.add_argument(
+        "--format",
+        choices=("json", "human"),
+        default="json",
+        help="Output JSON core format by default; use human for the legacy report.",
+    )
+
+    csl = sub.add_parser(
+        "csl",
+        help="Validate and emit an exact or approximate CSL core-format spec.",
+    )
+    csl.add_argument("--axis", nargs=3, type=int,
+                     metavar=("U", "V", "W"), required=True)
+    csl.add_argument("--plane", nargs=3, type=int,
+                     metavar=("H", "K", "L"), required=True)
+    csl_kind = csl.add_mutually_exclusive_group(required=True)
+    csl_kind.add_argument(
+        "--quat",
+        nargs=4,
+        type=int,
+        metavar=("W", "X", "Y", "Z"),
+        help="Integer quaternion [w x y z] for an exact CSL spec.",
+    )
+    csl_kind.add_argument(
+        "--angle",
+        type=float,
+        metavar="DEG",
+        help="Approximate misorientation angle in degrees.",
+    )
+    csl.add_argument("--sigma", type=int, default=None, help="Optional positive sigma.")
+    csl.add_argument(
+        "--max-exact-atoms",
+        type=int,
+        default=10_000,
+        help="Exact CSL cell-size guard used while validating --quat input.",
+    )
+
+    conv = sub.add_parser(
+        "convert",
+        help="Convert a JSON core-format spec to another supported core format.",
+    )
+    conv_in = conv.add_mutually_exclusive_group()
+    conv_in.add_argument("--input-json", help="Input core-format JSON object.")
+    conv_in.add_argument("--input-file", help="Path to an input core-format JSON file.")
+    conv.add_argument(
+        "--to",
+        choices=("five_dof", "pq", "csl"),
+        required=True,
+        help="Target core format.",
+    )
+    conv.add_argument(
+        "--max-exact-atoms",
+        type=int,
+        default=10_000,
+        help="Exact CSL/exactification cell-size guard.",
+    )
+
+    exact = sub.add_parser(
+        "exactify",
+        help="Exactify five_dof parameters through the Stage E hook.",
+    )
+    exact.add_argument(
+        "--params",
+        nargs=5,
+        type=float,
+        metavar=("ALPHA", "BETA", "GAMMA", "THETA", "PHI"),
+        required=True,
+        help="five_dof parameters in radians.",
+    )
+    exact.add_argument(
+        "--max-exact-atoms",
+        type=int,
+        default=10_000,
+        help="Exactification cell-size guard.",
+    )
+
+    canon = sub.add_parser(
+        "canonicalize",
+        help="Canonicalize exact P/Q matrices using GBOpt's canonicalize_pq routine.",
+    )
+    canon.add_argument(
+        "--P",
+        nargs=9,
+        type=float,
+        metavar="V",
+        required=True,
+        help="Grain 1 orientation matrix, 9 row-major values.",
+    )
+    canon.add_argument(
+        "--Q",
+        nargs=9,
+        type=float,
+        metavar="V",
+        required=True,
+        help="Grain 2 orientation matrix, 9 row-major values.",
+    )
 
     sub.add_parser(
         "self_test",
@@ -563,43 +937,118 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main() -> None:
+def main() -> int:
     """Entry point for the command-line interface."""
     parser = _build_parser()
     args = parser.parse_args()
 
     if args.mode == "self_test":
         run_self_test()
-        return
+        return 0
 
-    if args.mode == "axis_angle":
-        axis = np.array(args.axis)
-        normal = np.array(args.normal)
-        params = from_axis_angle(axis, args.angle, normal)
-        reference_Rmis = Rotation.from_rotvec(
-            axis / np.linalg.norm(axis) * np.radians(args.angle)
-        ).as_matrix()
-        input_summary = (
-            f"axis={axis.tolist()}  angle={args.angle} deg  normal={normal.tolist()}"
-        )
-        P_norm = Q_norm = None
+    try:
+        if args.mode == "axis_angle":
+            axis = np.array(args.axis)
+            normal = np.array(args.normal)
+            params = from_axis_angle(axis, args.angle, normal)
+            if args.format == "json":
+                _print_payload(_five_dof_payload(params))
+                return 0
 
-    else:
-        P = np.array(args.P).reshape(3, 3)
-        Q = np.array(args.Q).reshape(3, 3)
-        normal_arg = (
-            np.array(args.normal) if args.normal is not None else None
-        )
-        params = from_orientation_matrices(P, Q, normal_arg)
-        P_norm = normalize_rows(P)
-        Q_norm = normalize_rows(Q)
-        reference_Rmis = P_norm.T @ Q_norm
-        normal = P_norm[0]
-        input_summary = f"P={P.tolist()}  Q={Q.tolist()}"
+            reference_Rmis = Rotation.from_rotvec(
+                axis / np.linalg.norm(axis) * np.radians(args.angle)
+            ).as_matrix()
+            input_summary = (
+                f"axis={axis.tolist()}  angle={args.angle} deg  normal={normal.tolist()}"
+            )
+            checks = validate(params, normal, None, None, reference_Rmis)
+            print(format_output(params, input_summary, checks))
+            return 0
 
-    checks = validate(params, normal, P_norm, Q_norm, reference_Rmis)
-    print(format_output(params, input_summary, checks))
+        if args.mode == "orientation":
+            P = np.array(args.P).reshape(3, 3)
+            Q = np.array(args.Q).reshape(3, 3)
+            normal_arg = (
+                np.array(args.normal) if args.normal is not None else None
+            )
+            if args.target == "pq":
+                if args.format == "human":
+                    parser.error(
+                        "--format human is only supported with --target five_dof.")
+                _print_payload(_pq_payload(P, Q))
+                return 0
+
+            params = from_orientation_matrices(P, Q, normal_arg)
+            if args.format == "json":
+                _print_payload(_five_dof_payload(params))
+                return 0
+
+            P_norm = normalize_rows(P)
+            Q_norm = normalize_rows(Q)
+            reference_Rmis = P_norm.T @ Q_norm
+            normal = P_norm[0]
+            input_summary = f"P={P.tolist()}  Q={Q.tolist()}"
+            checks = validate(params, normal, P_norm, Q_norm, reference_Rmis)
+            print(format_output(params, input_summary, checks))
+            return 0
+
+        if args.mode == "csl":
+            _print_payload(
+                _csl_payload(
+                    args.axis,
+                    args.plane,
+                    quat=args.quat,
+                    angle_deg=args.angle,
+                    sigma=args.sigma,
+                    max_exact_atoms=args.max_exact_atoms,
+                )
+            )
+            return 0
+
+        if args.mode == "convert":
+            payload = _load_core_payload(args)
+            _print_payload(
+                _convert_payload(
+                    payload,
+                    args.to,
+                    max_exact_atoms=args.max_exact_atoms,
+                )
+            )
+            return 0
+
+        if args.mode == "exactify":
+            try:
+                P, Q = exactify_five_dof(
+                    np.asarray(args.params, dtype=float),
+                    max_exact_atoms=args.max_exact_atoms,
+                )
+            except NotImplementedError:
+                _print_payload(
+                    {
+                        "status": "not_implemented",
+                        "message": (
+                            "five_dof exactification is not yet implemented; "
+                            "this is the Stage E hook."
+                        ),
+                    }
+                )
+                return 0
+            _print_payload(_pq_payload(P, Q, basis_mode="primitive"))
+            return 0
+
+        if args.mode == "canonicalize":
+            P = np.array(args.P).reshape(3, 3)
+            Q = np.array(args.Q).reshape(3, 3)
+            P_canon, Q_canon = canonicalize_pq(P, Q)
+            _print_payload(_pq_payload(P_canon, Q_canon, basis_mode="primitive"))
+            return 0
+
+    except (BoundarySpecError, ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
+        parser.error(str(exc))
+
+    parser.error(f"Unhandled mode: {args.mode}")
+    return 2
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/GBOpt/Utils/gb_params.py
+++ b/GBOpt/Utils/gb_params.py
@@ -10,6 +10,7 @@ Usage
     python GBOpt/Utils/gb_params.py canonicalize --P ... --Q ...
     python GBOpt/Utils/gb_params.py self_test
 """
+from __future__ import annotations
 
 import argparse
 import json
@@ -33,10 +34,10 @@ from GBOpt.BoundarySpec import (  # noqa: E402
     FiveDOFSpec,
     PQSpec,
 )
-from GBOpt.Utils.gb_exact import (  # noqa: E402
+from GBOpt.crystallography import (
     canonicalize_pq,
     csl_approx_spec_to_embedding,
-    csl_spec_to_embedding,
+    csl_exact_spec_to_embedding,
     exactify_five_dof,
 )
 
@@ -493,7 +494,7 @@ def _csl_payload(
             sigma=sigma_int,
             quat=quat_int,
         )
-        csl_spec_to_embedding(spec, max_exact_atoms=max_exact_atoms)
+        csl_exact_spec_to_embedding(spec, max_exact_atoms=max_exact_atoms)
         payload = {
             "format": "csl",
             "exact": True,
@@ -622,7 +623,7 @@ def _convert_payload(
                 max_exact_atoms=max_exact_atoms,
             )
             if payload["exact"]:
-                embedding = csl_spec_to_embedding(
+                embedding = csl_exact_spec_to_embedding(
                     spec,
                     max_exact_atoms=max_exact_atoms,
                 )
@@ -632,7 +633,7 @@ def _convert_payload(
 
     if target == "pq":
         if source == "csl" and payload["exact"]:
-            embedding = csl_spec_to_embedding(
+            embedding = csl_exact_spec_to_embedding(
                 _csl_spec_from_payload(
                     payload,
                     max_exact_atoms=max_exact_atoms,

--- a/GBOpt/Utils/gb_params.py
+++ b/GBOpt/Utils/gb_params.py
@@ -2,10 +2,6 @@
 
 """Thin CLI for converting grain-boundary descriptions into GBOpt core formats.
 
-Boundary-spec dataclasses own core-format validation, and the crystallography package
-owns all domain conversion. This module is limited to tagged-JSON schema handling,
-human-readable reporting, command dispatch, and serialization.
-
 Examples
 --------
 Convert an axis-angle description to five-DOF JSON::

--- a/GBOpt/Utils/gb_params.py
+++ b/GBOpt/Utils/gb_params.py
@@ -641,10 +641,17 @@ def _convert_payload(
             )
             return _pq_payload(embedding.P, embedding.Q, basis_mode="primitive")
         if source == "five_dof":
-            P, Q = exactify_five_dof(
-                np.asarray(payload["params"], dtype=float),
-                max_exact_atoms=max_exact_atoms,
-            )
+            try:
+                P, Q = exactify_five_dof(
+                    np.asarray(payload["params"], dtype=float),
+                    max_exact_atoms=max_exact_atoms,
+                )
+            except NotImplementedError as exc:
+                raise ValueError(
+                    "Conversion from 'five_dof' to 'pq' requires five_dof "
+                    "exactification, which is not yet implemented. Use the "
+                    "exactify subcommand to query the Stage E hook status."
+                ) from exc
             return _pq_payload(P, Q, basis_mode="primitive")
 
     raise ValueError(f"Conversion from {source!r} to {target!r} is not available.")
@@ -878,7 +885,7 @@ def _build_parser() -> argparse.ArgumentParser:
     conv_in.add_argument("--input-file", help="Path to an input core-format JSON file.")
     conv.add_argument(
         "--to",
-        choices=("five_dof", "pq", "csl"),
+        choices=("five_dof", "pq"),
         required=True,
         help="Target core format.",
     )

--- a/GBOpt/crystallography/__init__.py
+++ b/GBOpt/crystallography/__init__.py
@@ -17,6 +17,7 @@ from .csl import (
     csl_from_scaled_rotation,
     dsc_basis,
 )
+from .exactification import exactify_five_dof
 from .pq import (
     canonicalize_pq,
     canonicalize_pq_paired,
@@ -40,6 +41,12 @@ __all__ = [
     "csl_exact_spec_to_embedding",
     "pq_spec_to_embedding",
     "primitive_bicrystal_atom_count",
+    "csl_from_scaled_rotation",
+    "dsc_basis",
+    "exactify_five_dof",
+    "canonicalize_pq",
+    "canonicalize_pq_paired",
+    "recover_exact_row_rotation_from_paired_pq",
     "CoincidenceCheck",
     "CSLResult",
     "DSCBasis",
@@ -48,9 +55,4 @@ __all__ = [
     "SmithDiagnostics",
     "normalize_integer_quaternion",
     "quaternion_to_scaled_rotation",
-    "csl_from_scaled_rotation",
-    "dsc_basis",
-    "canonicalize_pq",
-    "canonicalize_pq_paired",
-    "recover_exact_row_rotation_from_paired_pq"
 ]

--- a/GBOpt/crystallography/__init__.py
+++ b/GBOpt/crystallography/__init__.py
@@ -18,6 +18,17 @@ from .csl import (
     dsc_basis,
 )
 from .exactification import exactify_five_dof
+from .orientation import (
+    build_mixed_orientations,
+    build_symmetric_tilt_orientations,
+    build_tilt_orientations,
+    build_twist_orientations,
+    five_dof_from_axis_angle,
+    five_dof_from_orientation_matrices,
+    inclination_from_normal,
+    normalize_direction,
+    validate_orientation_matrix,
+)
 from .pq import (
     canonicalize_pq,
     canonicalize_pq_paired,
@@ -44,6 +55,15 @@ __all__ = [
     "csl_from_scaled_rotation",
     "dsc_basis",
     "exactify_five_dof",
+    "build_mixed_orientations",
+    "build_symmetric_tilt_orientations",
+    "build_tilt_orientations",
+    "build_twist_orientations",
+    "five_dof_from_axis_angle",
+    "five_dof_from_orientation_matrices",
+    "inclination_from_normal",
+    "normalize_direction",
+    "validate_orientation_matrix",
     "canonicalize_pq",
     "canonicalize_pq_paired",
     "recover_exact_row_rotation_from_paired_pq",

--- a/GBOpt/crystallography/boundary.py
+++ b/GBOpt/crystallography/boundary.py
@@ -20,6 +20,7 @@ from GBOpt.BoundarySpec import (
     BoundarySpecOrthogonalityError,
     CSLApproxSpec,
     CSLExactSpec,
+    FiveDOFSpec,
     PQSpec,
 )
 from GBOpt.Utils.integer_linalg import cross_int3
@@ -233,6 +234,36 @@ def csl_approx_spec_to_embedding(spec: CSLApproxSpec) -> BoundaryEmbedding:
     R_right = R_left @ R_mis
 
     return embedding_from_rotation_rows(R_left, R_right, source="csl")
+
+
+def five_dof_spec_to_embedding(spec: FiveDOFSpec) -> BoundaryEmbedding:
+    """Convert a FiveDOFSpec to a legacy-equivalent approximate embedding.
+
+    The five parameters use GBMaker's legacy convention: ``[alpha, beta, gamma, theta,
+    phi]`` where the first three entries are a ZXZ misorientation and the final two
+    entries are boundary inclination rotations about lab y and z. Exactification is
+    intentionally not attempted here; Stage E owns that bounded rationalization path.
+
+    :param spec: A validated ``FiveDOFSpec`` instance.
+    :return: ``BoundaryEmbedding`` with ``exact=False``, no P/Q matrices, and
+        ``source="five_dof"``.
+    """
+    params = np.asarray(spec.params, dtype=float)
+    R_mis = Rotation.from_euler("ZXZ", params[:3]).as_matrix()
+    R_incl = (
+        Rotation.from_euler("z", params[4])
+        * Rotation.from_euler("y", params[3])
+    ).as_matrix()
+
+    return BoundaryEmbedding(
+        P=None,
+        Q=None,
+        R_left=R_incl,
+        R_right=R_incl @ R_mis,
+        exact=False,
+        coherent=False,
+        source="five_dof",
+    )
 
 
 def primitive_bicrystal_atom_count(

--- a/GBOpt/crystallography/boundary.py
+++ b/GBOpt/crystallography/boundary.py
@@ -207,7 +207,7 @@ def csl_approx_spec_to_embedding(spec: CSLApproxSpec) -> BoundaryEmbedding:
     where ``R_mis`` is the rotation about the given axis by ``angle_deg``.
 
     :param spec: A ``CSLApproxSpec`` instance.
-    :return: ``BoundaryEmbedding`` with ``exact=False``, ``coherent=True``, and
+    :return: ``BoundaryEmbedding`` with ``exact=False``, ``coherent=False``, and
         ``source="csl"``.
     """
     plane = np.asarray(spec.plane, dtype=float)
@@ -233,7 +233,7 @@ def csl_approx_spec_to_embedding(spec: CSLApproxSpec) -> BoundaryEmbedding:
     )
     R_right = R_left @ R_mis
 
-    return embedding_from_rotation_rows(R_left, R_right, source="csl")
+    return embedding_from_rotation_rows(R_left, R_right, source="csl", coherent=False)
 
 
 def five_dof_spec_to_embedding(spec: FiveDOFSpec) -> BoundaryEmbedding:
@@ -305,5 +305,6 @@ __all__ = [
     "pq_spec_to_embedding",
     "csl_exact_spec_to_embedding",
     "csl_approx_spec_to_embedding",
+    "five_dof_spec_to_embedding",
     "primitive_bicrystal_atom_count",
 ]

--- a/GBOpt/crystallography/boundary.py
+++ b/GBOpt/crystallography/boundary.py
@@ -34,6 +34,7 @@ from .embedding import (
     primitive_metadata,
 )
 from .integer import row_gcd_reduce
+from .orientation import orientation_matrices_from_five_dof
 from .plane import inplane_area_index, plane_null_basis, rotation_preserves_plane
 from .pq import (
     canonicalize_pq_paired,
@@ -237,32 +238,37 @@ def csl_approx_spec_to_embedding(spec: CSLApproxSpec) -> BoundaryEmbedding:
 
 
 def five_dof_spec_to_embedding(spec: FiveDOFSpec) -> BoundaryEmbedding:
-    """Convert a FiveDOFSpec to a legacy-equivalent approximate embedding.
+    """Convert a validated ``FiveDOFSpec`` to an approximate embedding.
 
-    The five parameters use GBMaker's legacy convention: ``[alpha, beta, gamma, theta,
-    phi]`` where the first three entries are a ZXZ misorientation and the final two
-    entries are boundary inclination rotations about lab y and z. Exactification is
-    intentionally not attempted here; Stage E owns that bounded rationalization path.
+    The boundary adapter translates the validated five-DOF specification into
+    floating-point row-orientation matrices through
+    :func:`orientation_matrices_from_five_dof`, then delegates ``BoundaryEmbedding``
+    construction and final rotation validation to :func:`embedding_from_rotation_rows`.
 
-    :param spec: A validated ``FiveDOFSpec`` instance.
-    :return: ``BoundaryEmbedding`` with ``exact=False``, no P/Q matrices, and
-        ``source="five_dof"``.
+    Exactification is intentionally not attempted here. Five-DOF rationalization into
+    exact integer P/Q matrices belongs to the separate exactification path.
+
+    :param spec: Validated five-DOF boundary specification containing ``[alpha, beta,
+        gamma, theta, phi]`` in radians.
+    :return: Approximate ``BoundaryEmbedding`` with ``P=None``, ``Q=None``,
+        ``exact=False``, ``coherent=False``, and ``source="five_dof"``.
+    :raises BoundarySpecError: If the five-DOF values cannot be translated into proper
+        floating-point orientation matrices.
+    :raises BoundarySpecOrthogonalityError: If the translated left or right rows do not
+        form a proper orientation matrix during embedding construction.
     """
-    params = np.asarray(spec.params, dtype=float)
-    R_mis = Rotation.from_euler("ZXZ", params[:3]).as_matrix()
-    R_incl = (
-        Rotation.from_euler("z", params[4])
-        * Rotation.from_euler("y", params[3])
-    ).as_matrix()
+    try:
+        R_left, R_right = orientation_matrices_from_five_dof(spec.params)
+    except CrystallographyValueError as exc:
+        raise BoundarySpecError(
+            f"Invalid five-DOF orientation: {exc}"
+        ) from exc
 
-    return BoundaryEmbedding(
-        P=None,
-        Q=None,
-        R_left=R_incl,
-        R_right=R_incl @ R_mis,
-        exact=False,
-        coherent=False,
+    return embedding_from_rotation_rows(
+        R_left,
+        R_right,
         source="five_dof",
+        coherent=False,
     )
 
 

--- a/GBOpt/crystallography/embedding.py
+++ b/GBOpt/crystallography/embedding.py
@@ -21,6 +21,7 @@ from GBOpt.Utils.integer_linalg import cross_int3, dot_int
 
 from .csl import csl_from_scaled_rotation
 from .integer import as_int_array, integer_det3, row_gcd_reduce
+from .orientation import validate_orientation_matrix
 from .plane import inplane_area_index, inplane_basis_from_csl
 from .pq import canonicalize_pq, canonicalize_pq_paired
 from .reduction import gauss_reduce_2d
@@ -31,23 +32,36 @@ from .rotation import (
 from .types import CrystallographyValueError, InPlaneBasis, ScaledRotation
 
 
-def _as_float_matrix(matrix: np.ndarray) -> np.ndarray:
-    """Return matrix as a float ndarray for numerical rotation operations.
+def _validated_rotation_rows(
+    matrix: np.ndarray,
+    name: str,
+) -> np.ndarray:
+    """Return normalized proper rotation rows with embedding-layer exceptions.
 
-    :param matrix: Input matrix to convert to a float array.
-    :return: Float ndarray view or copy produced by np.asarray.
+    Delegates floating-point row-orientation validation to
+    :func:`GBOpt.crystallography.orientation.validate_orientation_matrix`. This keeps
+    normalization, shape checking, finite-value checking, orthogonality checking, and
+    handedness checking in the orientation module while preserving the exception type
+    expected by boundary-embedding callers.
+
+    :param matrix: Candidate 3 by 3 row-orientation matrix. Rows may have arbitrary
+        nonzero magnitudes but must be finite, mutually orthogonal after normalization,
+        and right-handed.
+    :param name: Human-readable matrix name included in validation error messages.
+    :return: Normalized ``float64`` row-orientation matrix with shape ``(3, 3)``.
+    :raises BoundarySpecOrthogonalityError: If ``matrix`` has the wrong shape, contains
+        non-finite or zero rows, is not orthogonal after row normalization, or is not
+        right-handed.
     """
-    return np.asarray(matrix, dtype=float)
-
-
-def _as_object_int_matrix(matrix: np.ndarray, name: str) -> np.ndarray:
-    """Return matrix as an exact object-dtype integer matrix.
-
-    :param matrix: Input matrix to convert to an object-dtype integer array.
-    :param name: Name used in validation error messages.
-    :return: 3 by 3 exact integer ndarray.
-    """
-    return as_int_array(matrix, (3, 3), name)
+    try:
+        return validate_orientation_matrix(matrix, name)
+    except CrystallographyValueError as exc:
+        message = str(exc)
+        if "right-handed" in message:
+            message = f"{name} is not a proper rotation matrix: {message}"
+        elif "orthogonal" in message:
+            message = f"{name} is not an orthogonal rotation matrix: {message}"
+        raise BoundarySpecOrthogonalityError(message) from exc
 
 
 def _csl_inplane(row_rotation: ScaledRotation, plane_int: np.ndarray) -> InPlaneBasis:
@@ -68,42 +82,6 @@ def _csl_inplane(row_rotation: ScaledRotation, plane_int: np.ndarray) -> InPlane
         return inplane_basis_from_csl(csl.basis_hnf, tuple(int(x) for x in plane_int))
     except CrystallographyValueError as exc:
         raise BoundarySpecError(str(exc)) from exc
-
-
-def _normalize_rotation_rows(matrix: np.ndarray) -> np.ndarray:
-    """Return a copy of M with each row normalized to unit length.
-
-    :param matrix: 3 by 3 float matrix whose rows are to be normalized.
-    :return: 3 by 3 float matrix with unit-length rows.
-    :raises BoundarySpecError: If any row is the zero row (norm == 0).
-    """
-    matrix_float = _as_float_matrix(matrix)
-    norms = np.linalg.norm(matrix_float, axis=1, keepdims=True)
-    if np.any(norms == 0):
-        raise BoundarySpecError(f"Zero row present in matrix: {matrix}")
-    return matrix_float / norms
-
-
-def _assert_proper_rotation_rows(R_left: np.ndarray, R_right: np.ndarray) -> None:
-    """Raise if either rotation matrix is not a proper rotation.
-
-    :param R_left: Left-grain rotation matrix.
-    :param R_right: Right-grain rotation matrix.
-    :raises BoundarySpecOrthogonalityError: If either matrix is not orthogonal or has
-        determinant not equal to ``1``.
-    """
-    identity = np.eye(3)
-    for name, R in (("R_left", R_left), ("R_right", R_right)):
-        orthogonal = np.allclose(R @ R.T, identity, atol=1e-10)
-        proper = abs(np.linalg.det(R) - 1) < 1e-10
-        if not orthogonal:
-            raise BoundarySpecOrthogonalityError(
-                f"{name} is not an orthogonal rotation matrix (R @ R.T != I)."
-            )
-        if not proper:
-            raise BoundarySpecOrthogonalityError(
-                f"{name} is not a proper rotation matrix (det(R) != 1)."
-            )
 
 
 def primitive_metadata(
@@ -130,8 +108,8 @@ def primitive_metadata(
         and boundary plane. Keyword argument, required.
     :param plane: Primitive boundary-plane normal as a length-3 integer array. Keyword
         argument, required.
-    :param rotation_denominator: Denominator ``N`` of the exact scaled rotation
-        ``R = M / N`` associated with this boundary. Keyword argument, required.
+    :param rotation_denominator: Denominator ``N`` of the exact scaled rotation ``R = M
+        / N`` associated with this boundary. Keyword argument, required.
     :param input_area_index: In-plane area index of caller-provided ``P`` rows, when
         available. Must be an integer multiple of ``primitive_area_index`` when
         supplied. Keyword argument, optional, defaults to ``None``.
@@ -140,9 +118,9 @@ def primitive_metadata(
         not required to be related by divisibility to ``primitive_area_index``. Keyword
         argument, optional, defaults to ``None``.
     :return: Boundary metadata attached to ``BoundaryEmbedding``.
-    :raises BoundarySpecError: If an area index is not positive, if
-        ``input_area_index`` is supplied but is not an integer multiple of
-        ``primitive_area_index``, or if metadata construction fails validation.
+    :raises BoundarySpecError: If an area index is not positive, if ``input_area_index``
+        is supplied but is not an integer multiple of ``primitive_area_index``, or if
+        metadata construction fails validation.
     """
     if basis_mode not in ("primitive", "supplied"):
         raise BoundarySpecError(
@@ -192,7 +170,7 @@ def embedding_from_pq(
     Q_canon: np.ndarray,
     *,
     source: str,
-    metadata=None,
+    metadata: PrimitiveCellMetadata | None = None,
 ) -> BoundaryEmbedding:
     """Build a ``BoundaryEmbedding`` from canonical P and Q matrices.
 
@@ -205,11 +183,12 @@ def embedding_from_pq(
         no metadata is available. Keyword argument, optional, defaults to ``None``.
     :return: ``BoundaryEmbedding`` with ``exact=True``, ``coherent=True``, and
         ``source`` as supplied. ``R_left`` and ``R_right`` are constructed by
-        normalizing each row of ``P_canon`` and ``Q_canon`` to unit length respectively.
+        normalizing and validating the rows of ``P_canon`` and ``Q_canon``.
+    :raises BoundarySpecOrthogonalityError: If either matrix has malformed, non-finite,
+        zero, non-orthogonal, or left-handed rows.
     """
-    R_left = _normalize_rotation_rows(P_canon)
-    R_right = _normalize_rotation_rows(Q_canon)
-    _assert_proper_rotation_rows(R_left, R_right)
+    R_left = _validated_rotation_rows(P_canon, "R_left")
+    R_right = _validated_rotation_rows(Q_canon, "R_right")
     return BoundaryEmbedding(
         P=P_canon,
         Q=Q_canon,
@@ -240,14 +219,13 @@ def embedding_from_rotation_rows(
         the returned ``BoundaryEmbedding``. Keyword argument, required.
     :param coherent: Whether the approximate embedding represents a coherent boundary
         construction. Keyword argument, optional, defaults to ``True``.
-    :return: Approximate ``BoundaryEmbedding`` with ``P=None``, ``Q=None``, and
-        ``exact=False``.
-    :raises BoundarySpecOrthogonalityError: If either rotation matrix is not orthogonal
-        or has determinant not equal to ``1``.
+    :return: Approximate ``BoundaryEmbedding`` with normalized ``R_left`` and
+        ``R_right``, ``P=None``, ``Q=None``, and ``exact=False``.
+    :raises BoundarySpecOrthogonalityError: If either matrix has malformed, non-finite,
+        zero, non-orthogonal, or left-handed rows.
     """
-    R_left = _as_float_matrix(R_left)
-    R_right = _as_float_matrix(R_right)
-    _assert_proper_rotation_rows(R_left, R_right)
+    R_left = _validated_rotation_rows(R_left, "R_left")
+    R_right = _validated_rotation_rows(R_right, "R_right")
 
     return BoundaryEmbedding(
         P=None,
@@ -391,9 +369,8 @@ def orthogonal_embedding_from_row_rotation_and_plane(
     # Validate the returned orientation frames before computing optional metadata
     # from those rows. This preserves BoundarySpecOrthogonalityError for malformed
     # canonical rows.
-    R_left = _normalize_rotation_rows(P_canon)
-    R_right = _normalize_rotation_rows(Q_canon)
-    _assert_proper_rotation_rows(R_left, R_right)
+    R_left = _validated_rotation_rows(P_canon, "R_left")
+    R_right = _validated_rotation_rows(Q_canon, "R_right")
 
     orientation_area_index = inplane_area_index(P_canon)
 

--- a/GBOpt/crystallography/exactification.py
+++ b/GBOpt/crystallography/exactification.py
@@ -1,0 +1,29 @@
+# Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
+
+"""Rationalization of approximate boundaries into exact crystallographic forms."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def exactify_five_dof(
+    params: np.ndarray,
+    *,
+    max_exact_atoms: int = 10_000,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Convert five-DOF boundary parameters to exact canonical P/Q matrices.
+
+    :param params: Five-DOF parameters ``[alpha, beta, gamma, theta, phi]`` in radians.
+    :param max_exact_atoms: Maximum permitted size of the resulting exact cell.
+        Keyword argument, optional, defaults to ``10000``.
+    :return: Canonical integer orientation matrices ``(P, Q)``.
+    :raises NotImplementedError: Five-DOF exactification is not yet implemented.
+    """
+    raise NotImplementedError(
+        "Conversion from five-DOF parameters to exact canonical P/Q matrices "
+        "is not implemented."
+    )
+
+
+__all__ = ["exactify_five_dof"]

--- a/GBOpt/crystallography/exactification.py
+++ b/GBOpt/crystallography/exactification.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import numpy as np
 
+from .types import CrystallographyNotImplementedError
+
 
 def exactify_five_dof(
     params: np.ndarray,
@@ -15,12 +17,13 @@ def exactify_five_dof(
     """Convert five-DOF boundary parameters to exact canonical P/Q matrices.
 
     :param params: Five-DOF parameters ``[alpha, beta, gamma, theta, phi]`` in radians.
-    :param max_exact_atoms: Maximum permitted size of the resulting exact cell.
-        Keyword argument, optional, defaults to ``10000``.
+    :param max_exact_atoms: Maximum permitted size of the resulting exact cell. Keyword
+        argument, optional, defaults to ``10000``.
     :return: Canonical integer orientation matrices ``(P, Q)``.
-    :raises NotImplementedError: Five-DOF exactification is not yet implemented.
+    :raises CrystallographyNotImplementedError: Five-DOF exactification is not yet
+        implemented.
     """
-    raise NotImplementedError(
+    raise CrystallographyNotImplementedError(
         "Conversion from five-DOF parameters to exact canonical P/Q matrices "
         "is not implemented."
     )

--- a/GBOpt/crystallography/orientation.py
+++ b/GBOpt/crystallography/orientation.py
@@ -27,7 +27,7 @@ _DEFAULT_ORIENTATION_TOL = 1.0e-10
 _DEFAULT_NORMAL_WARNING_DEG = 1.0
 
 # ---------------------------------------------------------------------------
-# Floating-point row-orientation construction and conversion
+# Validation and normalization
 # ---------------------------------------------------------------------------
 
 
@@ -126,6 +126,32 @@ def normalize_direction(
         non-finite values, or has norm no greater than ``tol``.
     """
     tol = _validated_tolerance(tol, "tol")
+    return _normalize_direction(direction, name, tol=tol)
+
+
+def _normalize_direction(
+    direction: object,
+    name: str,
+    *,
+    tol: float,
+) -> np.ndarray:
+    """Normalize a three-component direction using a prevalidated tolerance.
+
+    This internal helper converts ``direction`` to a finite ``float64`` vector, verifies
+    that its Euclidean norm is greater than ``tol``, and returns the corresponding unit
+    vector. Unlike :func:`normalize_direction`, it does not validate ``tol``; callers
+    should use it only after validating a shared tolerance value.
+
+    :param direction: Array-like object containing exactly three finite numeric
+        components. The direction need not already have unit length.
+    :param name: Human-readable argument name used in validation error messages.
+    :param tol: Prevalidated, finite, strictly positive lower bound for the direction's
+        Euclidean norm.
+    :return: Unit-length ``numpy.float64`` vector with shape ``(3,)``.
+    :raises CrystallographyValueError: If ``direction`` cannot be converted to a
+        three-component numeric vector, contains a non-finite value, or has a norm less
+        than or equal to ``tol``.
+    """
     vector = _vector3(direction, name)
     norm = float(np.linalg.norm(vector))
     if norm <= tol:
@@ -156,6 +182,39 @@ def validate_orientation_matrix(
         row-wise orientation matrix.
     """
     tol = _validated_tolerance(tol, "tol")
+    return _validate_orientation_matrix(matrix, name, tol=tol)
+
+
+def _validate_orientation_matrix(
+    matrix: object,
+    name: str,
+    *,
+    tol: float,
+) -> np.ndarray:
+    """Normalize and validate a row-wise orientation matrix.
+
+    Each row identifies the crystal direction aligned with one Cartesian laboratory
+    axis. The candidate matrix is converted to ``float64``, checked for the required
+    shape and finite values, and normalized row by row. The normalized rows must form a
+    mutually orthogonal, right-handed frame.
+
+    Unlike :func:`validate_orientation_matrix`, this internal helper assumes that
+    ``tol`` has already been validated as finite and strictly positive. It is intended
+    for call paths that reuse one tolerance across multiple validation operations.
+
+    :param matrix: Array-like candidate orientation matrix with shape ``(3, 3)``. Its
+        rows may have arbitrary nonzero magnitudes but must become mutually orthogonal
+        and right-handed after normalization.
+    :param name: Human-readable matrix name used in validation error messages.
+    :param tol: Prevalidated absolute tolerance used for minimum row norms, Gram-matrix
+        orthogonality error, and deviation of the normalized determinant from ``+1``.
+    :return: Row-normalized ``numpy.float64`` matrix with shape ``(3, 3)`` whose rows
+        form a proper right-handed orthonormal frame.
+    :raises CrystallographyValueError: If ``matrix`` cannot be converted to a numeric
+        array, does not have shape ``(3, 3)``, contains non-finite values, contains a
+        row whose norm is less than or equal to ``tol``, is not orthogonal within
+        ``tol``, or is not right-handed within ``tol``.
+    """
     try:
         candidate = np.asarray(matrix, dtype=np.float64)
     except (TypeError, ValueError) as exc:
@@ -171,8 +230,9 @@ def validate_orientation_matrix(
         raise CrystallographyValueError(f"{name} must contain only finite values.")
 
     norms = np.linalg.norm(candidate, axis=1)
-    if np.any(norms <= tol):
-        row = int(np.flatnonzero(norms <= tol)[0])
+    zero_rows = norms <= tol
+    if np.any(zero_rows):
+        row = int(np.flatnonzero(zero_rows)[0])
         raise CrystallographyValueError(
             f"{name} row {row} must be nonzero; got norm {norms[row]:.3e}."
         )
@@ -187,7 +247,7 @@ def validate_orientation_matrix(
             f"maximum Gram-matrix error is {gram_error:.3e}."
         )
 
-    determinant = float(np.linalg.det(normalized))
+    determinant = float(np.dot(normalized[0], np.cross(normalized[1], normalized[2])))
     if abs(determinant - 1.0) > tol:
         raise CrystallographyValueError(
             f"{name} must be right-handed after normalization; "
@@ -195,6 +255,11 @@ def validate_orientation_matrix(
         )
 
     return normalized
+
+
+# ---------------------------------------------------------------------------
+# Orientation-frame construction
+# ---------------------------------------------------------------------------
 
 
 def _project_into_plane(
@@ -206,11 +271,11 @@ def _project_into_plane(
 ) -> np.ndarray:
     """Project a direction into the plane perpendicular to a unit normal.
 
-    The supplied direction is first validated and normalized. Its component parallel to
-    ``normal`` is then removed, and the remaining in-plane component is normalized.
+    The supplied direction is validated, projected directly, and the remaining in-plane
+    component is normalized.
 
-    This private helper assumes that ``normal`` has already been validated as a finite
-    unit vector with shape ``(3,)``.
+    This private helper assumes that ``normal`` is a finite unit vector with shape
+    ``(3,)`` and that ``tol`` is finite and strictly positive.
 
     :param direction: Array-like three-component direction to project. It need not be
         normalized, but it must be finite and nonzero.
@@ -222,15 +287,20 @@ def _project_into_plane(
         magnitude and determining whether the projected component is effectively zero.
     :return: A unit-length ``numpy.float64`` vector with shape ``(3,)`` that lies in the
         plane perpendicular to ``normal``.
-    :raises CrystallographyValueError: If ``tol`` is invalid; if ``direction`` cannot be
-        interpreted as a finite, nonzero three-component vector; or if ``direction`` is
-        parallel to ``normal`` within ``tol`` and therefore has no nonzero in-plane
-        projection.
+    :raises CrystallographyValueError: If ``direction`` cannot be interpreted as a
+        finite, nonzero three-component vector, or if it is parallel to ``normal``
+        within ``tol`` and therefore has no nonzero in-plane projection.
     """
-    direction_hat = normalize_direction(direction, name, tol=tol)
-    projected = direction_hat - np.dot(direction_hat, normal) * normal
+    vector = _vector3(direction, name)
+    vector_norm = float(np.linalg.norm(vector))
+    if vector_norm <= tol:
+        raise CrystallographyValueError(
+            f"{name} must be nonzero; got norm {vector_norm:.3e}."
+        )
+
+    projected = vector - np.dot(vector, normal) * normal
     projected_norm = float(np.linalg.norm(projected))
-    if projected_norm <= tol:
+    if projected_norm <= tol * vector_norm:
         raise CrystallographyValueError(
             f"{name} must not be parallel to the boundary normal."
         )
@@ -249,8 +319,8 @@ def _default_in_plane_reference(
     Selecting the least-aligned basis vector avoids an unstable projection from a seed
     that is nearly parallel to the normal.
 
-    This private helper assumes that ``normal`` has already been validated as a finite
-    unit vector with shape ``(3,)``.
+    This private helper assumes that ``normal`` is a finite unit vector with shape
+    ``(3,)`` and that ``tol`` is finite and strictly positive.
 
     :param normal: Validated unit vector with shape ``(3,)`` defining the boundary-plane
         normal.
@@ -258,88 +328,39 @@ def _default_in_plane_reference(
         normalizing the selected Cartesian seed.
     :return: A unit-length ``numpy.float64`` vector with shape ``(3,)`` lying in the
         plane perpendicular to ``normal``.
-    :raises CrystallographyValueError: If ``tol`` is invalid or if the selected
-        Cartesian seed cannot be projected to a nonzero in-plane direction within
-        ``tol``.
+    :raises CrystallographyValueError: If the selected Cartesian seed cannot be
+        projected to a nonzero in-plane direction within ``tol``.
     """
-    basis = np.eye(3, dtype=np.float64)
-    seed = basis[int(np.argmin(np.abs(basis @ normal)))]
+    seed = np.zeros(3, dtype=np.float64)
+    seed[int(np.argmin(np.abs(normal)))] = 1.0
     return _project_into_plane(seed, normal, name="in-plane reference", tol=tol)
 
 
-def _orientation_from_normal_and_in_plane(
-    boundary_normal: object,
-    in_plane_direction: object,
-    *,
-    project_in_plane: bool,
-    tol: float,
-    name: str,
+def _orientation_from_unit_vectors(
+    normal: np.ndarray,
+    in_plane: np.ndarray,
 ) -> np.ndarray:
-    """Construct a right-handed row-wise orientation matrix.
+    """Construct a row-wise orientation matrix from two trusted unit vectors.
 
-    Row 0 is the normalized boundary normal. Row 1 is derived from the supplied in-plane
-    direction. Row 2 is the normalized cross product of rows 0 and 1, completing a
-    right-handed basis.
+    The boundary normal becomes the first row and the supplied in-plane direction
+    becomes the second row. Their normalized cross product becomes the third row,
+    producing a right-handed orientation frame.
 
-    When ``project_in_plane`` is true, the component of ``in_plane_direction`` parallel
-    to the boundary normal is removed before row 1 is normalized. When it is false, the
-    supplied direction must already be perpendicular to the boundary normal within
-    ``tol``.
+    This helper performs no input validation. Callers must provide finite, unit-length
+    vectors with shape ``(3,)`` that are mutually perpendicular. Supplying zero,
+    parallel, non-unit, or malformed vectors may produce a non-orthonormal matrix or
+    non-finite values.
 
-    :param boundary_normal: Array-like three-component boundary normal used to construct
-        row 0. It need not be normalized, but it must be finite and nonzero.
-    :param in_plane_direction: Array-like three-component direction used to construct
-        row 1. It need not be normalized, but it must be finite and nonzero.
-    :param project_in_plane: Whether to project ``in_plane_direction`` into the plane
-        perpendicular to ``boundary_normal``. If false, the function instead requires
-        the two normalized directions to be perpendicular within ``tol``.
-    :param tol: Strictly positive numerical tolerance used for vector validation,
-        normalization, perpendicularity testing, cross-product degeneracy testing, and
-        final orientation-matrix validation.
-    :param name: Human-readable name assigned to the constructed orientation matrix and
-        included in final validation error messages.
-    :return: A normalized, right-handed ``numpy.float64`` orientation matrix with shape
-        ``(3, 3)`` whose rows represent the boundary normal, first in-plane direction,
-        and completing in-plane direction.
-    :raises CrystallographyValueError: If ``tol`` is invalid; if either input direction
-        is malformed, non-finite, or zero within ``tol``; if ``project_in_plane`` is
-        false and the directions are not perpendicular within ``tol``; if the directions
-        do not define a nondegenerate basis; or if the constructed matrix fails
-        orthogonality or handedness validation.
+    :param normal: Finite unit vector with shape ``(3,)`` defining the boundary normal
+        and first orientation row.
+    :param in_plane: Finite unit vector with shape ``(3,)`` perpendicular to ``normal``
+        and defining the second orientation row.
+    :return: ``numpy.float64`` matrix with shape ``(3, 3)`` whose rows are ``normal``,
+        ``in_plane``, and the normalized cross product ``normal x in_plane``.
     """
-    normal = normalize_direction(boundary_normal, "boundary normal", tol=tol)
-    if project_in_plane:
-        in_plane = _project_into_plane(
-            in_plane_direction,
-            normal,
-            name="in-plane direction",
-            tol=tol,
-        )
-    else:
-        in_plane = normalize_direction(
-            in_plane_direction,
-            "in-plane direction",
-            tol=tol,
-        )
-        dot = float(np.dot(normal, in_plane))
-        if abs(dot) > tol:
-            raise CrystallographyValueError(
-                "in-plane direction must be perpendicular to the boundary normal; "
-                f"normalized dot product is {dot:.3e}."
-            )
-
     third = np.cross(normal, in_plane)
-    third_norm = float(np.linalg.norm(third))
-    if third_norm <= tol:
-        raise CrystallographyValueError(
-            "boundary normal and in-plane direction do not define an orientation."
-        )
-
-    return validate_orientation_matrix(
-        np.vstack((normal, in_plane, third / third_norm)),
-        name,
-        tol=tol,
-    )
+    third /= np.linalg.norm(third)
+    return np.stack((normal, in_plane, third))
 
 
 def _axis_angle_rotation(
@@ -365,14 +386,21 @@ def _axis_angle_rotation(
         normalized ``numpy.float64`` rotation axis with shape ``(3,)``, ``rotation`` is
         the corresponding proper ``numpy.float64`` rotation matrix with shape ``(3,
         3)``, and ``angle`` is the validated angle as a Python ``float`` in degrees.
-    :raises CrystallographyValueError: If ``tol`` is invalid; if ``rotation_axis``
-        cannot be interpreted as a finite, nonzero three-component vector; or if
-        ``angle_deg`` is boolean, non-real, or non-finite.
+    This private helper assumes that ``tol`` is finite and strictly positive.
+
+    :raises CrystallographyValueError: If ``rotation_axis`` cannot be interpreted as a
+        finite, nonzero three-component vector, or if ``angle_deg`` is boolean,
+        non-real, or non-finite.
     """
-    axis = normalize_direction(rotation_axis, "rotation axis", tol=tol)
+    axis = _normalize_direction(rotation_axis, "rotation axis", tol=tol)
     angle = _finite_float(angle_deg, "angle_deg")
     rotation = Rotation.from_rotvec(axis * math.radians(angle)).as_matrix()
     return axis, rotation, angle
+
+
+# ---------------------------------------------------------------------------
+# Boundary orientation builders
+# ---------------------------------------------------------------------------
 
 
 def build_tilt_orientations(
@@ -400,7 +428,7 @@ def build_tilt_orientations(
     :return: ``(P, Q)`` normalized row-orientation matrices.
     """
     tol = _validated_tolerance(tol, "tol")
-    normal = normalize_direction(
+    normal = _normalize_direction(
         left_boundary_normal,
         "left boundary normal",
         tol=tol,
@@ -413,14 +441,8 @@ def build_tilt_orientations(
             f"product is {dot:.3e}."
         )
 
-    P = _orientation_from_normal_and_in_plane(
-        normal,
-        axis,
-        project_in_plane=False,
-        tol=tol,
-        name="P",
-    )
-    Q = validate_orientation_matrix(P @ rotation, "Q", tol=tol)
+    P = _orientation_from_unit_vectors(normal, axis)
+    Q = P @ rotation
     return P, Q
 
 
@@ -448,7 +470,7 @@ def build_symmetric_tilt_orientations(
     :return: ``(P, Q)`` normalized row-orientation matrices.
     """
     tol = _validated_tolerance(tol, "tol")
-    median = normalize_direction(
+    median = _normalize_direction(
         median_boundary_normal,
         "median boundary normal",
         tol=tol,
@@ -465,33 +487,18 @@ def build_symmetric_tilt_orientations(
             f"normalized dot product is {dot:.3e}."
         )
 
-    left_half_rotation = Rotation.from_rotvec(
-        axis * math.radians(-0.5 * angle)
-    ).as_matrix()
     right_half_rotation = Rotation.from_rotvec(
         axis * math.radians(0.5 * angle)
     ).as_matrix()
-    left_normal = median @ left_half_rotation
+    left_normal = median @ right_half_rotation.T
     right_normal = median @ right_half_rotation
 
-    P = _orientation_from_normal_and_in_plane(
-        left_normal,
-        axis,
-        project_in_plane=False,
-        tol=tol,
-        name="P",
-    )
-    Q = _orientation_from_normal_and_in_plane(
-        right_normal,
-        axis,
-        project_in_plane=False,
-        tol=tol,
-        name="Q",
-    )
+    P = _orientation_from_unit_vectors(left_normal, axis)
+    Q = P @ full_rotation
 
-    if not np.allclose(P @ full_rotation, Q, atol=10.0 * tol, rtol=0.0):
+    if not np.allclose(Q[0], right_normal, atol=10.0 * tol, rtol=0.0):
         raise CrystallographyValueError(
-            "symmetric-tilt construction failed its relative-rotation invariant."
+            "symmetric-tilt construction failed its right-normal invariant."
         )
 
     left_deviation = P[0] - np.dot(P[0], median) * median
@@ -530,7 +537,7 @@ def build_twist_orientations(
     :return: ``(P, Q)`` normalized row-orientation matrices.
     """
     tol = _validated_tolerance(tol, "tol")
-    normal = normalize_direction(boundary_normal, "boundary normal", tol=tol)
+    normal = _normalize_direction(boundary_normal, "boundary normal", tol=tol)
     _, rotation, _ = _axis_angle_rotation(normal, angle_deg, tol=tol)
 
     if in_plane_reference is None:
@@ -543,14 +550,8 @@ def build_twist_orientations(
             tol=tol,
         )
 
-    P = _orientation_from_normal_and_in_plane(
-        normal,
-        in_plane,
-        project_in_plane=False,
-        tol=tol,
-        name="P",
-    )
-    Q = validate_orientation_matrix(P @ rotation, "Q", tol=tol)
+    P = _orientation_from_unit_vectors(normal, in_plane)
+    Q = P @ rotation
 
     if not np.allclose(P[0], Q[0], atol=10.0 * tol, rtol=0.0):
         raise CrystallographyValueError(
@@ -582,7 +583,7 @@ def build_mixed_orientations(
     :return: ``(P, Q)`` normalized row-orientation matrices.
     """
     tol = _validated_tolerance(tol, "tol")
-    normal = normalize_direction(
+    normal = _normalize_direction(
         left_boundary_normal,
         "left boundary normal",
         tol=tol,
@@ -607,15 +608,14 @@ def build_mixed_orientations(
         name="in-plane reference",
         tol=tol,
     )
-    P = _orientation_from_normal_and_in_plane(
-        normal,
-        in_plane,
-        project_in_plane=False,
-        tol=tol,
-        name="P",
-    )
-    Q = validate_orientation_matrix(P @ rotation, "Q", tol=tol)
+    P = _orientation_from_unit_vectors(normal, in_plane)
+    Q = P @ rotation
     return P, Q
+
+
+# ---------------------------------------------------------------------------
+# Five-degree-of-freedom conversions
+# ---------------------------------------------------------------------------
 
 
 def inclination_from_normal(
@@ -632,10 +632,20 @@ def inclination_from_normal(
     :param tol: Numerical tolerance. Keyword parameter, optional.
     :return: ``(theta, phi)`` in radians.
     """
-    normal = normalize_direction(boundary_normal, "boundary normal", tol=tol)
+    tol = _validated_tolerance(tol, "tol")
+    normal = _normalize_direction(boundary_normal, "boundary normal", tol=tol)
+    return _inclination_from_unit_normal(normal, tol=tol)
+
+
+def _inclination_from_unit_normal(
+    normal: np.ndarray,
+    *,
+    tol: float,
+) -> tuple[float, float]:
+    """Return inclination angles for an already normalized boundary normal."""
     nx, ny, nz = normal
-    phi = float(math.asin(float(np.clip(-ny, -1.0, 1.0))))
-    theta = 0.0 if abs(abs(ny) - 1.0) <= tol else float(math.atan2(nz, nx))
+    phi = math.asin(np.clip(-ny, -1.0, 1.0))
+    theta = 0.0 if abs(abs(ny) - 1.0) <= tol else math.atan2(nz, nx)
     return theta, phi
 
 
@@ -704,7 +714,8 @@ def five_dof_from_axis_angle(
     tol = _validated_tolerance(tol, "tol")
     _, rotation, _ = _axis_angle_rotation(rotation_axis, angle_deg, tol=tol)
     alpha, beta, gamma = _zxz_euler_angles(rotation)
-    theta, phi = inclination_from_normal(boundary_normal, tol=tol)
+    normal = _normalize_direction(boundary_normal, "boundary normal", tol=tol)
+    theta, phi = _inclination_from_unit_normal(normal, tol=tol)
     return np.array([alpha, beta, gamma, theta, phi], dtype=np.float64)
 
 
@@ -738,21 +749,24 @@ def five_dof_from_orientation_matrices(
             "normal_warning_deg must be non-negative."
         )
 
-    P_norm = validate_orientation_matrix(P, "P", tol=tol)
-    Q_norm = validate_orientation_matrix(Q, "Q", tol=tol)
+    P_norm = _validate_orientation_matrix(P, "P", tol=tol)
+    Q_norm = _validate_orientation_matrix(Q, "Q", tol=tol)
     rotation = P_norm.T @ Q_norm
     alpha, beta, gamma = _zxz_euler_angles(rotation)
 
     normal_from_P = P_norm[0]
     if boundary_normal is not None:
-        supplied = normalize_direction(
+        supplied = _normalize_direction(
             boundary_normal,
             "boundary normal",
             tol=tol,
         )
         cosine = float(np.clip(np.dot(normal_from_P, supplied), -1.0, 1.0))
-        discrepancy_deg = math.degrees(math.acos(cosine))
-        if discrepancy_deg > warning_deg:
+        warning_cosine = (
+            math.cos(math.radians(warning_deg)) if warning_deg < 180.0 else -1.0
+        )
+        if cosine < warning_cosine:
+            discrepancy_deg = math.degrees(math.acos(cosine))
             warnings.warn(
                 "Supplied boundary normal differs from P[0] by "
                 f"{discrepancy_deg:.2f} degrees; using P[0] for inclination.",
@@ -760,7 +774,7 @@ def five_dof_from_orientation_matrices(
                 stacklevel=2,
             )
 
-    theta, phi = inclination_from_normal(normal_from_P, tol=tol)
+    theta, phi = _inclination_from_unit_normal(normal_from_P, tol=tol)
     return np.array([alpha, beta, gamma, theta, phi], dtype=np.float64)
 
 
@@ -815,15 +829,12 @@ def orientation_matrices_from_five_dof(
         "ZXZ",
         [alpha, beta, gamma],
     ).as_matrix()
-    left = (
-        Rotation.from_euler("z", phi)
-        * Rotation.from_euler("y", theta)
-    ).as_matrix()
+    left = Rotation.from_euler("ZY", [phi, theta]).as_matrix()
     right = left @ misorientation
 
     return (
-        validate_orientation_matrix(left, "R_left", tol=tol),
-        validate_orientation_matrix(right, "R_right", tol=tol),
+        _validate_orientation_matrix(left, "R_left", tol=tol),
+        _validate_orientation_matrix(right, "R_right", tol=tol),
     )
 
 
@@ -836,5 +847,6 @@ __all__ = [
     "five_dof_from_orientation_matrices",
     "inclination_from_normal",
     "normalize_direction",
+    "orientation_matrices_from_five_dof",
     "validate_orientation_matrix",
 ]

--- a/GBOpt/crystallography/orientation.py
+++ b/GBOpt/crystallography/orientation.py
@@ -1,0 +1,840 @@
+# Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
+
+"""Floating-point crystallographic orientation-frame construction and conversion.
+
+Provides validation and construction of row-wise grain orientation matrices, geometric
+tilt, twist, and mixed-boundary frame builders, and conversion of axis-angle or paired
+orientation descriptions to GBMaker's five-DOF representation.
+
+The matrices handled here are floating-point orientation frames. They are not exact
+integer P/Q matrices and are not suitable as exact ``PQSpec`` input without a separate
+exactification step.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from numbers import Real
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from .types import CrystallographyValueError
+
+_DEFAULT_VECTOR_TOL = 1.0e-12
+_DEFAULT_ORIENTATION_TOL = 1.0e-10
+_DEFAULT_NORMAL_WARNING_DEG = 1.0
+
+# ---------------------------------------------------------------------------
+# Floating-point row-orientation construction and conversion
+# ---------------------------------------------------------------------------
+
+
+def _finite_float(value: object, name: str) -> float:
+    """Return *value* as a finite float.
+
+    :param value: Candidate scalar value.
+    :param name: Parameter name used in the error message.
+    :return: Finite floating-point value.
+    :raises CrystallographyValueError: If the value is boolean, non-numeric, or
+        non-finite.
+    """
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise CrystallographyValueError(
+            f"{name} must be a finite real number; got {value!r}."
+        )
+
+    result = float(value)
+    if not math.isfinite(result):
+        raise CrystallographyValueError(
+            f"{name} must be a finite real number; got {value!r}."
+        )
+    return result
+
+
+def _validated_tolerance(value: object, name: str) -> float:
+    """Validate and return a strictly positive numerical tolerance.
+
+    Boolean values are rejected even though ``bool`` is a subclass of ``int``. All other
+    real scalar values are converted to a Python ``float`` and must be finite and
+    greater than zero.
+
+    :param value: Candidate tolerance value. It must be a finite, non-boolean real
+        scalar greater than zero.
+    :param name: Human-readable name for the tolerance. This value is included in
+        validation error messages to identify the invalid argument.
+    :return: The validated tolerance as a finite, strictly positive Python ``float``.
+    :raises CrystallographyValueError: If ``value`` is boolean, is not a real scalar,
+        cannot be represented as a finite ``float``, or is less than or equal to zero.
+    """
+    result = _finite_float(value, name)
+    if result <= 0.0:
+        raise CrystallographyValueError(
+            f"{name} must be strictly positive; got {value!r}."
+        )
+    return result
+
+
+def _vector3(value: object, name: str) -> np.ndarray:
+    """Convert a value to a finite three-component floating-point vector.
+
+    The input is converted to a NumPy array with ``numpy.float64`` dtype. This function
+    validates only the vector's shape and finiteness; it does not normalize the vector
+    or require it to be nonzero.
+
+    :param value: Array-like value expected to contain exactly three numeric components.
+    :param name: Human-readable name for the vector. This value is included in
+        validation error messages to identify the invalid argument.
+    :return: A one-dimensional ``numpy.float64`` array with shape ``(3,)``. The returned
+        vector retains the input magnitude and is not normalized.
+    :raises CrystallographyValueError: If ``value`` cannot be converted to a
+        floating-point NumPy array, does not have shape ``(3,)``, or contains one or
+        more NaN or infinite components.
+    """
+    try:
+        vector = np.asarray(value, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise CrystallographyValueError(
+            f"{name} must be a finite three-component vector."
+        ) from exc
+
+    if vector.shape != (3,):
+        raise CrystallographyValueError(
+            f"{name} must have shape (3,); got {vector.shape}."
+        )
+    if not np.all(np.isfinite(vector)):
+        raise CrystallographyValueError(f"{name} must contain only finite values.")
+    return vector
+
+
+def normalize_direction(
+    direction: object,
+    name: str = "direction",
+    *,
+    tol: float = _DEFAULT_VECTOR_TOL,
+) -> np.ndarray:
+    """Return a normalized copy of a nonzero three-component direction.
+
+    :param direction: Candidate three-component direction.
+    :param name: Parameter name used in error messages. Optional, defaults to
+        ``"direction"``.
+    :param tol: Minimum accepted vector norm. Keyword parameter, optional, defaults to
+        ``1e-12``.
+    :return: Unit-length ``float64`` direction.
+    :raises CrystallographyValueError: If the direction has the wrong shape, contains
+        non-finite values, or has norm no greater than ``tol``.
+    """
+    tol = _validated_tolerance(tol, "tol")
+    vector = _vector3(direction, name)
+    norm = float(np.linalg.norm(vector))
+    if norm <= tol:
+        raise CrystallographyValueError(
+            f"{name} must be nonzero; got norm {norm:.3e}."
+        )
+    return vector / norm
+
+
+def validate_orientation_matrix(
+    matrix: object,
+    name: str = "orientation matrix",
+    *,
+    tol: float = _DEFAULT_ORIENTATION_TOL,
+) -> np.ndarray:
+    """Return a normalized, validated row-wise orientation matrix.
+
+    Rows identify the crystal directions aligned with the lab-frame x, y, and z axes.
+    The rows must be finite, nonzero, mutually orthogonal, and right-handed. Row lengths
+    need not be one on input; the returned matrix is row-normalized.
+
+    :param matrix: Candidate row-wise orientation matrix.
+    :param name: Matrix name used in error messages. Optional.
+    :param tol: Absolute orthogonality and determinant tolerance. Keyword parameter,
+        optional, defaults to ``1e-10``.
+    :return: Normalized ``float64`` matrix with shape ``(3, 3)``.
+    :raises CrystallographyValueError: If the matrix is malformed or is not a proper
+        row-wise orientation matrix.
+    """
+    tol = _validated_tolerance(tol, "tol")
+    try:
+        candidate = np.asarray(matrix, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise CrystallographyValueError(
+            f"{name} must be a finite 3 by 3 matrix."
+        ) from exc
+
+    if candidate.shape != (3, 3):
+        raise CrystallographyValueError(
+            f"{name} must have shape (3, 3); got {candidate.shape}."
+        )
+    if not np.all(np.isfinite(candidate)):
+        raise CrystallographyValueError(f"{name} must contain only finite values.")
+
+    norms = np.linalg.norm(candidate, axis=1)
+    if np.any(norms <= tol):
+        row = int(np.flatnonzero(norms <= tol)[0])
+        raise CrystallographyValueError(
+            f"{name} row {row} must be nonzero; got norm {norms[row]:.3e}."
+        )
+
+    normalized = candidate / norms[:, np.newaxis]
+    gram_error = float(
+        np.max(np.abs(normalized @ normalized.T - np.eye(3, dtype=np.float64)))
+    )
+    if gram_error > tol:
+        raise CrystallographyValueError(
+            f"{name} rows must be mutually orthogonal after normalization; "
+            f"maximum Gram-matrix error is {gram_error:.3e}."
+        )
+
+    determinant = float(np.linalg.det(normalized))
+    if abs(determinant - 1.0) > tol:
+        raise CrystallographyValueError(
+            f"{name} must be right-handed after normalization; "
+            f"determinant is {determinant:.12g}."
+        )
+
+    return normalized
+
+
+def _project_into_plane(
+    direction: object,
+    normal: np.ndarray,
+    *,
+    name: str,
+    tol: float,
+) -> np.ndarray:
+    """Project a direction into the plane perpendicular to a unit normal.
+
+    The supplied direction is first validated and normalized. Its component parallel to
+    ``normal`` is then removed, and the remaining in-plane component is normalized.
+
+    This private helper assumes that ``normal`` has already been validated as a finite
+    unit vector with shape ``(3,)``.
+
+    :param direction: Array-like three-component direction to project. It need not be
+        normalized, but it must be finite and nonzero.
+    :param normal: Validated unit vector with shape ``(3,)`` defining the normal of the
+        target plane.
+    :param name: Human-readable name for ``direction``. This value is included in
+        validation error messages to identify the invalid argument.
+    :param tol: Strictly positive numerical tolerance used when validating the direction
+        magnitude and determining whether the projected component is effectively zero.
+    :return: A unit-length ``numpy.float64`` vector with shape ``(3,)`` that lies in the
+        plane perpendicular to ``normal``.
+    :raises CrystallographyValueError: If ``tol`` is invalid; if ``direction`` cannot be
+        interpreted as a finite, nonzero three-component vector; or if ``direction`` is
+        parallel to ``normal`` within ``tol`` and therefore has no nonzero in-plane
+        projection.
+    """
+    direction_hat = normalize_direction(direction, name, tol=tol)
+    projected = direction_hat - np.dot(direction_hat, normal) * normal
+    projected_norm = float(np.linalg.norm(projected))
+    if projected_norm <= tol:
+        raise CrystallographyValueError(
+            f"{name} must not be parallel to the boundary normal."
+        )
+    return projected / projected_norm
+
+
+def _default_in_plane_reference(
+    normal: np.ndarray,
+    *,
+    tol: float,
+) -> np.ndarray:
+    """Choose a stable default direction in the plane perpendicular to a normal.
+
+    The Cartesian basis vector least aligned with ``normal`` is selected as a seed. That
+    seed is projected into the plane perpendicular to ``normal`` and normalized.
+    Selecting the least-aligned basis vector avoids an unstable projection from a seed
+    that is nearly parallel to the normal.
+
+    This private helper assumes that ``normal`` has already been validated as a finite
+    unit vector with shape ``(3,)``.
+
+    :param normal: Validated unit vector with shape ``(3,)`` defining the boundary-plane
+        normal.
+    :param tol: Strictly positive numerical tolerance used when projecting and
+        normalizing the selected Cartesian seed.
+    :return: A unit-length ``numpy.float64`` vector with shape ``(3,)`` lying in the
+        plane perpendicular to ``normal``.
+    :raises CrystallographyValueError: If ``tol`` is invalid or if the selected
+        Cartesian seed cannot be projected to a nonzero in-plane direction within
+        ``tol``.
+    """
+    basis = np.eye(3, dtype=np.float64)
+    seed = basis[int(np.argmin(np.abs(basis @ normal)))]
+    return _project_into_plane(seed, normal, name="in-plane reference", tol=tol)
+
+
+def _orientation_from_normal_and_in_plane(
+    boundary_normal: object,
+    in_plane_direction: object,
+    *,
+    project_in_plane: bool,
+    tol: float,
+    name: str,
+) -> np.ndarray:
+    """Construct a right-handed row-wise orientation matrix.
+
+    Row 0 is the normalized boundary normal. Row 1 is derived from the supplied in-plane
+    direction. Row 2 is the normalized cross product of rows 0 and 1, completing a
+    right-handed basis.
+
+    When ``project_in_plane`` is true, the component of ``in_plane_direction`` parallel
+    to the boundary normal is removed before row 1 is normalized. When it is false, the
+    supplied direction must already be perpendicular to the boundary normal within
+    ``tol``.
+
+    :param boundary_normal: Array-like three-component boundary normal used to construct
+        row 0. It need not be normalized, but it must be finite and nonzero.
+    :param in_plane_direction: Array-like three-component direction used to construct
+        row 1. It need not be normalized, but it must be finite and nonzero.
+    :param project_in_plane: Whether to project ``in_plane_direction`` into the plane
+        perpendicular to ``boundary_normal``. If false, the function instead requires
+        the two normalized directions to be perpendicular within ``tol``.
+    :param tol: Strictly positive numerical tolerance used for vector validation,
+        normalization, perpendicularity testing, cross-product degeneracy testing, and
+        final orientation-matrix validation.
+    :param name: Human-readable name assigned to the constructed orientation matrix and
+        included in final validation error messages.
+    :return: A normalized, right-handed ``numpy.float64`` orientation matrix with shape
+        ``(3, 3)`` whose rows represent the boundary normal, first in-plane direction,
+        and completing in-plane direction.
+    :raises CrystallographyValueError: If ``tol`` is invalid; if either input direction
+        is malformed, non-finite, or zero within ``tol``; if ``project_in_plane`` is
+        false and the directions are not perpendicular within ``tol``; if the directions
+        do not define a nondegenerate basis; or if the constructed matrix fails
+        orthogonality or handedness validation.
+    """
+    normal = normalize_direction(boundary_normal, "boundary normal", tol=tol)
+    if project_in_plane:
+        in_plane = _project_into_plane(
+            in_plane_direction,
+            normal,
+            name="in-plane direction",
+            tol=tol,
+        )
+    else:
+        in_plane = normalize_direction(
+            in_plane_direction,
+            "in-plane direction",
+            tol=tol,
+        )
+        dot = float(np.dot(normal, in_plane))
+        if abs(dot) > tol:
+            raise CrystallographyValueError(
+                "in-plane direction must be perpendicular to the boundary normal; "
+                f"normalized dot product is {dot:.3e}."
+            )
+
+    third = np.cross(normal, in_plane)
+    third_norm = float(np.linalg.norm(third))
+    if third_norm <= tol:
+        raise CrystallographyValueError(
+            "boundary normal and in-plane direction do not define an orientation."
+        )
+
+    return validate_orientation_matrix(
+        np.vstack((normal, in_plane, third / third_norm)),
+        name,
+        tol=tol,
+    )
+
+
+def _axis_angle_rotation(
+    rotation_axis: object,
+    angle_deg: object,
+    *,
+    tol: float,
+) -> tuple[np.ndarray, np.ndarray, float]:
+    """Validate an axis-angle description and construct its rotation matrix.
+
+    The rotation axis is converted to a finite three-component vector and normalized.
+    The angle is validated as a finite, non-boolean real scalar in degrees. SciPy's
+    rotation-vector convention is then used to construct the corresponding proper
+    rotation matrix.
+
+    :param rotation_axis: Array-like three-component rotation axis in crystal
+        coordinates. It need not be normalized, but it must be finite and nonzero.
+    :param angle_deg: Rotation angle in degrees. It must be a finite, non-boolean real
+        scalar.
+    :param tol: Strictly positive numerical tolerance used when validating and
+        normalizing ``rotation_axis``.
+    :return: A tuple ``(axis_hat, rotation, angle)`` where ``axis_hat`` is the
+        normalized ``numpy.float64`` rotation axis with shape ``(3,)``, ``rotation`` is
+        the corresponding proper ``numpy.float64`` rotation matrix with shape ``(3,
+        3)``, and ``angle`` is the validated angle as a Python ``float`` in degrees.
+    :raises CrystallographyValueError: If ``tol`` is invalid; if ``rotation_axis``
+        cannot be interpreted as a finite, nonzero three-component vector; or if
+        ``angle_deg`` is boolean, non-real, or non-finite.
+    """
+    axis = normalize_direction(rotation_axis, "rotation axis", tol=tol)
+    angle = _finite_float(angle_deg, "angle_deg")
+    rotation = Rotation.from_rotvec(axis * math.radians(angle)).as_matrix()
+    return axis, rotation, angle
+
+
+def build_tilt_orientations(
+    left_boundary_normal: object,
+    tilt_axis: object,
+    angle_deg: object,
+    *,
+    tol: float = _DEFAULT_ORIENTATION_TOL,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build row-orientation matrices for a general pure-tilt boundary.
+
+    ``left_boundary_normal`` is the boundary normal expressed in the left crystal. The
+    tilt axis must lie in the boundary plane. The right orientation is generated by the
+    requested relative rotation. This constructor does not label the result symmetric;
+    symmetry requires an independently specified median plane and is handled by
+    :func:`build_symmetric_tilt_orientations`.
+
+    The returned floating-point matrices are suitable for five-DOF conversion. They are
+    not guaranteed to be exact integer ``PQSpec`` input.
+
+    :param left_boundary_normal: Boundary normal in left-grain crystal coordinates.
+    :param tilt_axis: Common tilt axis in crystal coordinates.
+    :param angle_deg: Relative misorientation angle in degrees.
+    :param tol: Numerical tolerance. Keyword parameter, optional.
+    :return: ``(P, Q)`` normalized row-orientation matrices.
+    """
+    tol = _validated_tolerance(tol, "tol")
+    normal = normalize_direction(
+        left_boundary_normal,
+        "left boundary normal",
+        tol=tol,
+    )
+    axis, rotation, _ = _axis_angle_rotation(tilt_axis, angle_deg, tol=tol)
+    dot = float(np.dot(normal, axis))
+    if abs(dot) > tol:
+        raise CrystallographyValueError(
+            "tilt axis must lie in the boundary plane; normalized normal-axis dot "
+            f"product is {dot:.3e}."
+        )
+
+    P = _orientation_from_normal_and_in_plane(
+        normal,
+        axis,
+        project_in_plane=False,
+        tol=tol,
+        name="P",
+    )
+    Q = validate_orientation_matrix(P @ rotation, "Q", tol=tol)
+    return P, Q
+
+
+def build_symmetric_tilt_orientations(
+    median_boundary_normal: object,
+    tilt_axis: object,
+    angle_deg: object,
+    *,
+    tol: float = _DEFAULT_ORIENTATION_TOL,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build a geometrically symmetric pure-tilt orientation pair.
+
+    ``median_boundary_normal`` is the bisector normal about which the left and right
+    crystal boundary normals are placed at equal and opposite half angles. For example,
+    a median normal ``[1, 0, 0]``, tilt axis ``[0, 0, 1]``, and angle ``2*atan(1/5)``
+    produce normals parallel to ``[5, 1, 0]`` and ``[5, -1, 0]``.
+
+    The returned floating-point matrices are not exact integer ``PQSpec`` input unless a
+    separate exactification step succeeds.
+
+    :param median_boundary_normal: Symmetry-bisector boundary normal.
+    :param tilt_axis: Common tilt axis, perpendicular to the median normal.
+    :param angle_deg: Total left-to-right misorientation angle in degrees.
+    :param tol: Numerical tolerance. Keyword parameter, optional.
+    :return: ``(P, Q)`` normalized row-orientation matrices.
+    """
+    tol = _validated_tolerance(tol, "tol")
+    median = normalize_direction(
+        median_boundary_normal,
+        "median boundary normal",
+        tol=tol,
+    )
+    axis, full_rotation, angle = _axis_angle_rotation(
+        tilt_axis,
+        angle_deg,
+        tol=tol,
+    )
+    dot = float(np.dot(median, axis))
+    if abs(dot) > tol:
+        raise CrystallographyValueError(
+            "tilt axis must be perpendicular to the median boundary normal; "
+            f"normalized dot product is {dot:.3e}."
+        )
+
+    left_half_rotation = Rotation.from_rotvec(
+        axis * math.radians(-0.5 * angle)
+    ).as_matrix()
+    right_half_rotation = Rotation.from_rotvec(
+        axis * math.radians(0.5 * angle)
+    ).as_matrix()
+    left_normal = median @ left_half_rotation
+    right_normal = median @ right_half_rotation
+
+    P = _orientation_from_normal_and_in_plane(
+        left_normal,
+        axis,
+        project_in_plane=False,
+        tol=tol,
+        name="P",
+    )
+    Q = _orientation_from_normal_and_in_plane(
+        right_normal,
+        axis,
+        project_in_plane=False,
+        tol=tol,
+        name="Q",
+    )
+
+    if not np.allclose(P @ full_rotation, Q, atol=10.0 * tol, rtol=0.0):
+        raise CrystallographyValueError(
+            "symmetric-tilt construction failed its relative-rotation invariant."
+        )
+
+    left_deviation = P[0] - np.dot(P[0], median) * median
+    right_deviation = Q[0] - np.dot(Q[0], median) * median
+    if not np.allclose(
+        left_deviation,
+        -right_deviation,
+        atol=10.0 * tol,
+        rtol=0.0,
+    ):
+        raise CrystallographyValueError(
+            "symmetric-tilt construction failed its mirror-normal invariant."
+        )
+
+    return P, Q
+
+
+def build_twist_orientations(
+    boundary_normal: object,
+    angle_deg: object,
+    *,
+    in_plane_reference: object | None = None,
+    tol: float = _DEFAULT_ORIENTATION_TOL,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build row-orientation matrices for a pure-twist boundary.
+
+    The rotation axis is the boundary normal. ``in_plane_reference`` controls the
+    otherwise arbitrary lab-y direction of the left grain. When omitted, a stable
+    Cartesian seed is selected automatically.
+
+    :param boundary_normal: Common boundary normal and twist axis.
+    :param angle_deg: Relative twist angle in degrees.
+    :param in_plane_reference: Optional direction used to define the left in-plane
+        basis. It is projected into the boundary plane.
+    :param tol: Numerical tolerance. Keyword parameter, optional.
+    :return: ``(P, Q)`` normalized row-orientation matrices.
+    """
+    tol = _validated_tolerance(tol, "tol")
+    normal = normalize_direction(boundary_normal, "boundary normal", tol=tol)
+    _, rotation, _ = _axis_angle_rotation(normal, angle_deg, tol=tol)
+
+    if in_plane_reference is None:
+        in_plane = _default_in_plane_reference(normal, tol=tol)
+    else:
+        in_plane = _project_into_plane(
+            in_plane_reference,
+            normal,
+            name="in-plane reference",
+            tol=tol,
+        )
+
+    P = _orientation_from_normal_and_in_plane(
+        normal,
+        in_plane,
+        project_in_plane=False,
+        tol=tol,
+        name="P",
+    )
+    Q = validate_orientation_matrix(P @ rotation, "Q", tol=tol)
+
+    if not np.allclose(P[0], Q[0], atol=10.0 * tol, rtol=0.0):
+        raise CrystallographyValueError(
+            "twist construction failed to preserve the boundary normal."
+        )
+    return P, Q
+
+
+def build_mixed_orientations(
+    left_boundary_normal: object,
+    rotation_axis: object,
+    angle_deg: object,
+    *,
+    in_plane_reference: object | None = None,
+    tol: float = _DEFAULT_ORIENTATION_TOL,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build row-orientation matrices for a mixed tilt/twist boundary.
+
+    A mixed boundary requires the rotation axis to have both a component normal to the
+    boundary and a component in its plane. By default, the in-plane projection of the
+    rotation axis defines the left lab-y direction. A different in-plane reference may
+    be supplied explicitly.
+
+    :param left_boundary_normal: Boundary normal in left-grain crystal coordinates.
+    :param rotation_axis: Mixed-character misorientation axis.
+    :param angle_deg: Relative misorientation angle in degrees.
+    :param in_plane_reference: Optional left-grain in-plane basis seed.
+    :param tol: Numerical tolerance. Keyword parameter, optional.
+    :return: ``(P, Q)`` normalized row-orientation matrices.
+    """
+    tol = _validated_tolerance(tol, "tol")
+    normal = normalize_direction(
+        left_boundary_normal,
+        "left boundary normal",
+        tol=tol,
+    )
+    axis, rotation, _ = _axis_angle_rotation(rotation_axis, angle_deg, tol=tol)
+    normal_component = abs(float(np.dot(normal, axis)))
+    if normal_component <= tol:
+        raise CrystallographyValueError(
+            "mixed boundary requires a nonzero twist component; the rotation axis "
+            "lies in the boundary plane."
+        )
+    if 1.0 - normal_component <= tol:
+        raise CrystallographyValueError(
+            "mixed boundary requires a nonzero tilt component; the rotation axis is "
+            "parallel to the boundary normal."
+        )
+
+    reference = axis if in_plane_reference is None else in_plane_reference
+    in_plane = _project_into_plane(
+        reference,
+        normal,
+        name="in-plane reference",
+        tol=tol,
+    )
+    P = _orientation_from_normal_and_in_plane(
+        normal,
+        in_plane,
+        project_in_plane=False,
+        tol=tol,
+        name="P",
+    )
+    Q = validate_orientation_matrix(P @ rotation, "Q", tol=tol)
+    return P, Q
+
+
+def inclination_from_normal(
+    boundary_normal: object,
+    *,
+    tol: float = _DEFAULT_VECTOR_TOL,
+) -> tuple[float, float]:
+    """Return GBMaker inclination angles ``(theta, phi)`` for a boundary normal.
+
+    GBMaker uses ``Rincl = Rz(phi) @ Ry(theta)`` and row-vector coordinates. Under that
+    convention the first row of ``Rincl`` is the crystal direction aligned with lab x.
+
+    :param boundary_normal: Boundary normal in crystal coordinates.
+    :param tol: Numerical tolerance. Keyword parameter, optional.
+    :return: ``(theta, phi)`` in radians.
+    """
+    normal = normalize_direction(boundary_normal, "boundary normal", tol=tol)
+    nx, ny, nz = normal
+    phi = float(math.asin(float(np.clip(-ny, -1.0, 1.0))))
+    theta = 0.0 if abs(abs(ny) - 1.0) <= tol else float(math.atan2(nz, nx))
+    return theta, phi
+
+
+def _zxz_euler_angles(rotation: np.ndarray) -> np.ndarray:
+    """Extract intrinsic ZXZ Euler angles from a proper rotation matrix.
+
+    SciPy emits a gimbal-lock warning when the middle ZXZ angle is singular. In that
+    case, SciPy still returns a valid canonical Euler-angle representative, so this
+    helper suppresses only that warning and returns the resulting angles unchanged.
+
+    This private helper expects ``rotation`` to have already been constructed or
+    validated as a finite proper rotation matrix.
+
+    :param rotation: Finite proper rotation matrix with shape ``(3, 3)`` to convert
+        using SciPy's intrinsic ``ZXZ`` Euler convention.
+    :return: A ``numpy.ndarray`` with shape ``(3,)`` containing ``[alpha, beta, gamma]``
+        in radians. At a gimbal-lock singularity, the returned values are SciPy's
+        canonical representative and are not a unique Euler decomposition.
+    :raises ValueError: If ``rotation`` does not have an acceptable matrix shape or
+        cannot be interpreted by SciPy as a valid rotation.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Gimbal lock detected.*",
+            category=UserWarning,
+        )
+        return Rotation.from_matrix(rotation).as_euler("ZXZ")
+
+
+def five_dof_from_axis_angle(
+    rotation_axis: object,
+    angle_deg: object,
+    boundary_normal: object,
+    *,
+    tol: float = _DEFAULT_ORIENTATION_TOL,
+) -> np.ndarray:
+    """Convert an axis-angle boundary description to five-DOF parameters.
+
+    The axis-angle pair defines the crystal-frame misorientation. Its proper rotation
+    matrix is decomposed using the intrinsic ZXZ Euler convention to obtain ``alpha``,
+    ``beta``, and ``gamma``. The left-grain boundary normal independently determines the
+    GBMaker inclination angles ``theta`` and ``phi``.
+
+    The returned array therefore has the form ``[alpha, beta, gamma, theta, phi]``, with
+    all angles expressed in radians.
+
+    :param rotation_axis: Array-like three-component misorientation axis in crystal
+        coordinates. It need not be normalized, but it must be finite and nonzero.
+    :param angle_deg: Misorientation angle in degrees. It must be a finite, non-boolean
+        real scalar.
+    :param boundary_normal: Array-like three-component left-grain boundary normal in
+        crystal coordinates. It need not be normalized, but it must be finite and
+        nonzero.
+    :param tol: Strictly positive numerical tolerance used when validating and
+        normalizing the rotation axis and boundary normal. Keyword-only; defaults to
+        ``_DEFAULT_ORIENTATION_TOL``.
+    :return: A one-dimensional ``numpy.float64`` array with shape ``(5,)`` containing
+        ``[alpha, beta, gamma, theta, phi]`` in radians.
+    :raises CrystallographyValueError: If ``tol`` is invalid; if ``rotation_axis`` or
+        ``boundary_normal`` cannot be interpreted as a finite, nonzero three-component
+        vector; or if ``angle_deg`` is boolean, non-real, or non-finite.
+    :raises ValueError: If SciPy cannot convert the constructed rotation matrix to an
+        intrinsic ZXZ Euler-angle representation.
+    """
+    tol = _validated_tolerance(tol, "tol")
+    _, rotation, _ = _axis_angle_rotation(rotation_axis, angle_deg, tol=tol)
+    alpha, beta, gamma = _zxz_euler_angles(rotation)
+    theta, phi = inclination_from_normal(boundary_normal, tol=tol)
+    return np.array([alpha, beta, gamma, theta, phi], dtype=np.float64)
+
+
+def five_dof_from_orientation_matrices(
+    P: object,
+    Q: object,
+    boundary_normal: object | None = None,
+    *,
+    tol: float = _DEFAULT_ORIENTATION_TOL,
+    normal_warning_deg: float = _DEFAULT_NORMAL_WARNING_DEG,
+) -> np.ndarray:
+    """Convert row-wise orientation matrices to GBMaker five-DOF parameters.
+
+    ``P`` and ``Q`` may contain scaled crystallographic directions; each row is
+    normalized during validation. ``boundary_normal`` is an optional consistency check
+    only. The inclination is always derived from normalized ``P[0]``.
+
+    :param P: Left-grain row-wise orientation matrix.
+    :param Q: Right-grain row-wise orientation matrix.
+    :param boundary_normal: Optional independently supplied boundary normal.
+    :param tol: Numerical tolerance. Keyword parameter, optional.
+    :param normal_warning_deg: Angular discrepancy above which a ``UserWarning`` is
+        emitted for ``boundary_normal``. Keyword parameter, optional, defaults to one
+        degree.
+    :return: Five angles ``[alpha, beta, gamma, theta, phi]`` in radians.
+    """
+    tol = _validated_tolerance(tol, "tol")
+    warning_deg = _finite_float(normal_warning_deg, "normal_warning_deg")
+    if warning_deg < 0.0:
+        raise CrystallographyValueError(
+            "normal_warning_deg must be non-negative."
+        )
+
+    P_norm = validate_orientation_matrix(P, "P", tol=tol)
+    Q_norm = validate_orientation_matrix(Q, "Q", tol=tol)
+    rotation = P_norm.T @ Q_norm
+    alpha, beta, gamma = _zxz_euler_angles(rotation)
+
+    normal_from_P = P_norm[0]
+    if boundary_normal is not None:
+        supplied = normalize_direction(
+            boundary_normal,
+            "boundary normal",
+            tol=tol,
+        )
+        cosine = float(np.clip(np.dot(normal_from_P, supplied), -1.0, 1.0))
+        discrepancy_deg = math.degrees(math.acos(cosine))
+        if discrepancy_deg > warning_deg:
+            warnings.warn(
+                "Supplied boundary normal differs from P[0] by "
+                f"{discrepancy_deg:.2f} degrees; using P[0] for inclination.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    theta, phi = inclination_from_normal(normal_from_P, tol=tol)
+    return np.array([alpha, beta, gamma, theta, phi], dtype=np.float64)
+
+
+def orientation_matrices_from_five_dof(
+    params: object,
+    *,
+    tol: float = _DEFAULT_ORIENTATION_TOL,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Convert GBMaker five-DOF parameters to row-orientation matrices.
+
+    The five parameters use GBMaker's legacy convention
+    ``[alpha, beta, gamma, theta, phi]``. The first three values define the
+    crystal-frame misorientation using intrinsic ZXZ Euler angles. The final two
+    values define the left-grain inclination matrix as
+    ``Rz(phi) @ Ry(theta)``.
+
+    The right-grain orientation is constructed as
+    ``R_right = R_left @ R_misorientation``.
+
+    :param params: Array-like sequence containing
+        ``[alpha, beta, gamma, theta, phi]`` in radians.
+    :param tol: Strictly positive numerical tolerance used when validating the
+        resulting row-orientation matrices. Keyword-only, optional, defaults to
+        ``_DEFAULT_ORIENTATION_TOL``.
+    :return: A tuple ``(R_left, R_right)`` containing normalized, proper,
+        row-wise orientation matrices with shape ``(3, 3)``.
+    :raises CrystallographyValueError: If ``params`` cannot be converted to a
+        finite floating-point sequence of length five, if ``tol`` is invalid,
+        or if either resulting matrix fails row-orientation validation.
+    """
+    tol = _validated_tolerance(tol, "tol")
+
+    try:
+        values = np.asarray(params, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise CrystallographyValueError(
+            "params must be a finite five-element sequence."
+        ) from exc
+
+    if values.shape != (5,):
+        raise CrystallographyValueError(
+            f"params must have shape (5,); got {values.shape}."
+        )
+    if not np.all(np.isfinite(values)):
+        raise CrystallographyValueError(
+            "params must contain only finite values."
+        )
+
+    alpha, beta, gamma, theta, phi = values
+
+    misorientation = Rotation.from_euler(
+        "ZXZ",
+        [alpha, beta, gamma],
+    ).as_matrix()
+    left = (
+        Rotation.from_euler("z", phi)
+        * Rotation.from_euler("y", theta)
+    ).as_matrix()
+    right = left @ misorientation
+
+    return (
+        validate_orientation_matrix(left, "R_left", tol=tol),
+        validate_orientation_matrix(right, "R_right", tol=tol),
+    )
+
+
+__all__ = [
+    "build_mixed_orientations",
+    "build_symmetric_tilt_orientations",
+    "build_tilt_orientations",
+    "build_twist_orientations",
+    "five_dof_from_axis_angle",
+    "five_dof_from_orientation_matrices",
+    "inclination_from_normal",
+    "normalize_direction",
+    "validate_orientation_matrix",
+]

--- a/GBOpt/crystallography/pq.py
+++ b/GBOpt/crystallography/pq.py
@@ -1,6 +1,6 @@
 # Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
 
-"""P/Q matrix canonicalization and row-rotation recovery.
+"""P/Q canonicalization and rotation recovery.
 
 Provides canonical forms for grain orientation matrices and recovers exact scaled
 rotations from paired P/Q row matrices. Does not import ``BoundaryEmbedding``, boundary
@@ -24,6 +24,10 @@ from .integer import (
 from .reduction import gauss_reduce_2d, gauss_reduce_2d_paired
 from .rotation import validate_scaled_rotation_matrix
 from .types import CrystallographyValueError, ScaledRotation
+
+# ---------------------------------------------------------------------------
+# Exact integer P/Q canonicalization and rotation recovery
+# ---------------------------------------------------------------------------
 
 
 def _first_nonzero_sign(row: np.ndarray) -> int:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,58 @@
 # GBOpt
 GBOpt is a Python package for creating, manipulating, and optimizing bicrystal grain boundary structures through configurable global optimization workflows. It uses a modular architecture, with separate modules for structure creation, manipulation, and optimization. In the initial release:
-- GB creation is facilitated through a single parameterization of the macroscopic degrees of freedom (misorientation and inclination).
+- GB creation is facilitated through boundary-spec inputs that cover legacy five-degree-of-freedom parameters, exact P/Q orientation matrices, and CSL descriptions.
 - GBs can be manipulated using grain translation, atom insertion, atom removal, and displacement along soft phonon modes.
 - GB optimization is performed using either a Monte Carlo or an evolutionary algorithm optimizer, with energy evaluations currently using LAMMPS as the atomistic calculator.
 
 The modular nature of the software is intended to allow easy extensibility to additional grain boundary parameterizations, structural manipulations, optimization engines, and external calculators.
+
+## Boundary construction API
+
+New code should build grain boundaries through `GBMaker.from_boundary_spec(...)`
+rather than the deprecated direct `GBMaker(...)` constructor. Supported core
+input formats are:
+
+- `FiveDOFSpec(params)` for the legacy `[alpha, beta, gamma, theta, phi]`
+  ZXZ-plus-inclination parameterization. This currently builds in
+  `mode="approximate"`; exactification is reserved for a future Stage E hook.
+- `PQSpec(P, Q)` for exact row-wise orientation matrices, where rows give
+  the crystal directions aligned with lab x, y, and z for the left and right
+  grains.
+- `CSLExactSpec(axis, plane, quat, sigma=None)` and
+  `CSLApproxSpec(axis, plane, angle_deg, sigma=None)` for CSL-oriented input.
+  Exact CSL specs use an integer quaternion; approximate CSL specs use a
+  floating-point angle.
+
+Construction modes are:
+
+- `mode="exact"` for exact integer P/Q construction. This requires `PQSpec` or
+  `CSLExactSpec` until five-DOF exactification is implemented.
+- `mode="prefer_exact"` to use exact construction when available and warn
+  before falling back where exactification is not implemented.
+- `mode="approximate"` for the floating-point builder. This is the intended
+  mode for incoherent or arbitrary-angle interfaces, not just a fallback.
+
+Constructed objects expose `inplane_periodic` coherence metadata. Exact
+coherent constructions report `(True, True)`, while approximate incoherent
+interfaces report `(False, False)`.
+
+Example:
+
+```python
+import numpy as np
+
+from GBOpt import GBMaker
+from GBOpt.BoundarySpec import FiveDOFSpec
+
+gb = GBMaker.from_boundary_spec(
+    3.52,
+    "fcc",
+    "Ni",
+    FiveDOFSpec(np.array([0.643501, 0.0, 0.0, 0.0, -0.321751])),
+    mode="approximate",
+    gb_thickness=20.0,
+)
+```
 
 To install, create a new conda environment
 ```

--- a/examples/density_optimization/README.md
+++ b/examples/density_optimization/README.md
@@ -81,6 +81,12 @@ Each call produces a two-panel figure:
 
 ## Track 2 — Re-run the optimization
 
+`optimize.py` builds the Σ5[001]{310} starting structure with
+`GBMaker.from_boundary_spec(..., FiveDOFSpec(...), mode="approximate")`.
+This preserves the legacy five-DOF example geometry while avoiding the
+deprecated direct constructor. Exact five-DOF reconstruction is
+not enabled until the future exactification hook is implemented.
+
 ### Requirements
 
 - LAMMPS compiled with the KOKKOS and MANYBODY packages. The results in

--- a/examples/density_optimization/README.md
+++ b/examples/density_optimization/README.md
@@ -81,7 +81,7 @@ Each call produces a two-panel figure:
 
 ## Track 2 — Re-run the optimization
 
-`optimize.py` builds the Σ5[001]{310} starting structure with
+`optimize.py` builds the $\Sigma 5$5[001]{310} starting structure with
 `GBMaker.from_boundary_spec(..., FiveDOFSpec(...), mode="approximate")`.
 This preserves the legacy five-DOF example geometry while avoiding the
 deprecated direct constructor. Exact five-DOF reconstruction is

--- a/examples/density_optimization/scripts/optimize.py
+++ b/examples/density_optimization/scripts/optimize.py
@@ -32,6 +32,7 @@ import numpy as np
 from slurm_utils import SlurmJob, submit_job, wait_for_jobs
 
 from GBOpt import GBMaker, GBManipulator, GBMinimizer
+from GBOpt.BoundarySpec import FiveDOFSpec
 
 PENALTY = 1.0e30
 BOUNDARY = "sigma5_310_STGB"
@@ -76,6 +77,28 @@ def _detect_failure_reason(paths: Sequence[Path]) -> str | None:
     if any(_file_contains(p, ERROR_SIGNATURES["non_numeric_unstable"]) for p in paths):
         return "non_numeric_unstable"
     return None
+
+
+def _build_gb(
+    lattice_parameter: float,
+    structure: str,
+    atom_types: str | List[str],
+    misorientation: np.ndarray,
+    gb_thickness: float,
+    *,
+    x_dim_min: int,
+    repeat_factor: Tuple[int, int],
+    interaction_distance: float,
+) -> GBMaker:
+    return GBMaker.from_boundary_spec(
+        lattice_parameter, structure, atom_types, FiveDOFSpec(misorientation),
+        mode="approximate",
+        gb_thickness=gb_thickness,
+        x_dim_min=x_dim_min,
+        repeat_factor=repeat_factor,
+        interaction_distance=interaction_distance,
+        vacuum=0,
+    )
 
 
 def _wait_for_fresh_file(
@@ -349,18 +372,18 @@ def run_density_optimization(
     theta = math.radians(36.869898)
     misorientation = np.array([theta, 0.0, 0.0, 0.0, -theta / 2.0])
 
-    GB0 = GBMaker(
-        lattice_parameter, structure, lattice_parameter, misorientation, atom_types,
+    GB0 = _build_gb(
+        lattice_parameter, structure, atom_types, misorientation, lattice_parameter,
         x_dim_min=x_dim_min, repeat_factor=repeat_factor,
-        interaction_distance=interaction_distance, vacuum=0,
+        interaction_distance=interaction_distance,
     )
     gb_thickness = 2 * max(GB0.spacing["x"]["left"], GB0.spacing["x"]["right"])
     del GB0
 
-    GB = GBMaker(
-        lattice_parameter, structure, gb_thickness, misorientation, atom_types,
+    GB = _build_gb(
+        lattice_parameter, structure, atom_types, misorientation, gb_thickness,
         x_dim_min=x_dim_min, repeat_factor=repeat_factor,
-        interaction_distance=interaction_distance, vacuum=0,
+        interaction_distance=interaction_distance,
     )
     GB.write_lammps(str(output_dir / "initial.dat"), type_as_int=True)
 

--- a/examples/gb_optimization/README.md
+++ b/examples/gb_optimization/README.md
@@ -10,7 +10,7 @@ referenced in the accompanying manuscript.
 ```
 gb_optimization/
 ├── config/
-│   ├── boundaries.py          # misorientation arrays for each boundary
+│   ├── boundaries.py          # legacy five_dof arrays for each boundary
 │   ├── ga.toml                # GA hyperparameters
 │   ├── mc.toml                # MC hyperparameters
 │   └── literature_gbe.toml   # reference GBE values from literature
@@ -90,6 +90,12 @@ python scripts/plot_mc_comparison.py --material Fe --boundary sigma5_310_STGB \
 ```
 
 ## Track 2 — Re-run the optimization
+
+The run scripts construct initial structures with
+`GBMaker.from_boundary_spec(..., FiveDOFSpec(...), mode="approximate")`.
+The boundary table below is still stored as legacy five-DOF misorientation
+arrays in `config/boundaries.py`; until five-DOF exactification is implemented,
+these examples intentionally use the approximate path.
 
 ### Requirements
 

--- a/examples/gb_optimization/scripts/make_initial.py
+++ b/examples/gb_optimization/scripts/make_initial.py
@@ -11,6 +11,7 @@ except ImportError:
     import tomli as tomllib
 
 from GBOpt import GBMaker, GBManipulator
+from GBOpt.BoundarySpec import FiveDOFSpec
 
 SCRIPTS_DIR = Path(__file__).parent
 PROJECT_ROOT = SCRIPTS_DIR.parent
@@ -23,6 +24,27 @@ def _load_boundaries():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod.BOUNDARIES
+
+
+def _build_gb(
+    a0,
+    structure,
+    atom_types,
+    misorientation,
+    gb_thickness,
+    interaction_distance,
+    x_dim_min,
+    repeat_factor,
+):
+    return GBMaker.from_boundary_spec(
+        a0, structure, atom_types, FiveDOFSpec(misorientation),
+        mode="approximate",
+        gb_thickness=gb_thickness,
+        interaction_distance=interaction_distance,
+        x_dim_min=x_dim_min,
+        repeat_factor=repeat_factor,
+        vacuum=0,
+    )
 
 
 def main() -> None:
@@ -50,23 +72,14 @@ def main() -> None:
     r = mat["interaction_distance"]
     x_dim_min = mat.get("x_dim_min", 60)
 
-    GB = GBMaker(
-        a0, structure, a0, misorientation,
-        atom_types=atom_types,
-        interaction_distance=r,
-        x_dim_min=x_dim_min,
-        repeat_factor=repeat_factor,
-        vacuum=0,
+    GB = _build_gb(
+        a0, structure, atom_types, misorientation, a0, r, x_dim_min, repeat_factor,
     )
     gb_thickness = 2 * max(GB.spacing["x"]["left"], GB.spacing["x"]["right"])
 
-    GB = GBMaker(
-        a0, structure, gb_thickness, misorientation,
-        atom_types=atom_types,
-        interaction_distance=r,
-        x_dim_min=x_dim_min,
-        repeat_factor=repeat_factor,
-        vacuum=0,
+    GB = _build_gb(
+        a0, structure, atom_types, misorientation, gb_thickness, r, x_dim_min,
+        repeat_factor,
     )
 
     manip = GBManipulator(GB)

--- a/examples/gb_optimization/scripts/run_ga.py
+++ b/examples/gb_optimization/scripts/run_ga.py
@@ -22,6 +22,7 @@ except ImportError:
 from slurm_utils import SlurmJob, submit_job, wait_for_jobs
 
 from GBOpt import GBMaker, GBManipulator, GBMinimizer
+from GBOpt.BoundarySpec import FiveDOFSpec
 
 SCRIPTS_DIR = Path(__file__).parent
 PROJECT_ROOT = SCRIPTS_DIR.parent
@@ -62,6 +63,28 @@ def _load_boundaries():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod.BOUNDARIES
+
+
+def _build_gb(
+    lattice_parameter: float,
+    structure: str,
+    atom_types: str | List[str],
+    misorientation: np.ndarray,
+    gb_thickness: float,
+    *,
+    x_dim_min: int,
+    repeat_factor: Tuple[int, int],
+    interaction_distance: float,
+) -> GBMaker:
+    return GBMaker.from_boundary_spec(
+        lattice_parameter, structure, atom_types, FiveDOFSpec(misorientation),
+        mode="approximate",
+        gb_thickness=gb_thickness,
+        x_dim_min=x_dim_min,
+        repeat_factor=repeat_factor,
+        interaction_distance=interaction_distance,
+        vacuum=0,
+    )
 
 
 def _file_contains(path: Path, needle: str) -> bool:
@@ -392,24 +415,20 @@ def run_evolution(
         material=material,
     )
 
-    GB0 = GBMaker(
-        lattice_parameter, structure, lattice_parameter, misorientation,
-        atom_types=atom_types,
+    GB0 = _build_gb(
+        lattice_parameter, structure, atom_types, misorientation, lattice_parameter,
         x_dim_min=x_dim_min,
         repeat_factor=repeat_factor,
         interaction_distance=interaction_distance,
-        vacuum=0,
     )
     gb_thickness = 2 * max(GB0.spacing["x"]["left"], GB0.spacing["x"]["right"])
     del GB0
 
-    GB = GBMaker(
-        lattice_parameter, structure, gb_thickness, misorientation,
-        atom_types=atom_types,
+    GB = _build_gb(
+        lattice_parameter, structure, atom_types, misorientation, gb_thickness,
         x_dim_min=x_dim_min,
         repeat_factor=repeat_factor,
         interaction_distance=interaction_distance,
-        vacuum=0,
     )
 
     if initial_structure is not None:

--- a/examples/gb_optimization/scripts/run_mc.py
+++ b/examples/gb_optimization/scripts/run_mc.py
@@ -20,6 +20,7 @@ except ImportError:
     import tomli as tomllib
 
 from GBOpt import GBMaker, GBManipulator, GBMinimizer
+from GBOpt.BoundarySpec import FiveDOFSpec
 
 SCRIPTS_DIR = Path(__file__).parent
 PROJECT_ROOT = SCRIPTS_DIR.parent
@@ -50,6 +51,28 @@ def _load_boundaries():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod.BOUNDARIES
+
+
+def _build_gb(
+    lattice_parameter: float,
+    structure: str,
+    atom_types: str | List[str],
+    misorientation: np.ndarray,
+    gb_thickness: float,
+    *,
+    x_dim_min: int,
+    repeat_factor: Tuple[int, int],
+    interaction_distance: float,
+) -> GBMaker:
+    return GBMaker.from_boundary_spec(
+        lattice_parameter, structure, atom_types, FiveDOFSpec(misorientation),
+        mode="approximate",
+        gb_thickness=gb_thickness,
+        x_dim_min=x_dim_min,
+        repeat_factor=repeat_factor,
+        interaction_distance=interaction_distance,
+        vacuum=0,
+    )
 
 
 def get_gb_energy(
@@ -186,24 +209,20 @@ def run_mc(
         material=material
     )
 
-    GB0 = GBMaker(
-        lattice_parameter, structure, lattice_parameter, misorientation,
-        atom_types=atom_types,
+    GB0 = _build_gb(
+        lattice_parameter, structure, atom_types, misorientation, lattice_parameter,
         interaction_distance=interaction_distance,
         x_dim_min=x_dim_min,
         repeat_factor=repeat_factor,
-        vacuum=0,
     )
     gb_thickness = 2 * max(GB0.spacing["x"]["left"], GB0.spacing["x"]["right"])
     del GB0
 
-    GB = GBMaker(
-        lattice_parameter, structure, gb_thickness, misorientation,
-        atom_types=atom_types,
+    GB = _build_gb(
+        lattice_parameter, structure, atom_types, misorientation, gb_thickness,
         interaction_distance=interaction_distance,
         x_dim_min=x_dim_min,
         repeat_factor=repeat_factor,
-        vacuum=0,
     )
 
     extra = {"initial_structure": str(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 pythonpath = tests
+filterwarnings =
+    ignore:GBMaker\(\.\.\.\) is deprecated; use GBMaker\.from_boundary_spec\(\.\.\.\)\.:DeprecationWarning
 markers =
     known_bug: Marks test as a known bug
     slow: Marks tests as slow

--- a/tests/test_crystallography_boundary.py
+++ b/tests/test_crystallography_boundary.py
@@ -8,11 +8,13 @@ from GBOpt.BoundarySpec import (
     BoundarySpecOrthogonalityError,
     CSLApproxSpec,
     CSLExactSpec,
+    FiveDOFSpec,
     PQSpec,
 )
-from GBOpt.crystallography import (
+from GBOpt.crystallography.boundary import (
     csl_approx_spec_to_embedding,
     csl_exact_spec_to_embedding,
+    five_dof_spec_to_embedding,
     pq_spec_to_embedding,
     primitive_bicrystal_atom_count,
 )
@@ -641,7 +643,7 @@ def test_csl_approx_spec_to_embedding_zero_angle_gives_same_rotations():
     np.testing.assert_allclose(emb.R_left, emb.R_right, atol=1e-12, rtol=0.0)
 
 
-def test_csl_approx_spec_to_embedding_non_axis_aligned_plane():
+def test_csl_approx_spec_to_embedding_is_approximate_and_incoherent():
     spec = CSLApproxSpec(
         axis=[1, 0, 0],
         plane=[1, 1, 1],
@@ -651,7 +653,7 @@ def test_csl_approx_spec_to_embedding_non_axis_aligned_plane():
     emb = csl_approx_spec_to_embedding(spec)
 
     assert emb.exact is False
-    assert emb.coherent is True
+    assert emb.coherent is False
     assert emb.source == "csl"
     assert emb.P is None
     assert emb.Q is None
@@ -666,6 +668,55 @@ def test_csl_approx_spec_to_embedding_non_axis_aligned_plane():
     )
 
     _assert_proper_rotation_pair(emb)
+
+
+# --------------------------------------------------------------------------------------
+# five_dof_spec_to_embedding
+# --------------------------------------------------------------------------------------
+
+
+def test_five_dof_spec_to_embedding_delegates_to_rotation_embedding(
+    monkeypatch,
+):
+    spec = FiveDOFSpec([0, 0, 0, 0, 0])
+    expected_left = np.eye(3)
+    expected_right = np.eye(3)
+    expected_embedding = object()
+
+    monkeypatch.setattr(
+        "GBOpt.crystallography.boundary.orientation_matrices_from_five_dof",
+        lambda params: (expected_left, expected_right),
+    )
+
+    calls = {}
+
+    def fake_embedding_from_rotation_rows(
+        R_left,
+        R_right,
+        *,
+        source,
+        coherent,
+    ):
+        calls.update(
+            R_left=R_left,
+            R_right=R_right,
+            source=source,
+            coherent=coherent,
+        )
+        return expected_embedding
+
+    monkeypatch.setattr(
+        "GBOpt.crystallography.boundary.embedding_from_rotation_rows",
+        fake_embedding_from_rotation_rows,
+    )
+
+    result = five_dof_spec_to_embedding(spec)
+
+    assert result is expected_embedding
+    assert calls["R_left"] is expected_left
+    assert calls["R_right"] is expected_right
+    assert calls["source"] == "five_dof"
+    assert calls["coherent"] is False
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/test_crystallography_boundary.py
+++ b/tests/test_crystallography_boundary.py
@@ -362,12 +362,7 @@ def test_pq_spec_supplied_mode_does_not_fabricate_primitive_metadata_for_unrecov
 
     emb = pq_spec_to_embedding(spec)
 
-    _assert_embedding_flags(
-        emb,
-        exact=True,
-        coherent=True,
-        source="pq",
-    )
+    _assert_embedding_flags(emb, exact=True, coherent=True, source="pq")
     _assert_proper_rotation_pair(emb)
 
     assert emb.P is not None
@@ -626,7 +621,7 @@ def test_sigma5_twist_csl_embedding_pins_expected_primitive_pq_rows():
 
 def test_csl_approx_spec_to_embedding_flags(approx_sigma5_spec):
     emb = csl_approx_spec_to_embedding(approx_sigma5_spec)
-    _assert_embedding_flags(emb, exact=False, coherent=True, source="csl")
+    _assert_embedding_flags(emb, exact=False, coherent=False, source="csl")
 
 
 def test_csl_approx_spec_to_embedding_P_Q_are_none(approx_sigma5_spec):

--- a/tests/test_crystallography_exactification.py
+++ b/tests/test_crystallography_exactification.py
@@ -1,0 +1,18 @@
+# Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
+
+"""Tests for crystallographic exactification operations."""
+
+import numpy as np
+import pytest
+
+from GBOpt.crystallography.exactification import exactify_five_dof
+
+
+def test_exactify_five_dof_is_not_implemented():
+    params = np.zeros(5, dtype=float)
+
+    with pytest.raises(
+        NotImplementedError,
+        match=r"five-DOF parameters to exact canonical P/Q matrices",
+    ):
+        exactify_five_dof(params)

--- a/tests/test_crystallography_orientation.py
+++ b/tests/test_crystallography_orientation.py
@@ -1,0 +1,402 @@
+# Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
+import math
+import warnings
+
+import numpy as np
+import pytest
+from scipy.spatial.transform import Rotation
+
+from GBOpt.crystallography.orientation import (
+    build_mixed_orientations,
+    build_symmetric_tilt_orientations,
+    build_tilt_orientations,
+    build_twist_orientations,
+    five_dof_from_axis_angle,
+    five_dof_from_orientation_matrices,
+    inclination_from_normal,
+    normalize_direction,
+    orientation_matrices_from_five_dof,
+    validate_orientation_matrix,
+)
+from GBOpt.crystallography.types import CrystallographyValueError
+
+
+def _assert_proper_orientation(matrix: np.ndarray, *, atol: float = 1.0e-10) -> None:
+    assert matrix.shape == (3, 3)
+    np.testing.assert_allclose(matrix @ matrix.T, np.eye(3), atol=atol, rtol=0.0)
+    assert np.linalg.det(matrix) == pytest.approx(1.0, abs=atol)
+
+
+def _axis_rotation(axis: object, angle_deg: float) -> np.ndarray:
+    axis_hat = np.asarray(axis, dtype=float)
+    axis_hat /= np.linalg.norm(axis_hat)
+    return Rotation.from_rotvec(axis_hat * math.radians(angle_deg)).as_matrix()
+
+
+def _inclination_matrix(params: np.ndarray) -> np.ndarray:
+    theta, phi = params[3:]
+    return (
+        Rotation.from_euler("z", phi) * Rotation.from_euler("y", theta)
+    ).as_matrix()
+
+
+# --------------------------------------------------------------------------------------
+# Floating-point direction and orientation validation
+# --------------------------------------------------------------------------------------
+
+
+def test_normalize_direction_returns_unit_copy_without_mutating_input():
+    direction = np.array([3.0, 4.0, 0.0])
+    original = direction.copy()
+
+    normalized = normalize_direction(direction)
+
+    np.testing.assert_array_equal(direction, original)
+    np.testing.assert_allclose(normalized, [0.6, 0.8, 0.0])
+    assert np.linalg.norm(normalized) == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    ("direction", "match"),
+    [
+        pytest.param([0.0, 0.0, 0.0], "nonzero", id="zero"),
+        pytest.param([1.0, 2.0], "shape", id="wrong-shape"),
+        pytest.param([1.0, np.nan, 0.0], "finite", id="nan"),
+        pytest.param([1.0, np.inf, 0.0], "finite", id="infinite"),
+    ],
+)
+def test_normalize_direction_rejects_invalid_vectors(direction, match):
+    with pytest.raises(CrystallographyValueError, match=match):
+        normalize_direction(direction)
+
+
+@pytest.mark.parametrize("tol", [0.0, -1.0, np.inf, np.nan, True])
+def test_normalize_direction_rejects_invalid_tolerance(tol):
+    with pytest.raises(CrystallographyValueError):
+        normalize_direction([1.0, 0.0, 0.0], tol=tol)
+
+
+def test_validate_orientation_matrix_normalizes_scaled_rows():
+    matrix = np.diag([2.0, 3.0, 4.0])
+
+    normalized = validate_orientation_matrix(matrix)
+
+    np.testing.assert_allclose(normalized, np.eye(3))
+    _assert_proper_orientation(normalized)
+
+
+@pytest.mark.parametrize(
+    ("matrix", "match"),
+    [
+        pytest.param(np.eye(2), "shape", id="wrong-shape"),
+        pytest.param(
+            [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            "nonzero",
+            id="zero-row",
+        ),
+        pytest.param(
+            [[1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            "orthogonal",
+            id="nonorthogonal",
+        ),
+        pytest.param(np.diag([-1.0, 1.0, 1.0]), "right-handed", id="left-handed"),
+        pytest.param(
+            [[1.0, 0.0, 0.0], [0.0, np.nan, 0.0], [0.0, 0.0, 1.0]],
+            "finite",
+            id="nonfinite",
+        ),
+    ],
+)
+def test_validate_orientation_matrix_rejects_invalid_matrices(matrix, match):
+    with pytest.raises(CrystallographyValueError, match=match):
+        validate_orientation_matrix(matrix)
+
+
+# --------------------------------------------------------------------------------------
+# Floating-point P/Q builders
+# --------------------------------------------------------------------------------------
+
+
+def test_build_tilt_orientations_satisfies_row_rotation_contract():
+    normal = np.array([3.0, 1.0, 0.0])
+    axis = np.array([0.0, 0.0, 1.0])
+    angle_deg = 36.869898
+
+    P, Q = build_tilt_orientations(normal, axis, angle_deg)
+
+    _assert_proper_orientation(P)
+    _assert_proper_orientation(Q)
+    np.testing.assert_allclose(P[0], normal / np.linalg.norm(normal))
+    np.testing.assert_allclose(P[1], axis)
+    np.testing.assert_allclose(Q, P @ _axis_rotation(axis, angle_deg), atol=1.0e-12)
+
+
+def test_build_tilt_orientations_rejects_axis_outside_boundary_plane():
+    with pytest.raises(
+        CrystallographyValueError,
+        match="must lie in the boundary plane",
+    ):
+        build_tilt_orientations([1, 0, 0], [1, 0, 1], 30.0)
+
+
+def test_build_symmetric_tilt_orientations_mirrors_boundary_normals():
+    median = np.array([1.0, 0.0, 0.0])
+    axis = np.array([0.0, 0.0, 1.0])
+    angle_deg = 2.0 * math.degrees(math.atan(1.0 / 5.0))
+
+    P, Q = build_symmetric_tilt_orientations(median, axis, angle_deg)
+
+    _assert_proper_orientation(P)
+    _assert_proper_orientation(Q)
+    np.testing.assert_allclose(P[0], np.array([5.0, 1.0, 0.0]) / math.sqrt(26.0))
+    np.testing.assert_allclose(Q[0], np.array([5.0, -1.0, 0.0]) / math.sqrt(26.0))
+    np.testing.assert_allclose(Q, P @ _axis_rotation(axis, angle_deg), atol=1.0e-12)
+
+
+def test_build_symmetric_tilt_orientations_rejects_nonperpendicular_axis():
+    with pytest.raises(CrystallographyValueError, match="perpendicular"):
+        build_symmetric_tilt_orientations([1, 0, 0], [1, 0, 1], 30.0)
+
+
+def test_build_twist_orientations_preserves_boundary_normal():
+    normal = np.array([1.0, 1.0, 1.0])
+    angle_deg = 60.0
+
+    P, Q = build_twist_orientations(normal, angle_deg)
+
+    _assert_proper_orientation(P)
+    _assert_proper_orientation(Q)
+    np.testing.assert_allclose(P[0], normal / np.linalg.norm(normal))
+    np.testing.assert_allclose(Q[0], P[0], atol=1.0e-12)
+    np.testing.assert_allclose(Q, P @ _axis_rotation(normal, angle_deg), atol=1.0e-12)
+
+
+def test_build_twist_orientations_projects_custom_reference():
+    P, _Q = build_twist_orientations(
+        [0.0, 0.0, 1.0],
+        45.0,
+        in_plane_reference=[1.0, 1.0, 5.0],
+    )
+
+    np.testing.assert_allclose(P[1], [1.0 / math.sqrt(2.0), 1.0 / math.sqrt(2.0), 0.0])
+
+
+def test_build_twist_orientations_rejects_parallel_reference():
+    with pytest.raises(CrystallographyValueError, match="must not be parallel"):
+        build_twist_orientations(
+            [0.0, 0.0, 1.0],
+            45.0,
+            in_plane_reference=[0.0, 0.0, 2.0],
+        )
+
+
+def test_build_mixed_orientations_uses_axis_projection_by_default():
+    normal = np.array([3.0, 1.0, 1.0])
+    axis = np.array([0.0, 0.0, 1.0])
+    angle_deg = 36.869898
+
+    P, Q = build_mixed_orientations(normal, axis, angle_deg)
+
+    normal_hat = normal / np.linalg.norm(normal)
+    projected_axis = axis - np.dot(axis, normal_hat) * normal_hat
+    projected_axis /= np.linalg.norm(projected_axis)
+
+    _assert_proper_orientation(P)
+    _assert_proper_orientation(Q)
+    np.testing.assert_allclose(P[0], normal_hat)
+    np.testing.assert_allclose(P[1], projected_axis)
+    np.testing.assert_allclose(Q, P @ _axis_rotation(axis, angle_deg), atol=1.0e-12)
+
+
+@pytest.mark.parametrize(
+    ("normal", "axis", "match"),
+    [
+        pytest.param([1, 0, 0], [0, 1, 0], "twist component", id="pure-tilt"),
+        pytest.param([1, 0, 0], [2, 0, 0], "tilt component", id="pure-twist"),
+    ],
+)
+def test_build_mixed_orientations_rejects_pure_boundaries(normal, axis, match):
+    with pytest.raises(CrystallographyValueError, match=match):
+        build_mixed_orientations(normal, axis, 30.0)
+
+
+# --------------------------------------------------------------------------------------
+# Five-DOF conversion
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "normal",
+    [
+        pytest.param([1.0, 0.0, 0.0], id="lab-x"),
+        pytest.param([3.0, 1.0, 2.0], id="general"),
+        pytest.param([0.0, 1.0, 0.0], id="positive-y-singularity"),
+        pytest.param([0.0, -1.0, 0.0], id="negative-y-singularity"),
+    ],
+)
+def test_inclination_from_normal_reconstructs_unit_normal(normal):
+    theta, phi = inclination_from_normal(normal)
+    params = np.array([0.0, 0.0, 0.0, theta, phi])
+
+    reconstructed = _inclination_matrix(params)[0]
+
+    np.testing.assert_allclose(
+        reconstructed,
+        np.asarray(normal, dtype=float) / np.linalg.norm(normal),
+        atol=1.0e-12,
+    )
+
+
+def test_five_dof_from_axis_angle_reconstructs_rotation_and_inclination():
+    axis = np.array([1.0, 1.0, 1.0])
+    normal = np.array([3.0, 1.0, 2.0])
+    angle_deg = 60.0
+
+    params = five_dof_from_axis_angle(axis, angle_deg, normal)
+
+    reconstructed_rotation = Rotation.from_euler("ZXZ", params[:3]).as_matrix()
+    np.testing.assert_allclose(
+        reconstructed_rotation,
+        _axis_rotation(axis, angle_deg),
+        atol=1.0e-12,
+    )
+    np.testing.assert_allclose(
+        _inclination_matrix(params)[0],
+        normal / np.linalg.norm(normal),
+        atol=1.0e-12,
+    )
+
+
+def test_five_dof_from_axis_angle_suppresses_scipy_gimbal_lock_warning():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        params = five_dof_from_axis_angle([0, 0, 1], 30.0, [1, 0, 0])
+
+    reconstructed = Rotation.from_euler("ZXZ", params[:3]).as_matrix()
+    np.testing.assert_allclose(reconstructed, _axis_rotation([0, 0, 1], 30.0))
+
+
+def test_five_dof_from_orientation_matrices_accepts_scaled_rows():
+    angle_deg = 36.869898
+    P_unit, Q_unit = build_tilt_orientations([3, 1, 0], [0, 0, 1], angle_deg)
+    P = P_unit * np.array([2.0, 3.0, 4.0])[:, np.newaxis]
+    Q = Q_unit * np.array([5.0, 6.0, 7.0])[:, np.newaxis]
+
+    params = five_dof_from_orientation_matrices(P, Q)
+
+    reconstructed_rotation = Rotation.from_euler("ZXZ", params[:3]).as_matrix()
+    np.testing.assert_allclose(
+        reconstructed_rotation,
+        P_unit.T @ Q_unit,
+        atol=1.0e-12,
+    )
+    np.testing.assert_allclose(_inclination_matrix(params)[0], P_unit[0], atol=1.0e-12)
+
+
+def test_five_dof_from_orientation_matrices_warns_and_uses_p_normal():
+    P = np.eye(3)
+    Q = _axis_rotation([0, 0, 1], 20.0)
+
+    with pytest.warns(UserWarning, match=r"differs from P\[0\]"):
+        params = five_dof_from_orientation_matrices(
+            P,
+            Q,
+            boundary_normal=[0, 1, 0],
+        )
+
+    np.testing.assert_allclose(_inclination_matrix(params)[0], P[0], atol=1.0e-12)
+
+
+@pytest.mark.parametrize("normal_warning_deg", [-1.0, np.nan, np.inf, True])
+def test_five_dof_from_orientation_matrices_rejects_invalid_warning_threshold(
+    normal_warning_deg,
+):
+    with pytest.raises(CrystallographyValueError):
+        five_dof_from_orientation_matrices(
+            np.eye(3),
+            np.eye(3),
+            normal_warning_deg=normal_warning_deg,
+        )
+
+
+# --------------------------------------------------------------------------------------
+# orientation_matrices_from_five_dof
+# --------------------------------------------------------------------------------------
+
+
+def test_orientation_matrices_from_five_dof_reconstructs_frames():
+    params = np.array(
+        [
+            np.radians(20.0),
+            np.radians(35.0),
+            np.radians(-10.0),
+            np.radians(15.0),
+            np.radians(-25.0),
+        ]
+    )
+
+    R_left, R_right = orientation_matrices_from_five_dof(params)
+
+    expected_misorientation = Rotation.from_euler(
+        "ZXZ",
+        params[:3],
+    ).as_matrix()
+    expected_left = (
+        Rotation.from_euler("z", params[4])
+        * Rotation.from_euler("y", params[3])
+    ).as_matrix()
+
+    np.testing.assert_allclose(R_left, expected_left, atol=1e-12)
+    np.testing.assert_allclose(
+        R_left.T @ R_right,
+        expected_misorientation,
+        atol=1e-12,
+    )
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        pytest.param(
+            [],
+            r"params must have shape \(5,\)",
+            id="empty",
+        ),
+        pytest.param(
+            [0.0, 0.0, 0.0, 0.0],
+            r"params must have shape \(5,\)",
+            id="too-short",
+        ),
+        pytest.param(
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            r"params must have shape \(5,\)",
+            id="too-long",
+        ),
+        pytest.param(
+            [[0.0, 0.0, 0.0, 0.0, 0.0]],
+            r"params must have shape \(5,\)",
+            id="two-dimensional",
+        ),
+        pytest.param(
+            [np.nan, 0.0, 0.0, 0.0, 0.0],
+            "params must contain only finite values",
+            id="nan",
+        ),
+        pytest.param(
+            [0.0, np.inf, 0.0, 0.0, 0.0],
+            "params must contain only finite values",
+            id="positive-infinity",
+        ),
+        pytest.param(
+            [0.0, 0.0, -np.inf, 0.0, 0.0],
+            "params must contain only finite values",
+            id="negative-infinity",
+        ),
+    ],
+)
+def test_orientation_matrices_from_five_dof_rejects_invalid_params(
+    params,
+    message,
+):
+    with pytest.raises(CrystallographyValueError, match=message):
+        orientation_matrices_from_five_dof(params)

--- a/tests/test_crystallography_orientation.py
+++ b/tests/test_crystallography_orientation.py
@@ -41,7 +41,7 @@ def _inclination_matrix(params: np.ndarray) -> np.ndarray:
 
 
 # --------------------------------------------------------------------------------------
-# Floating-point direction and orientation validation
+# Direction and orientation validation
 # --------------------------------------------------------------------------------------
 
 
@@ -63,6 +63,7 @@ def test_normalize_direction_returns_unit_copy_without_mutating_input():
         pytest.param([1.0, 2.0], "shape", id="wrong-shape"),
         pytest.param([1.0, np.nan, 0.0], "finite", id="nan"),
         pytest.param([1.0, np.inf, 0.0], "finite", id="infinite"),
+        pytest.param(["bad", 0.0, 0.0], "finite three-component", id="nonnumeric"),
     ],
 )
 def test_normalize_direction_rejects_invalid_vectors(direction, match):
@@ -70,9 +71,24 @@ def test_normalize_direction_rejects_invalid_vectors(direction, match):
         normalize_direction(direction)
 
 
-@pytest.mark.parametrize("tol", [0.0, -1.0, np.inf, np.nan, True])
-def test_normalize_direction_rejects_invalid_tolerance(tol):
-    with pytest.raises(CrystallographyValueError):
+def test_normalize_direction_rejects_norm_equal_to_tolerance():
+    with pytest.raises(CrystallographyValueError, match="nonzero"):
+        normalize_direction([1.0, 0.0, 0.0], tol=1.0)
+
+
+@pytest.mark.parametrize(
+    ("tol", "match"),
+    [
+        pytest.param(0.0, "strictly positive", id="zero"),
+        pytest.param(-1.0, "strictly positive", id="negative"),
+        pytest.param(np.inf, "finite real number", id="infinite"),
+        pytest.param(np.nan, "finite real number", id="nan"),
+        pytest.param(True, "finite real number", id="boolean"),
+        pytest.param("bad", "finite real number", id="nonnumeric"),
+    ],
+)
+def test_normalize_direction_rejects_invalid_tolerance(tol, match):
+    with pytest.raises(CrystallographyValueError, match=match):
         normalize_direction([1.0, 0.0, 0.0], tol=tol)
 
 
@@ -105,6 +121,11 @@ def test_validate_orientation_matrix_normalizes_scaled_rows():
             "finite",
             id="nonfinite",
         ),
+        pytest.param(
+            [[1.0, 0.0, 0.0], [0.0, "bad", 0.0], [0.0, 0.0, 1.0]],
+            "finite 3 by 3 matrix",
+            id="nonnumeric",
+        ),
     ],
 )
 def test_validate_orientation_matrix_rejects_invalid_matrices(matrix, match):
@@ -112,8 +133,20 @@ def test_validate_orientation_matrix_rejects_invalid_matrices(matrix, match):
         validate_orientation_matrix(matrix)
 
 
+@pytest.mark.parametrize(
+    ("tol", "match"),
+    [
+        pytest.param(0.0, "strictly positive", id="nonpositive"),
+        pytest.param(True, "finite real number", id="boolean"),
+    ],
+)
+def test_validate_orientation_matrix_rejects_invalid_tolerance(tol, match):
+    with pytest.raises(CrystallographyValueError, match=match):
+        validate_orientation_matrix(np.eye(3), tol=tol)
+
+
 # --------------------------------------------------------------------------------------
-# Floating-point P/Q builders
+# Boundary orientation builders
 # --------------------------------------------------------------------------------------
 
 
@@ -171,22 +204,38 @@ def test_build_twist_orientations_preserves_boundary_normal():
     np.testing.assert_allclose(Q, P @ _axis_rotation(normal, angle_deg), atol=1.0e-12)
 
 
-def test_build_twist_orientations_projects_custom_reference():
-    P, _Q = build_twist_orientations(
-        [0.0, 0.0, 1.0],
-        45.0,
-        in_plane_reference=[1.0, 1.0, 5.0],
+def test_build_twist_orientations_uses_projected_custom_reference():
+    normal = np.array([0.0, 0.0, 1.0])
+    reference = np.array([1.0, 1.0, 5.0])
+    angle_deg = 45.0
+
+    P, Q = build_twist_orientations(
+        normal,
+        angle_deg,
+        in_plane_reference=reference,
     )
 
-    np.testing.assert_allclose(P[1], [1.0 / math.sqrt(2.0), 1.0 / math.sqrt(2.0), 0.0])
+    expected_in_plane = np.array([1.0, 1.0, 0.0]) / math.sqrt(2.0)
+    _assert_proper_orientation(P)
+    _assert_proper_orientation(Q)
+    np.testing.assert_allclose(P[0], normal)
+    np.testing.assert_allclose(P[1], expected_in_plane)
+    np.testing.assert_allclose(Q, P @ _axis_rotation(normal, angle_deg), atol=1.0e-12)
 
 
-def test_build_twist_orientations_rejects_parallel_reference():
-    with pytest.raises(CrystallographyValueError, match="must not be parallel"):
+@pytest.mark.parametrize(
+    ("reference", "match"),
+    [
+        pytest.param([0.0, 0.0, 0.0], "nonzero", id="zero"),
+        pytest.param([0.0, 0.0, 2.0], "must not be parallel", id="parallel"),
+    ],
+)
+def test_build_twist_orientations_rejects_invalid_custom_reference(reference, match):
+    with pytest.raises(CrystallographyValueError, match=match):
         build_twist_orientations(
             [0.0, 0.0, 1.0],
             45.0,
-            in_plane_reference=[0.0, 0.0, 2.0],
+            in_plane_reference=reference,
         )
 
 
@@ -208,6 +257,43 @@ def test_build_mixed_orientations_uses_axis_projection_by_default():
     np.testing.assert_allclose(Q, P @ _axis_rotation(axis, angle_deg), atol=1.0e-12)
 
 
+def test_build_mixed_orientations_uses_projected_custom_reference():
+    normal = np.array([0.0, 0.0, 1.0])
+    axis = np.array([1.0, 0.0, 1.0])
+    reference = np.array([0.0, 2.0, 3.0])
+    angle_deg = 30.0
+
+    P, Q = build_mixed_orientations(
+        normal,
+        axis,
+        angle_deg,
+        in_plane_reference=reference,
+    )
+
+    _assert_proper_orientation(P)
+    _assert_proper_orientation(Q)
+    np.testing.assert_allclose(P[0], normal)
+    np.testing.assert_allclose(P[1], [0.0, 1.0, 0.0])
+    np.testing.assert_allclose(Q, P @ _axis_rotation(axis, angle_deg), atol=1.0e-12)
+
+
+@pytest.mark.parametrize(
+    ("reference", "match"),
+    [
+        pytest.param([0.0, 0.0, 0.0], "nonzero", id="zero"),
+        pytest.param([0.0, 0.0, 2.0], "must not be parallel", id="parallel"),
+    ],
+)
+def test_build_mixed_orientations_rejects_invalid_custom_reference(reference, match):
+    with pytest.raises(CrystallographyValueError, match=match):
+        build_mixed_orientations(
+            [0.0, 0.0, 1.0],
+            [1.0, 0.0, 1.0],
+            30.0,
+            in_plane_reference=reference,
+        )
+
+
 @pytest.mark.parametrize(
     ("normal", "axis", "match"),
     [
@@ -221,7 +307,7 @@ def test_build_mixed_orientations_rejects_pure_boundaries(normal, axis, match):
 
 
 # --------------------------------------------------------------------------------------
-# Five-DOF conversion
+# Five-DOF encoding
 # --------------------------------------------------------------------------------------
 
 
@@ -276,6 +362,20 @@ def test_five_dof_from_axis_angle_suppresses_scipy_gimbal_lock_warning():
     np.testing.assert_allclose(reconstructed, _axis_rotation([0, 0, 1], 30.0))
 
 
+@pytest.mark.parametrize(
+    "angle_deg",
+    [
+        pytest.param(True, id="boolean"),
+        pytest.param(np.nan, id="nan"),
+        pytest.param(np.inf, id="infinite"),
+        pytest.param("bad", id="nonnumeric"),
+    ],
+)
+def test_five_dof_from_axis_angle_rejects_invalid_angle(angle_deg):
+    with pytest.raises(CrystallographyValueError, match="finite real number"):
+        five_dof_from_axis_angle([0, 0, 1], angle_deg, [1, 0, 0])
+
+
 def test_five_dof_from_orientation_matrices_accepts_scaled_rows():
     angle_deg = 36.869898
     P_unit, Q_unit = build_tilt_orientations([3, 1, 0], [0, 0, 1], angle_deg)
@@ -307,11 +407,53 @@ def test_five_dof_from_orientation_matrices_warns_and_uses_p_normal():
     np.testing.assert_allclose(_inclination_matrix(params)[0], P[0], atol=1.0e-12)
 
 
-@pytest.mark.parametrize("normal_warning_deg", [-1.0, np.nan, np.inf, True])
+def test_five_dof_from_orientation_matrices_accepts_matching_supplied_normal_without_warning():
+    P = np.eye(3)
+    Q = _axis_rotation([0, 0, 1], 20.0)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        params = five_dof_from_orientation_matrices(
+            P,
+            Q,
+            boundary_normal=[1.0, 1.0e-3, 0.0],
+            normal_warning_deg=1.0,
+        )
+
+    np.testing.assert_allclose(_inclination_matrix(params)[0], P[0], atol=1.0e-12)
+
+
+def test_five_dof_from_orientation_matrices_disables_normal_warning_at_180_degrees():
+    P = np.eye(3)
+    Q = _axis_rotation([0, 0, 1], 20.0)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        params = five_dof_from_orientation_matrices(
+            P,
+            Q,
+            boundary_normal=[-1.0, 0.0, 0.0],
+            normal_warning_deg=180.0,
+        )
+
+    np.testing.assert_allclose(_inclination_matrix(params)[0], P[0], atol=1.0e-12)
+
+
+@pytest.mark.parametrize(
+    ("normal_warning_deg", "match"),
+    [
+        pytest.param(-1.0, "non-negative", id="negative"),
+        pytest.param(np.nan, "finite real number", id="nan"),
+        pytest.param(np.inf, "finite real number", id="infinite"),
+        pytest.param(True, "finite real number", id="boolean"),
+        pytest.param("bad", "finite real number", id="nonnumeric"),
+    ],
+)
 def test_five_dof_from_orientation_matrices_rejects_invalid_warning_threshold(
     normal_warning_deg,
+    match,
 ):
-    with pytest.raises(CrystallographyValueError):
+    with pytest.raises(CrystallographyValueError, match=match):
         five_dof_from_orientation_matrices(
             np.eye(3),
             np.eye(3),
@@ -320,62 +462,71 @@ def test_five_dof_from_orientation_matrices_rejects_invalid_warning_threshold(
 
 
 # --------------------------------------------------------------------------------------
-# orientation_matrices_from_five_dof
+# Five-DOF decoding and round trips
 # --------------------------------------------------------------------------------------
 
 
-def test_orientation_matrices_from_five_dof_reconstructs_frames():
-    params = np.array(
-        [
-            np.radians(20.0),
-            np.radians(35.0),
-            np.radians(-10.0),
-            np.radians(15.0),
-            np.radians(-25.0),
-        ]
-    )
+def test_five_dof_decoding_reconstructs_left_inclination_and_relative_misorientation(
+) -> None:
+    params = np.radians([20.0, 35.0, -10.0, 15.0, -25.0])
 
     R_left, R_right = orientation_matrices_from_five_dof(params)
 
-    expected_misorientation = Rotation.from_euler(
-        "ZXZ",
-        params[:3],
-    ).as_matrix()
+    expected_misorientation = Rotation.from_euler("ZXZ", params[:3]).as_matrix()
     expected_left = (
         Rotation.from_euler("z", params[4])
         * Rotation.from_euler("y", params[3])
     ).as_matrix()
 
-    np.testing.assert_allclose(R_left, expected_left, atol=1e-12)
+    _assert_proper_orientation(R_left)
+    _assert_proper_orientation(R_right)
+    np.testing.assert_allclose(R_left, expected_left, atol=1.0e-12)
     np.testing.assert_allclose(
         R_left.T @ R_right,
         expected_misorientation,
-        atol=1e-12,
+        atol=1.0e-12,
     )
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.param(
+            np.radians([20.0, 35.0, -10.0, 15.0, -25.0]),
+            id="general",
+        ),
+        pytest.param(
+            np.radians([30.0, 0.0, 20.0, 15.0, -25.0]),
+            id="zxz-gimbal-lock",
+        ),
+        pytest.param(
+            np.radians([10.0, 20.0, 30.0, 0.0, -90.0]),
+            id="inclination-singularity",
+        ),
+    ],
+)
+def test_orientation_matrix_five_dof_round_trip_preserves_frames(params):
+    expected_left, expected_right = orientation_matrices_from_five_dof(params)
+
+    encoded = five_dof_from_orientation_matrices(expected_left, expected_right)
+    actual_left, actual_right = orientation_matrices_from_five_dof(encoded)
+
+    np.testing.assert_allclose(actual_left, expected_left, atol=1.0e-12)
+    np.testing.assert_allclose(actual_right, expected_right, atol=1.0e-12)
 
 
 @pytest.mark.parametrize(
     ("params", "message"),
     [
         pytest.param(
-            [],
-            r"params must have shape \(5,\)",
-            id="empty",
-        ),
-        pytest.param(
             [0.0, 0.0, 0.0, 0.0],
             r"params must have shape \(5,\)",
-            id="too-short",
-        ),
-        pytest.param(
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-            r"params must have shape \(5,\)",
-            id="too-long",
+            id="wrong-length",
         ),
         pytest.param(
             [[0.0, 0.0, 0.0, 0.0, 0.0]],
             r"params must have shape \(5,\)",
-            id="two-dimensional",
+            id="wrong-rank",
         ),
         pytest.param(
             [np.nan, 0.0, 0.0, 0.0, 0.0],
@@ -385,18 +536,27 @@ def test_orientation_matrices_from_five_dof_reconstructs_frames():
         pytest.param(
             [0.0, np.inf, 0.0, 0.0, 0.0],
             "params must contain only finite values",
-            id="positive-infinity",
+            id="infinite",
         ),
         pytest.param(
-            [0.0, 0.0, -np.inf, 0.0, 0.0],
-            "params must contain only finite values",
-            id="negative-infinity",
+            ["bad", 0.0, 0.0, 0.0, 0.0],
+            "params must be a finite five-element sequence",
+            id="nonnumeric",
         ),
     ],
 )
-def test_orientation_matrices_from_five_dof_rejects_invalid_params(
-    params,
-    message,
-):
+def test_orientation_matrices_from_five_dof_rejects_invalid_params(params, message):
     with pytest.raises(CrystallographyValueError, match=message):
         orientation_matrices_from_five_dof(params)
+
+
+@pytest.mark.parametrize(
+    ("tol", "match"),
+    [
+        pytest.param(0.0, "strictly positive", id="nonpositive"),
+        pytest.param(True, "finite real number", id="boolean"),
+    ],
+)
+def test_orientation_matrices_from_five_dof_rejects_invalid_tolerance(tol, match):
+    with pytest.raises(CrystallographyValueError, match=match):
+        orientation_matrices_from_five_dof(np.zeros(5), tol=tol)

--- a/tests/test_gb_params.py
+++ b/tests/test_gb_params.py
@@ -1,0 +1,139 @@
+# Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+from GBOpt.BoundarySpec import CSLApproxSpec, CSLExactSpec, FiveDOFSpec, PQSpec
+from GBOpt.Utils.gb_exact import canonicalize_pq, csl_spec_to_embedding
+
+
+class TestGBParamsCLI(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.repo_root = Path(__file__).resolve().parents[1]
+        cls.script = cls.repo_root / "GBOpt" / "Utils" / "gb_params.py"
+
+    def run_cli(self, *args):
+        result = subprocess.run(
+            [sys.executable, str(self.script), *map(str, args)],
+            cwd=self.repo_root,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return json.loads(result.stdout)
+
+    @staticmethod
+    def matrix_payload(matrix):
+        arr = np.asarray(matrix, dtype=float)
+        return [[int(round(v)) for v in row] for row in arr]
+
+    def test_axis_angle_outputs_five_dof_core_format(self):
+        payload = self.run_cli(
+            "axis_angle",
+            "--axis", 1, 1, 1,
+            "--angle", 60,
+            "--normal", 1, 1, 1,
+        )
+
+        self.assertEqual(payload["format"], "five_dof")
+        self.assertEqual(payload["units"], "radians")
+        FiveDOFSpec(payload["params"])
+
+    def test_orientation_outputs_five_dof_core_format(self):
+        payload = self.run_cli(
+            "orientation",
+            "--P", 1, 0, 0, 0, 1, 0, 0, 0, 1,
+            "--Q", 0, 1, 0, 0, 0, 1, 1, 0, 0,
+        )
+
+        self.assertEqual(payload["format"], "five_dof")
+        FiveDOFSpec(payload["params"])
+
+    def test_csl_outputs_exact_core_format(self):
+        payload = self.run_cli(
+            "csl",
+            "--axis", 0, 0, 1,
+            "--plane", 1, 0, 0,
+            "--quat", 2, 0, 0, 1,
+            "--sigma", 5,
+        )
+
+        self.assertEqual(payload["format"], "csl")
+        self.assertTrue(payload["exact"])
+        CSLExactSpec(
+            axis=payload["axis"],
+            plane=payload["plane"],
+            quat=payload["quat"],
+            sigma=payload["sigma"],
+        )
+
+    def test_csl_outputs_approximate_core_format(self):
+        payload = self.run_cli(
+            "csl",
+            "--axis", 0, 0, 1,
+            "--plane", 1, 0, 0,
+            "--angle", 17.3,
+        )
+
+        self.assertEqual(payload["format"], "csl")
+        self.assertFalse(payload["exact"])
+        CSLApproxSpec(
+            axis=payload["axis"],
+            plane=payload["plane"],
+            angle_deg=payload["angle_deg"],
+        )
+
+    def test_convert_exact_csl_outputs_pq_core_format(self):
+        source = {
+            "format": "csl",
+            "exact": True,
+            "axis": [0, 0, 1],
+            "plane": [1, 0, 0],
+            "quat": [2, 0, 0, 1],
+            "sigma": 5,
+        }
+
+        payload = self.run_cli("convert", "--to", "pq", "--input-json", json.dumps(source))
+
+        self.assertEqual(payload["format"], "pq")
+        PQSpec(payload["P"], payload["Q"], basis_mode=payload["basis_mode"])
+        embedding = csl_spec_to_embedding(
+            CSLExactSpec(
+                axis=source["axis"],
+                plane=source["plane"],
+                quat=source["quat"],
+                sigma=source["sigma"],
+            )
+        )
+        self.assertEqual(payload["P"], self.matrix_payload(embedding.P))
+        self.assertEqual(payload["Q"], self.matrix_payload(embedding.Q))
+
+    def test_exactify_reports_stage_e_hook(self):
+        payload = self.run_cli("exactify", "--params", 0, 0, 0, 0, 0)
+
+        self.assertEqual(payload["status"], "not_implemented")
+        self.assertIn("Stage E", payload["message"])
+
+    def test_canonicalize_invokes_canonicalize_pq(self):
+        P = np.array([[2, 0, 0], [0, 3, 0], [0, 0, 4]], dtype=float)
+        Q = np.array([[2, 0, 0], [0, 3, 0], [0, 0, 4]], dtype=float)
+        payload = self.run_cli(
+            "canonicalize",
+            "--P", *P.ravel().tolist(),
+            "--Q", *Q.ravel().tolist(),
+        )
+
+        expected_P, expected_Q = canonicalize_pq(P, Q)
+        self.assertEqual(payload["format"], "pq")
+        self.assertEqual(payload["P"], self.matrix_payload(expected_P))
+        self.assertEqual(payload["Q"], self.matrix_payload(expected_Q))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gb_params.py
+++ b/tests/test_gb_params.py
@@ -3,173 +3,224 @@
 import json
 import subprocess
 import sys
-import unittest
 from pathlib import Path
+from typing import Any
 
 import numpy as np
+import pytest
 
 from GBOpt.BoundarySpec import CSLApproxSpec, CSLExactSpec, FiveDOFSpec, PQSpec
-from GBOpt.Utils.gb_exact import canonicalize_pq, csl_spec_to_embedding
+from GBOpt.crystallography.boundary import csl_exact_spec_to_embedding
+from GBOpt.crystallography.embedding import canonicalize_pq
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GB_PARAMS_SCRIPT = REPO_ROOT / "GBOpt" / "Utils" / "gb_params.py"
+
+FIVE_DOF_ZERO_SOURCE = {
+    "format": "five_dof",
+    "params": [0, 0, 0, 0, 0],
+}
 
 
-class TestGBParamsCLI(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.repo_root = Path(__file__).resolve().parents[1]
-        cls.script = cls.repo_root / "GBOpt" / "Utils" / "gb_params.py"
+def _run_cli(*args: object) -> subprocess.CompletedProcess[str]:
+    """Run the gb_params CLI and return the completed subprocess."""
+    return subprocess.run(
+        [sys.executable, str(GB_PARAMS_SCRIPT), *map(str, args)],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
 
-    def run_cli(self, *args):
-        result = subprocess.run(
-            [sys.executable, str(self.script), *map(str, args)],
-            cwd=self.repo_root,
-            text=True,
-            capture_output=True,
-            check=True,
-        )
-        return json.loads(result.stdout)
 
-    def run_cli_error(self, *args):
-        return subprocess.run(
-            [sys.executable, str(self.script), *map(str, args)],
-            cwd=self.repo_root,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
+def _run_cli_json(*args: object) -> dict[str, Any]:
+    """Run a successful CLI command and decode its JSON output."""
+    result = _run_cli(*args)
 
-    @staticmethod
-    def matrix_payload(matrix):
-        arr = np.asarray(matrix, dtype=float)
-        return [[int(round(v)) for v in row] for row in arr]
+    assert result.returncode == 0, (
+        f"gb_params exited with status {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
 
-    def test_axis_angle_outputs_five_dof_core_format(self):
-        payload = self.run_cli(
-            "axis_angle",
-            "--axis", 1, 1, 1,
-            "--angle", 60,
-            "--normal", 1, 1, 1,
-        )
-
-        self.assertEqual(payload["format"], "five_dof")
-        self.assertEqual(payload["units"], "radians")
-        FiveDOFSpec(payload["params"])
-
-    def test_orientation_outputs_five_dof_core_format(self):
-        payload = self.run_cli(
-            "orientation",
-            "--P", 1, 0, 0, 0, 1, 0, 0, 0, 1,
-            "--Q", 0, 1, 0, 0, 0, 1, 1, 0, 0,
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        pytest.fail(
+            "gb_params did not produce valid JSON\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}\n"
+            f"JSON error: {exc}"
         )
 
-        self.assertEqual(payload["format"], "five_dof")
-        FiveDOFSpec(payload["params"])
-
-    def test_csl_outputs_exact_core_format(self):
-        payload = self.run_cli(
-            "csl",
-            "--axis", 0, 0, 1,
-            "--plane", 1, 0, 0,
-            "--quat", 2, 0, 0, 1,
-            "--sigma", 5,
-        )
-
-        self.assertEqual(payload["format"], "csl")
-        self.assertTrue(payload["exact"])
-        CSLExactSpec(
-            axis=payload["axis"],
-            plane=payload["plane"],
-            quat=payload["quat"],
-            sigma=payload["sigma"],
-        )
-
-    def test_csl_outputs_approximate_core_format(self):
-        payload = self.run_cli(
-            "csl",
-            "--axis", 0, 0, 1,
-            "--plane", 1, 0, 0,
-            "--angle", 17.3,
-        )
-
-        self.assertEqual(payload["format"], "csl")
-        self.assertFalse(payload["exact"])
-        CSLApproxSpec(
-            axis=payload["axis"],
-            plane=payload["plane"],
-            angle_deg=payload["angle_deg"],
-        )
-
-    def test_convert_exact_csl_outputs_pq_core_format(self):
-        source = {
-            "format": "csl",
-            "exact": True,
-            "axis": [0, 0, 1],
-            "plane": [1, 0, 0],
-            "quat": [2, 0, 0, 1],
-            "sigma": 5,
-        }
-
-        payload = self.run_cli("convert", "--to", "pq", "--input-json", json.dumps(source))
-
-        self.assertEqual(payload["format"], "pq")
-        PQSpec(payload["P"], payload["Q"], basis_mode=payload["basis_mode"])
-        embedding = csl_spec_to_embedding(
-            CSLExactSpec(
-                axis=source["axis"],
-                plane=source["plane"],
-                quat=source["quat"],
-                sigma=source["sigma"],
-            )
-        )
-        self.assertEqual(payload["P"], self.matrix_payload(embedding.P))
-        self.assertEqual(payload["Q"], self.matrix_payload(embedding.Q))
-
-    def test_exactify_reports_stage_e_hook(self):
-        payload = self.run_cli("exactify", "--params", 0, 0, 0, 0, 0)
-
-        self.assertEqual(payload["status"], "not_implemented")
-        self.assertIn("Stage E", payload["message"])
-
-    def test_convert_five_dof_to_pq_reports_exactification_gap(self):
-        source = {
-            "format": "five_dof",
-            "params": [0, 0, 0, 0, 0],
-        }
-
-        result = self.run_cli_error(
-            "convert", "--to", "pq", "--input-json", json.dumps(source)
-        )
-
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("five_dof exactification", result.stderr)
-        self.assertIn("not yet implemented", result.stderr)
-
-    def test_convert_rejects_unsupported_csl_target_at_parse_time(self):
-        source = {
-            "format": "five_dof",
-            "params": [0, 0, 0, 0, 0],
-        }
-
-        result = self.run_cli_error(
-            "convert", "--to", "csl", "--input-json", json.dumps(source)
-        )
-
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("invalid choice: 'csl'", result.stderr)
-
-    def test_canonicalize_invokes_canonicalize_pq(self):
-        P = np.array([[2, 0, 0], [0, 3, 0], [0, 0, 4]], dtype=float)
-        Q = np.array([[2, 0, 0], [0, 3, 0], [0, 0, 4]], dtype=float)
-        payload = self.run_cli(
-            "canonicalize",
-            "--P", *P.ravel().tolist(),
-            "--Q", *Q.ravel().tolist(),
-        )
-
-        expected_P, expected_Q = canonicalize_pq(P, Q)
-        self.assertEqual(payload["format"], "pq")
-        self.assertEqual(payload["P"], self.matrix_payload(expected_P))
-        self.assertEqual(payload["Q"], self.matrix_payload(expected_Q))
+    assert isinstance(payload, dict), (
+        f"Expected a JSON object, got {type(payload).__name__}"
+    )
+    return payload
 
 
-if __name__ == "__main__":
-    unittest.main()
+def _matrix_payload(matrix: np.ndarray) -> list[list[int]]:
+    """Convert a numerical matrix to the CLI's nested integer-list format."""
+    return np.rint(np.asarray(matrix, dtype=float)).astype(int).tolist()
+
+
+def _assert_five_dof_payload(payload: dict[str, Any]) -> None:
+    """Assert that a payload conforms to the FiveDOF core format."""
+    assert payload["format"] == "five_dof"
+    FiveDOFSpec(payload["params"])
+
+
+def test_axis_angle_outputs_five_dof_core_format():
+    payload = _run_cli_json(
+        "axis_angle",
+        "--axis", 1, 1, 1,
+        "--angle", 60,
+        "--normal", 1, 1, 1,
+    )
+
+    _assert_five_dof_payload(payload)
+    assert payload["units"] == "radians"
+
+
+def test_orientation_outputs_five_dof_core_format():
+    payload = _run_cli_json(
+        "orientation",
+        "--P", 1, 0, 0, 0, 1, 0, 0, 0, 1,
+        "--Q", 0, 1, 0, 0, 0, 1, 1, 0, 0,
+    )
+
+    _assert_five_dof_payload(payload)
+
+
+def test_csl_outputs_exact_core_format():
+    payload = _run_cli_json(
+        "csl",
+        "--axis", 0, 0, 1,
+        "--plane", 1, 0, 0,
+        "--quat", 2, 0, 0, 1,
+        "--sigma", 5,
+    )
+
+    assert payload["format"] == "csl"
+    assert payload["exact"] is True
+
+    CSLExactSpec(
+        axis=payload["axis"],
+        plane=payload["plane"],
+        quat=payload["quat"],
+        sigma=payload["sigma"],
+    )
+
+
+def test_csl_outputs_approximate_core_format():
+    payload = _run_cli_json(
+        "csl",
+        "--axis", 0, 0, 1,
+        "--plane", 1, 0, 0,
+        "--angle", 17.3,
+    )
+
+    assert payload["format"] == "csl"
+    assert payload["exact"] is False
+
+    CSLApproxSpec(
+        axis=payload["axis"],
+        plane=payload["plane"],
+        angle_deg=payload["angle_deg"],
+    )
+
+
+def test_convert_exact_csl_outputs_pq_core_format():
+    source = {
+        "format": "csl",
+        "exact": True,
+        "axis": [0, 0, 1],
+        "plane": [1, 0, 0],
+        "quat": [2, 0, 0, 1],
+        "sigma": 5,
+    }
+
+    payload = _run_cli_json(
+        "convert",
+        "--to",
+        "pq",
+        "--input-json",
+        json.dumps(source),
+    )
+
+    assert payload["format"] == "pq"
+
+    PQSpec(
+        payload["P"],
+        payload["Q"],
+        basis_mode=payload["basis_mode"],
+    )
+
+    source_spec = CSLExactSpec(
+        axis=source["axis"],
+        plane=source["plane"],
+        quat=source["quat"],
+        sigma=source["sigma"],
+    )
+    embedding = csl_exact_spec_to_embedding(source_spec)
+
+    assert embedding.P is not None
+    assert embedding.Q is not None
+    assert payload["P"] == _matrix_payload(embedding.P)
+    assert payload["Q"] == _matrix_payload(embedding.Q)
+
+
+def test_exactify_reports_stage_e_hook():
+    payload = _run_cli_json(
+        "exactify",
+        "--params", 0, 0, 0, 0, 0,
+    )
+
+    assert payload["status"] == "not_implemented"
+    assert "Stage E" in payload["message"]
+
+
+def test_convert_five_dof_to_pq_reports_exactification_gap():
+    result = _run_cli(
+        "convert",
+        "--to",
+        "pq",
+        "--input-json",
+        json.dumps(FIVE_DOF_ZERO_SOURCE),
+    )
+
+    assert result.returncode != 0
+    assert "five_dof exactification" in result.stderr
+    assert "not yet implemented" in result.stderr
+
+
+def test_convert_rejects_unsupported_csl_target_at_parse_time():
+    result = _run_cli(
+        "convert",
+        "--to",
+        "csl",
+        "--input-json",
+        json.dumps(FIVE_DOF_ZERO_SOURCE),
+    )
+
+    assert result.returncode != 0
+    assert "invalid choice: 'csl'" in result.stderr
+
+
+def test_canonicalize_outputs_canonical_pq_core_format():
+    P = np.diag([2.0, 3.0, 4.0])
+    Q = np.diag([2.0, 3.0, 4.0])
+
+    payload = _run_cli_json(
+        "canonicalize",
+        "--P",
+        *P.ravel(),
+        "--Q",
+        *Q.ravel(),
+    )
+
+    expected_P, expected_Q = canonicalize_pq(P, Q)
+
+    assert payload["format"] == "pq"
+    assert payload["P"] == _matrix_payload(expected_P)
+    assert payload["Q"] == _matrix_payload(expected_Q)

--- a/tests/test_gb_params.py
+++ b/tests/test_gb_params.py
@@ -1,5 +1,6 @@
 # Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
 
+import io
 import json
 import subprocess
 import sys
@@ -8,10 +9,12 @@ from typing import Any
 
 import numpy as np
 import pytest
+from scipy.spatial.transform import Rotation
 
 from GBOpt.BoundarySpec import CSLApproxSpec, CSLExactSpec, FiveDOFSpec, PQSpec
 from GBOpt.crystallography.boundary import csl_exact_spec_to_embedding
-from GBOpt.crystallography.embedding import canonicalize_pq
+from GBOpt.crystallography.pq import canonicalize_pq_paired
+from GBOpt.Utils import gb_params
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 GB_PARAMS_SCRIPT = REPO_ROOT / "GBOpt" / "Utils" / "gb_params.py"
@@ -20,36 +23,63 @@ FIVE_DOF_ZERO_SOURCE = {
     "format": "five_dof",
     "params": [0, 0, 0, 0, 0],
 }
+IDENTITY_PQ_SOURCE = {
+    "format": "pq",
+    "P": [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+    "Q": [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+    "basis_mode": "primitive",
+}
+EXACT_CSL_SOURCE = {
+    "format": "csl",
+    "exact": True,
+    "axis": [0, 0, 1],
+    "plane": [1, 0, 0],
+    "quat": [2, 0, 0, 1],
+    "sigma": 5,
+}
+APPROXIMATE_CSL_SOURCE = {
+    "format": "csl",
+    "exact": False,
+    "axis": [0, 0, 1],
+    "plane": [1, 0, 0],
+    "angle_deg": 17.3,
+}
 
 
-def _run_cli(*args: object) -> subprocess.CompletedProcess[str]:
-    """Run the gb_params CLI and return the completed subprocess."""
+def _run_cli(
+    *args: object,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the standalone ``gb_params`` script in a subprocess.
+
+    :param args: Command-line arguments passed to the script.
+    :param input_text: Optional text supplied to the subprocess standard input.
+    :return: Completed subprocess result with captured text output.
+    """
     return subprocess.run(
         [sys.executable, str(GB_PARAMS_SCRIPT), *map(str, args)],
         cwd=REPO_ROOT,
+        input=input_text,
         text=True,
         capture_output=True,
         check=False,
     )
 
 
-def _run_cli_json(*args: object) -> dict[str, Any]:
-    """Run a successful CLI command and decode its JSON output."""
-    result = _run_cli(*args)
+def _decode_json_output(stdout: str, stderr: str = "") -> dict[str, Any]:
+    """Decode a JSON object from command output with an informative test failure.
 
-    assert result.returncode == 0, (
-        f"gb_params exited with status {result.returncode}\n"
-        f"stdout:\n{result.stdout}\n"
-        f"stderr:\n{result.stderr}"
-    )
-
+    :param stdout: Standard output expected to contain one JSON object.
+    :param stderr: Standard error included in a failure diagnostic.
+    :return: Decoded JSON object.
+    """
     try:
-        payload = json.loads(result.stdout)
+        payload = json.loads(stdout)
     except json.JSONDecodeError as exc:
         pytest.fail(
             "gb_params did not produce valid JSON\n"
-            f"stdout:\n{result.stdout}\n"
-            f"stderr:\n{result.stderr}\n"
+            f"stdout:\n{stdout}\n"
+            f"stderr:\n{stderr}\n"
             f"JSON error: {exc}"
         )
 
@@ -59,41 +89,122 @@ def _run_cli_json(*args: object) -> dict[str, Any]:
     return payload
 
 
+def _run_main_json(capsys: pytest.CaptureFixture[str], *args: object) -> dict[str, Any]:
+    """Run ``gb_params.main`` successfully and decode its JSON output.
+
+    :param capsys: Pytest capture fixture used to collect command output.
+    :param args: Command-line arguments passed to ``gb_params.main``.
+    :return: Decoded JSON object printed by the command.
+    """
+    assert gb_params.main([str(value) for value in args]) == 0
+    captured = capsys.readouterr()
+    return _decode_json_output(captured.out, captured.err)
+
+
+def _run_main_error(
+    capsys: pytest.CaptureFixture[str],
+    *args: object,
+) -> str:
+    """Run ``gb_params.main`` expecting argparse error termination.
+
+    :param capsys: Pytest capture fixture used to collect command output.
+    :param args: Command-line arguments passed to ``gb_params.main``.
+    :return: Captured standard-error text.
+    """
+    with pytest.raises(SystemExit) as caught:
+        gb_params.main([str(value) for value in args])
+
+    assert caught.value.code == 2
+    return capsys.readouterr().err
+
+
 def _matrix_payload(matrix: np.ndarray) -> list[list[int]]:
-    """Convert a numerical matrix to the CLI's nested integer-list format."""
-    return np.rint(np.asarray(matrix, dtype=float)).astype(int).tolist()
+    """Convert an exact matrix to nested Python-integer lists.
+
+    :param matrix: Numerical matrix whose entries are exactly integer-valued.
+    :return: Nested list preserving Python-sized integer values.
+    """
+    return [[int(value) for value in row] for row in np.asarray(matrix, dtype=object)]
 
 
-def _assert_five_dof_payload(payload: dict[str, Any]) -> None:
-    """Assert that a payload conforms to the FiveDOF core format."""
+def _assert_five_dof_payload(payload: dict[str, Any]) -> FiveDOFSpec:
+    """Validate and return a five-DOF payload as ``FiveDOFSpec``.
+
+    :param payload: Candidate tagged JSON payload.
+    :return: Validated five-DOF specification.
+    """
     assert payload["format"] == "five_dof"
-    FiveDOFSpec(payload["params"])
+    assert payload["units"] == "radians"
+    return FiveDOFSpec(payload["params"])
 
 
-def test_axis_angle_outputs_five_dof_core_format():
-    payload = _run_cli_json(
+# --------------------------------------------------------------------------------------
+# Direct-script and basic command behavior
+# --------------------------------------------------------------------------------------
+
+
+def test_axis_angle_direct_script_outputs_five_dof_core_format():
+    result = _run_cli(
         "axis_angle",
         "--axis", 1, 1, 1,
         "--angle", 60,
         "--normal", 1, 1, 1,
     )
 
-    _assert_five_dof_payload(payload)
-    assert payload["units"] == "radians"
+    assert result.returncode == 0, result.stderr
+    payload = _decode_json_output(result.stdout, result.stderr)
+    spec = _assert_five_dof_payload(payload)
+
+    reconstructed = Rotation.from_euler("ZXZ", spec.params[:3]).as_matrix()
+    axis = np.ones(3) / np.sqrt(3.0)
+    expected = Rotation.from_rotvec(axis * np.deg2rad(60.0)).as_matrix()
+    np.testing.assert_allclose(reconstructed, expected, atol=1.0e-12)
 
 
-def test_orientation_outputs_five_dof_core_format():
-    payload = _run_cli_json(
+def test_orientation_outputs_five_dof_core_format(capsys):
+    payload = _run_main_json(
+        capsys,
         "orientation",
         "--P", 1, 0, 0, 0, 1, 0, 0, 0, 1,
-        "--Q", 0, 1, 0, 0, 0, 1, 1, 0, 0,
+        "--Q", 0, 1, 0, -1, 0, 0, 0, 0, 1,
     )
 
-    _assert_five_dof_payload(payload)
+    spec = _assert_five_dof_payload(payload)
+    reconstructed = Rotation.from_euler("ZXZ", spec.params[:3]).as_matrix()
+    np.testing.assert_allclose(
+        reconstructed,
+        np.array([[0, 1, 0], [-1, 0, 0], [0, 0, 1]], dtype=float),
+        atol=1.0e-12,
+    )
 
 
-def test_csl_outputs_exact_core_format():
-    payload = _run_cli_json(
+def test_axis_angle_human_output_reports_symbolic_multiple(capsys):
+    angle_deg = 2.0 * np.degrees(np.arctan(1.0 / 5.0))
+
+    assert gb_params.main(
+        [
+            "axis_angle",
+            "--axis", "0", "0", "1",
+            "--angle", str(angle_deg),
+            "--normal", "1", "0", "0",
+            "--format", "human",
+        ]
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert "GBOpt Misorientation Parameters" in output
+    assert "2*arctan(1/5)" in output
+    assert "PASS: inclination reproduces the boundary normal" in output
+
+
+# --------------------------------------------------------------------------------------
+# CSL commands
+# --------------------------------------------------------------------------------------
+
+
+def test_csl_outputs_exact_core_format(capsys):
+    payload = _run_main_json(
+        capsys,
         "csl",
         "--axis", 0, 0, 1,
         "--plane", 1, 0, 0,
@@ -103,7 +214,6 @@ def test_csl_outputs_exact_core_format():
 
     assert payload["format"] == "csl"
     assert payload["exact"] is True
-
     CSLExactSpec(
         axis=payload["axis"],
         plane=payload["plane"],
@@ -112,8 +222,9 @@ def test_csl_outputs_exact_core_format():
     )
 
 
-def test_csl_outputs_approximate_core_format():
-    payload = _run_cli_json(
+def test_csl_outputs_approximate_core_format(capsys):
+    payload = _run_main_json(
+        capsys,
         "csl",
         "--axis", 0, 0, 1,
         "--plane", 1, 0, 0,
@@ -122,7 +233,6 @@ def test_csl_outputs_approximate_core_format():
 
     assert payload["format"] == "csl"
     assert payload["exact"] is False
-
     CSLApproxSpec(
         axis=payload["axis"],
         plane=payload["plane"],
@@ -130,37 +240,40 @@ def test_csl_outputs_approximate_core_format():
     )
 
 
-def test_convert_exact_csl_outputs_pq_core_format():
-    source = {
-        "format": "csl",
-        "exact": True,
-        "axis": [0, 0, 1],
-        "plane": [1, 0, 0],
-        "quat": [2, 0, 0, 1],
-        "sigma": 5,
-    }
+def test_csl_rejects_sigma_mismatch(capsys):
+    stderr = _run_main_error(
+        capsys,
+        "csl",
+        "--axis", 0, 0, 1,
+        "--plane", 1, 0, 0,
+        "--quat", 2, 0, 0, 1,
+        "--sigma", 13,
+    )
 
-    payload = _run_cli_json(
+    assert "Sigma mismatch" in stderr
+
+
+# --------------------------------------------------------------------------------------
+# Core-format conversion
+# --------------------------------------------------------------------------------------
+
+
+def test_convert_exact_csl_outputs_pq_core_format(capsys):
+    payload = _run_main_json(
+        capsys,
         "convert",
-        "--to",
-        "pq",
-        "--input-json",
-        json.dumps(source),
+        "--to", "pq",
+        "--input-json", json.dumps(EXACT_CSL_SOURCE),
     )
 
     assert payload["format"] == "pq"
-
-    PQSpec(
-        payload["P"],
-        payload["Q"],
-        basis_mode=payload["basis_mode"],
-    )
+    PQSpec(payload["P"], payload["Q"], basis_mode=payload["basis_mode"])
 
     source_spec = CSLExactSpec(
-        axis=source["axis"],
-        plane=source["plane"],
-        quat=source["quat"],
-        sigma=source["sigma"],
+        axis=EXACT_CSL_SOURCE["axis"],
+        plane=EXACT_CSL_SOURCE["plane"],
+        quat=EXACT_CSL_SOURCE["quat"],
+        sigma=EXACT_CSL_SOURCE["sigma"],
     )
     embedding = csl_exact_spec_to_embedding(source_spec)
 
@@ -170,57 +283,262 @@ def test_convert_exact_csl_outputs_pq_core_format():
     assert payload["Q"] == _matrix_payload(embedding.Q)
 
 
-def test_exactify_reports_stage_e_hook():
-    payload = _run_cli_json(
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param(EXACT_CSL_SOURCE, id="exact-csl"),
+        pytest.param(APPROXIMATE_CSL_SOURCE, id="approximate-csl"),
+        pytest.param(IDENTITY_PQ_SOURCE, id="pq"),
+    ],
+)
+def test_convert_supported_sources_to_five_dof(capsys, source):
+    payload = _run_main_json(
+        capsys,
+        "convert",
+        "--to", "five_dof",
+        "--input-json", json.dumps(source),
+    )
+
+    _assert_five_dof_payload(payload)
+
+
+def test_convert_same_format_normalizes_five_dof_payload(capsys):
+    source = {
+        "format": "five_dof",
+        "params": [-0.0, 1.0e-16, 0.25, -0.5, 1.0],
+    }
+
+    payload = _run_main_json(
+        capsys,
+        "convert",
+        "--to", "five_dof",
+        "--input-json", json.dumps(source),
+    )
+
+    assert payload == {
+        "format": "five_dof",
+        "params": [0.0, 0.0, 0.25, -0.5, 1.0],
+        "units": "radians",
+    }
+
+
+def test_convert_same_pq_format_preserves_large_integers(capsys):
+    large = 2**53 + 1
+    source = {
+        "format": "pq",
+        "P": [[large, 0, 0], [0, 1, 0], [0, 0, 1]],
+        "Q": [[large, 0, 0], [0, 1, 0], [0, 0, 1]],
+        "basis_mode": "supplied",
+    }
+
+    payload = _run_main_json(
+        capsys,
+        "convert",
+        "--to", "pq",
+        "--input-json", json.dumps(source),
+    )
+
+    assert payload["P"][0][0] == large
+    assert payload["Q"][0][0] == large
+    assert isinstance(payload["P"][0][0], int)
+
+
+def test_convert_accepts_unambiguous_legacy_csl_payload_without_exact(capsys):
+    source = dict(EXACT_CSL_SOURCE)
+    source.pop("exact")
+
+    payload = _run_main_json(
+        capsys,
+        "convert",
+        "--to", "five_dof",
+        "--input-json", json.dumps(source),
+    )
+
+    _assert_five_dof_payload(payload)
+
+
+@pytest.mark.parametrize(
+    ("source", "message"),
+    [
+        pytest.param(
+            {
+                "format": "csl",
+                "exact": True,
+                "axis": [0, 0, 1],
+                "plane": [1, 0, 0],
+                "angle_deg": 30.0,
+            },
+            "exact csl payload requires 'quat'",
+            id="exact-with-angle",
+        ),
+        pytest.param(
+            {
+                "format": "csl",
+                "exact": False,
+                "axis": [0, 0, 1],
+                "plane": [1, 0, 0],
+                "quat": [2, 0, 0, 1],
+            },
+            "approximate csl payload requires 'angle_deg'",
+            id="approximate-with-quaternion",
+        ),
+        pytest.param(
+            {
+                "format": "csl",
+                "axis": [0, 0, 1],
+                "plane": [1, 0, 0],
+                "quat": [2, 0, 0, 1],
+                "angle_deg": 30.0,
+            },
+            "exactly one of 'quat' or 'angle_deg'",
+            id="legacy-ambiguous",
+        ),
+        pytest.param(
+            {
+                "format": "csl",
+                "exact": "yes",
+                "axis": [0, 0, 1],
+                "plane": [1, 0, 0],
+                "quat": [2, 0, 0, 1],
+            },
+            "field 'exact' must be boolean",
+            id="nonboolean-discriminator",
+        ),
+    ],
+)
+def test_convert_rejects_contradictory_csl_payloads(capsys, source, message):
+    stderr = _run_main_error(
+        capsys,
+        "convert",
+        "--to", "five_dof",
+        "--input-json", json.dumps(source),
+    )
+
+    assert message in stderr
+
+
+def test_convert_rejects_noninteger_exact_pq_entry(capsys):
+    source = {
+        "format": "pq",
+        "P": [[1.5, 0, 0], [0, 1, 0], [0, 0, 1]],
+        "Q": [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+    }
+
+    stderr = _run_main_error(
+        capsys,
+        "convert",
+        "--to", "pq",
+        "--input-json", json.dumps(source),
+    )
+
+    assert "integer" in stderr
+
+
+def test_convert_rejects_boolean_sigma(capsys):
+    source = dict(EXACT_CSL_SOURCE, sigma=True)
+
+    stderr = _run_main_error(
+        capsys,
+        "convert",
+        "--to",
+        "five_dof",
+        "--input-json",
+        json.dumps(source),
+    )
+
+    assert "sigma must not be boolean" in stderr
+
+
+# --------------------------------------------------------------------------------------
+# Input sources and command errors
+# --------------------------------------------------------------------------------------
+
+
+def test_convert_reads_payload_from_file(capsys, tmp_path):
+    input_file = tmp_path / "boundary.json"
+    input_file.write_text(json.dumps(FIVE_DOF_ZERO_SOURCE), encoding="utf-8")
+
+    payload = _run_main_json(
+        capsys,
+        "convert",
+        "--to", "five_dof",
+        "--input-file", input_file,
+    )
+
+    _assert_five_dof_payload(payload)
+
+
+def test_convert_reads_payload_from_standard_input(capsys, monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(FIVE_DOF_ZERO_SOURCE)))
+
+    payload = _run_main_json(capsys, "convert", "--to", "five_dof")
+
+    _assert_five_dof_payload(payload)
+
+
+def test_convert_rejects_malformed_json(capsys):
+    stderr = _run_main_error(
+        capsys,
+        "convert",
+        "--to", "five_dof",
+        "--input-json", "{not-json}",
+    )
+
+    assert "Expecting property name" in stderr
+
+
+def test_exactify_reports_unavailable_operation_as_error(capsys):
+    stderr = _run_main_error(
+        capsys,
         "exactify",
         "--params", 0, 0, 0, 0, 0,
     )
 
-    assert payload["status"] == "not_implemented"
-    assert "Stage E" in payload["message"]
+    assert "exactification is not implemented" in stderr
 
 
-def test_convert_five_dof_to_pq_reports_exactification_gap():
-    result = _run_cli(
+def test_convert_five_dof_to_pq_reports_exactification_gap(capsys):
+    stderr = _run_main_error(
+        capsys,
         "convert",
-        "--to",
-        "pq",
-        "--input-json",
-        json.dumps(FIVE_DOF_ZERO_SOURCE),
+        "--to", "pq",
+        "--input-json", json.dumps(FIVE_DOF_ZERO_SOURCE),
     )
 
-    assert result.returncode != 0
-    assert "five_dof exactification" in result.stderr
-    assert "not yet implemented" in result.stderr
+    assert "exactification" in stderr
+    assert "not implemented" in stderr
 
 
-def test_convert_rejects_unsupported_csl_target_at_parse_time():
-    result = _run_cli(
+def test_convert_rejects_unsupported_csl_target_at_parse_time(capsys):
+    stderr = _run_main_error(
+        capsys,
         "convert",
-        "--to",
-        "csl",
-        "--input-json",
-        json.dumps(FIVE_DOF_ZERO_SOURCE),
+        "--to", "csl",
+        "--input-json", json.dumps(FIVE_DOF_ZERO_SOURCE),
     )
 
-    assert result.returncode != 0
-    assert "invalid choice: 'csl'" in result.stderr
+    assert "invalid choice: 'csl'" in stderr
 
 
-def test_canonicalize_outputs_canonical_pq_core_format():
-    P = np.diag([2.0, 3.0, 4.0])
-    Q = np.diag([2.0, 3.0, 4.0])
+# --------------------------------------------------------------------------------------
+# Canonicalization
+# --------------------------------------------------------------------------------------
 
-    payload = _run_cli_json(
+
+def test_canonicalize_outputs_paired_canonical_pq_core_format(capsys):
+    P = np.array([[0, 0, 1], [2, 1, 0], [-1, 2, 0]], dtype=object)
+    Q = np.array([[0, 0, 1], [1, 2, 0], [-2, 1, 0]], dtype=object)
+
+    payload = _run_main_json(
+        capsys,
         "canonicalize",
-        "--P",
-        *P.ravel(),
-        "--Q",
-        *Q.ravel(),
+        "--P", *P.ravel(),
+        "--Q", *Q.ravel(),
     )
 
-    expected_P, expected_Q = canonicalize_pq(P, Q)
+    expected_P, expected_Q = canonicalize_pq_paired(P, Q)
 
     assert payload["format"] == "pq"
+    assert payload["basis_mode"] == "primitive"
     assert payload["P"] == _matrix_payload(expected_P)
     assert payload["Q"] == _matrix_payload(expected_Q)

--- a/tests/test_gb_params.py
+++ b/tests/test_gb_params.py
@@ -28,6 +28,15 @@ class TestGBParamsCLI(unittest.TestCase):
         )
         return json.loads(result.stdout)
 
+    def run_cli_error(self, *args):
+        return subprocess.run(
+            [sys.executable, str(self.script), *map(str, args)],
+            cwd=self.repo_root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
     @staticmethod
     def matrix_payload(matrix):
         arr = np.asarray(matrix, dtype=float)
@@ -119,6 +128,33 @@ class TestGBParamsCLI(unittest.TestCase):
 
         self.assertEqual(payload["status"], "not_implemented")
         self.assertIn("Stage E", payload["message"])
+
+    def test_convert_five_dof_to_pq_reports_exactification_gap(self):
+        source = {
+            "format": "five_dof",
+            "params": [0, 0, 0, 0, 0],
+        }
+
+        result = self.run_cli_error(
+            "convert", "--to", "pq", "--input-json", json.dumps(source)
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("five_dof exactification", result.stderr)
+        self.assertIn("not yet implemented", result.stderr)
+
+    def test_convert_rejects_unsupported_csl_target_at_parse_time(self):
+        source = {
+            "format": "five_dof",
+            "params": [0, 0, 0, 0, 0],
+        }
+
+        result = self.run_cli_error(
+            "convert", "--to", "csl", "--input-json", json.dumps(source)
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid choice: 'csl'", result.stderr)
 
     def test_canonicalize_invokes_canonicalize_pq(self):
         P = np.array([[2, 0, 0], [0, 3, 0], [0, 0, 4]], dtype=float)

--- a/tests/test_gbmaker.py
+++ b/tests/test_gbmaker.py
@@ -713,6 +713,56 @@ def test_find_commensurate_pair_rejects_invalid_max_n(max_n):
         _find_commensurate_pair(1.0, 1.0, max_n=max_n)
 
 
+class TestGBMakerConstructorDeprecation(unittest.TestCase):
+    def _legacy_kwargs(self):
+        theta = math.radians(36.869898)
+        return {
+            "a0": 3.61,
+            "structure": "fcc",
+            "gb_thickness": 10.0,
+            "misorientation": np.array([theta, 0.0, 0.0, 0.0, -theta / 2.0]),
+            "atom_types": "Cu",
+            "repeat_factor": 2,
+            "x_dim_min": 30.0,
+            "vacuum": 10.0,
+            "interaction_distance": 1.0,
+            "gb_id": 1,
+        }
+
+    def test_legacy_constructor_emits_single_deprecation_warning(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            gbm = GBMaker(**self._legacy_kwargs())
+
+        deprecations = [
+            warning for warning in caught
+            if issubclass(warning.category, DeprecationWarning)
+            and "GBMaker(...)" in str(warning.message)
+        ]
+        self.assertEqual(len(deprecations), 1)
+        self.assertTrue(gbm.whole_system.size > 0)
+
+    def test_from_boundary_spec_does_not_emit_legacy_deprecation_warning(self):
+        from GBOpt.BoundarySpec import CSLApproxSpec
+
+        spec = CSLApproxSpec(axis=[0, 0, 1], plane=[1, 0, 0], angle_deg=36.87)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            gbm = GBMaker.from_boundary_spec(
+                3.61, "fcc", "Cu", spec, mode="approximate",
+                gb_thickness=10.0, repeat_factor=2, x_dim_min=30.0,
+                vacuum=10.0, interaction_distance=1.0, gb_id=1,
+            )
+
+        deprecations = [
+            warning for warning in caught
+            if issubclass(warning.category, DeprecationWarning)
+            and "GBMaker(...)" in str(warning.message)
+        ]
+        self.assertEqual(deprecations, [])
+        self.assertTrue(gbm.whole_system.size > 0)
+
+
 class TestGBMaker(unittest.TestCase):
     def setUp(self):
         # Common test setup

--- a/tests/test_gbmaker.py
+++ b/tests/test_gbmaker.py
@@ -493,7 +493,11 @@ def _build_non_csl_approximate_boundary() -> GBMaker:
 
 
 def test_non_csl_approximate_spec_builds_as_incoherent():
-    gb = _build_non_csl_approximate_boundary()
+    with pytest.warns(
+        UserWarning,
+        match=r"Gap equalization would remove all atoms from the right grain",
+    ):
+        gb = _build_non_csl_approximate_boundary()
 
     assert gb.whole_system.size > 0
     assert gb.inplane_periodic == (False, False)
@@ -502,7 +506,11 @@ def test_non_csl_approximate_spec_builds_as_incoherent():
 
 
 def test_non_csl_approximate_spec_caps_inplane_box():
-    gb = _build_non_csl_approximate_boundary()
+    with pytest.warns(
+        UserWarning,
+        match=r"Gap equalization would remove all atoms from the right grain",
+    ):
+        gb = _build_non_csl_approximate_boundary()
 
     assert gb.spacing["y"] <= 15.0 * gb.a0
     assert gb.spacing["z"] <= 15.0 * gb.a0
@@ -713,54 +721,69 @@ def test_find_commensurate_pair_rejects_invalid_max_n(max_n):
         _find_commensurate_pair(1.0, 1.0, max_n=max_n)
 
 
-class TestGBMakerConstructorDeprecation(unittest.TestCase):
-    def _legacy_kwargs(self):
-        theta = math.radians(36.869898)
-        return {
-            "a0": 3.61,
-            "structure": "fcc",
-            "gb_thickness": 10.0,
-            "misorientation": np.array([theta, 0.0, 0.0, 0.0, -theta / 2.0]),
-            "atom_types": "Cu",
-            "repeat_factor": 2,
-            "x_dim_min": 30.0,
-            "vacuum": 10.0,
-            "interaction_distance": 1.0,
-            "gb_id": 1,
-        }
+@pytest.fixture
+def compact_gbmaker_options():
+    return {
+        "gb_thickness": 10.0,
+        "repeat_factor": 2,
+        "x_dim_min": 30.0,
+        "vacuum": 10.0,
+        "interaction_distance": 1.0,
+        "gb_id": 1,
+    }
 
-    def test_legacy_constructor_emits_single_deprecation_warning(self):
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            gbm = GBMaker(**self._legacy_kwargs())
 
-        deprecations = [
-            warning for warning in caught
-            if issubclass(warning.category, DeprecationWarning)
-            and "GBMaker(...)" in str(warning.message)
-        ]
-        self.assertEqual(len(deprecations), 1)
-        self.assertTrue(gbm.whole_system.size > 0)
+def test_legacy_constructor_emits_single_deprecation_warning(
+    compact_gbmaker_options,
+):
+    theta = math.radians(36.869898)
 
-    def test_from_boundary_spec_does_not_emit_legacy_deprecation_warning(self):
-        from GBOpt.BoundarySpec import CSLApproxSpec
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"GBMaker\(\.\.\.\)",
+    ) as caught:
+        gbm = GBMaker(
+            a0=3.61,
+            structure="fcc",
+            misorientation=np.array(
+                [theta, 0.0, 0.0, 0.0, -theta / 2.0]
+            ),
+            atom_types="Cu",
+            **compact_gbmaker_options,
+        )
 
-        spec = CSLApproxSpec(axis=[0, 0, 1], plane=[1, 0, 0], angle_deg=36.87)
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            gbm = GBMaker.from_boundary_spec(
-                3.61, "fcc", "Cu", spec, mode="approximate",
-                gb_thickness=10.0, repeat_factor=2, x_dim_min=30.0,
-                vacuum=10.0, interaction_distance=1.0, gb_id=1,
-            )
+    assert len(caught) == 1
+    assert gbm.whole_system.size > 0
 
-        deprecations = [
-            warning for warning in caught
-            if issubclass(warning.category, DeprecationWarning)
-            and "GBMaker(...)" in str(warning.message)
-        ]
-        self.assertEqual(deprecations, [])
-        self.assertTrue(gbm.whole_system.size > 0)
+
+def test_from_boundary_spec_does_not_emit_legacy_deprecation_warning(
+    compact_gbmaker_options,
+    recwarn,
+):
+    spec = CSLApproxSpec(
+        axis=[0, 0, 1],
+        plane=[1, 0, 0],
+        angle_deg=36.87,
+    )
+
+    gbm = GBMaker.from_boundary_spec(
+        3.61,
+        "fcc",
+        "Cu",
+        spec,
+        mode="approximate",
+        **compact_gbmaker_options,
+    )
+
+    legacy_deprecations = [
+        warning
+        for warning in recwarn
+        if issubclass(warning.category, DeprecationWarning)
+        and "GBMaker(...)" in str(warning.message)
+    ]
+
+    assert not legacy_deprecations
+    assert gbm.whole_system.size > 0
 
 
 class TestGBMaker(unittest.TestCase):

--- a/tests/test_gbmaker.py
+++ b/tests/test_gbmaker.py
@@ -468,6 +468,47 @@ def test_invalid_public_mismatch_arguments_raise(kwargs, match):
 
 
 # --------------------------------------------------------------------------------------
+# Approximate incoherent interfaces
+# --------------------------------------------------------------------------------------
+
+
+def _build_non_csl_approximate_boundary() -> GBMaker:
+    spec = CSLApproxSpec(
+        axis=[0, 0, 1],
+        plane=[1, 0, 0],
+        angle_deg=17.3,
+    )
+    return GBMaker.from_boundary_spec(
+        3.615,
+        "fcc",
+        "Cu",
+        spec,
+        mode="approximate",
+        gb_thickness=0.0,
+        repeat_factor=2,
+        x_dim_min=8.0,
+        vacuum=5.0,
+        interaction_distance=1.0,
+    )
+
+
+def test_non_csl_approximate_spec_builds_as_incoherent():
+    gb = _build_non_csl_approximate_boundary()
+
+    assert gb.whole_system.size > 0
+    assert gb.inplane_periodic == (False, False)
+    assert gb._GBMaker__embedding is not None
+    assert gb._GBMaker__embedding.coherent is False
+
+
+def test_non_csl_approximate_spec_caps_inplane_box():
+    gb = _build_non_csl_approximate_boundary()
+
+    assert gb.spacing["y"] <= 15.0 * gb.a0
+    assert gb.spacing["z"] <= 15.0 * gb.a0
+
+
+# --------------------------------------------------------------------------------------
 # Commensurate-pair search
 # --------------------------------------------------------------------------------------
 

--- a/tests/test_gbmaker_from_boundary_spec.py
+++ b/tests/test_gbmaker_from_boundary_spec.py
@@ -174,7 +174,7 @@ def test_from_boundary_spec_rejects_exact_mode_for_cslapproxspec(build_gb):
 def test_from_boundary_spec_rejects_approximate_mode_for_exact_specs(build_gb, spec):
     with pytest.raises(
         NotImplementedError,
-        match=r"mode 'approximate' is not yet supported.*only mode='exact'",
+        match=r"mode 'approximate' is not yet supported.*mode='prefer_exact'",
     ):
         build_gb(spec, mode="approximate")
 

--- a/tests/test_gbmaker_from_boundary_spec.py
+++ b/tests/test_gbmaker_from_boundary_spec.py
@@ -146,7 +146,9 @@ def test_from_boundary_spec_equivalent_exact_specs_build_equivalent_bicrystals(
 # --------------------------------------------------------------------------------------
 
 
-def test_from_boundary_spec_approximate_csl_builds_finite_monatomic_bicrystal(build_gb):
+def test_from_boundary_spec_approximate_csl_builds_finite_incoherent_bicrystal(
+    build_gb
+):
     gb = build_gb(SIGMA5_TILT_APPROX_SPEC, mode="approximate")
 
     assert gb.left_grain.size > 0
@@ -154,7 +156,7 @@ def test_from_boundary_spec_approximate_csl_builds_finite_monatomic_bicrystal(bu
     assert gb.whole_system.size == gb.left_grain.size + gb.right_grain.size
     assert set(gb.whole_system["name"]) == {"Cu"}
     assert np.isfinite(_positions(gb.whole_system)).all()
-    assert gb.inplane_periodic == (True, True)
+    assert gb.inplane_periodic == (False, False)
 
 
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
### Summary
Completes the user-facing migration surface. Adds `FiveDOFSpec` with `mode="approximate"`
so existing five-DOF workflows can adopt the new API without re-expressing boundaries as
`PQSpec` or `CSLExactSpec`. Marks `CSLApproxSpec` as producing incoherent interfaces,
issues `DeprecationWarning` on the legacy `GBMaker` constructor, extends `gb_params` with
`convert` and `describe` subcommands, and migrates all repository examples to boundary-spec
inputs. Before this PR, legacy five-DOF users had no supported path forward under the new
API; after it, they do.

### Closes / References
Closes #48
Refs #42

*Note:* Depends on #55 

### Reviewer notes
- The `DeprecationWarning` on the legacy constructor (`2a9e0ae`) is intentional; existing
  tests that construct `GBMaker` directly will surface it, which is the desired signal
  prompting migration. Tests have been updated to expect the warning where needed.
- `cd8a999` migrates all `GBMaker(...)` call sites in `examples/` to the appropriate spec
  type; the boundaries themselves are unchanged, only the calling convention.