### PR TITLE
Five-DOF exactification and initial v0.2.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+All notable changes to GBOpt are documented in this file.
+
+## v0.2.0 — boundary-spec API and exact stoichiometric construction
+
+### Added
+
+- **BoundarySpec API** — `GBMaker.from_boundary_spec()` accepts structured spec objects
+  (`PQSpec`, `CSLExactSpec`, `CSLApproxSpec`, `FiveDOFSpec`) as an alternative to the
+  legacy positional-argument constructor.
+- **Exact stoichiometric construction** — `mode="exact"` (default for all spec types)
+  uses a period-aligned integer grain-filling pipeline that preserves crystallographic
+  plane completeness and eliminates stoichiometry failures in multi-component GBs.
+- **`inplane_periodic` coherence metadata** — `GBMaker` now exposes `inplane_periodic`
+  as a public property indicating whether the interface plane is coherent in-plane.
+- **First-class approximate mode** — `CSLApproxSpec` and `FiveDOFSpec(mode="approximate")`
+  support incoherent interfaces without requiring the boundary to be re-expressed as a
+  rational CSL.
+- **`exactify_five_dof`** — converts any cubic-CSL boundary expressed in five-DOF
+  notation to a `CSLExactSpec` at the nearest rational-CSL misorientation, allowing
+  legacy five-DOF inputs to participate in exact stoichiometric construction.
+- **`gb_params` CLI** — new `convert`, `describe`, `exactify`, and `canonicalize`
+  subcommands.
+- **Examples migration** — all `examples/` scripts updated from legacy `GBMaker(...)`
+  calls to the appropriate spec type.
+- **Supporting internals** — `BoundaryEmbedding` dataclass; `exact_csl.py` standalone
+  CSL arithmetic module; `prefer_exact` construction mode.
+
+### Fixed
+
+- Fluorite Σ5 stoichiometry and general multi-component GB stoichiometry failures
+  resolved by the exact integer filling path; `@pytest.mark.known_bug` removed from
+  `test_fluorite_stoichiometric`.
+
+### Deprecated
+
+- The legacy `GBMaker(a0, structure, gb_thickness, misorientation, atom_types, ...)`
+  positional constructor now issues a `DeprecationWarning`. Migrate to
+  `GBMaker.from_boundary_spec(<spec>)`. The legacy path will be removed in a future
+  release.
+
+### Known limitations
+
+- The exact construction path requires y- and z-box dimensions to be commensurate with
+  the chosen repeat periods; boundaries with irrational in-plane periodicities must use
+  `mode="approximate"`.
+- `exactify_five_dof` is limited to rationalizable cubic-CSL inputs; non-cubic lattices
+  and boundaries with no nearby rational misorientation are not yet supported.
+- Approximate-angle snapping and oblique in-plane periodicity vectors are deferred to a
+  future release.

--- a/GBOpt/BoundarySpec.py
+++ b/GBOpt/BoundarySpec.py
@@ -491,54 +491,59 @@ class CSLApproxSpec(_CSLSpecBase):
         object.__setattr__(self, "angle_deg", angle)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class PrimitiveCellMetadata:
     """Primitive boundary-defining cell metadata for exact embeddings.
 
-    Stores boundary-topology quantities produced by the CSL or PQ adapter, not crystal
-    structure data. ``UnitCell`` holds the atomic basis and lattice parameter; this
-    class holds boundary-level geometry: optional caller-input area provenance, minimal
-    primitive CSL area, optional returned orientation-row area, boundary-plane normal,
-    and exact rotation denominator.
+    Stores boundary-topology quantities produced by the CSL or P/Q adapters, not
+    crystal-structure data. ``UnitCell`` owns the atomic basis and lattice parameter;
+    this class records the primitive boundary-cell topology and provenance.
 
-    ``orientation_area_index`` describes the area of the returned
-    ``BoundaryEmbedding.P`` orientation rows when reported. It is descriptive only and is
-    not required to be an integer multiple of ``primitive_area_index`` because
-    orthogonal embeddings may use orientation rows rather than a CSL supercell basis.
+    ``input_reduction_index`` and ``conventional_cell_multiplier`` are derived
+    attributes. They are not constructor arguments:
 
-    :param basis_mode: ``"primitive"``or ``"supplied"`` construction path that produced
-        this metadata.
-    :param input_area_index: In-plane area index of caller-provided ``P`` rows, when
-        available.
+    * ``input_reduction_index`` is ``input_area_index // primitive_area_index`` when an
+      input area is available.
+    * ``conventional_cell_multiplier`` is ``2 * primitive_area_index``.
+
+    ``orientation_area_index`` describes the area index of the returned
+    ``BoundaryEmbedding.P`` rows when reported. It is descriptive only and need not be
+    an integer multiple of ``primitive_area_index`` because an orthogonal orientation
+    frame is not necessarily a primitive CSL basis.
+
+    :param basis_mode: Construction path that produced the metadata: ``"primitive"`` or
+        ``"supplied"``.
     :param primitive_area_index: Minimal in-plane area index of the primitive CSL cell.
-    :param input_reduction_index: ``input_area_index // primitive_area_index`` when
-        ``input_area_index`` is available; otherwise ``None``.
-    :param orientation_area_index: In-plane area index of the returned
-        ``BoundaryEmbedding.P`` rows, when useful to report.
     :param plane: Primitive boundary-plane normal ``(h, k, l)``.
-    :param rotation_denominator: Denominator ``N`` of the exact scaled rotation that
-        produced this boundary.
-    :param conventional_cell_multiplier: Atom-count multiplier ``2 *
-        primitive_area_index`` for converting a conventional-cell atom count to a
-        primitive bicrystal atom count.
+    :param rotation_denominator: Positive denominator ``N`` of the exact scaled rotation
+        that produced the boundary.
+    :param input_area_index: In-plane area index of caller-provided ``P`` rows, when
+        available. It must be an integer multiple of ``primitive_area_index``. Keyword
+        argument, optional, defaults to ``None``.
+    :param orientation_area_index: In-plane area index of the returned
+        ``BoundaryEmbedding.P`` rows, when useful to report. Keyword argument, optional,
+        defaults to ``None``.
+    :ivar input_reduction_index: Derived input-to-primitive area ratio, or ``None``.
+    :ivar conventional_cell_multiplier: Derived multiplier ``2 * primitive_area_index``.
     """
 
     basis_mode: Literal["primitive", "supplied"]
-    input_area_index: int | None
     primitive_area_index: int
-    input_reduction_index: int | None
-    orientation_area_index: int | None
     plane: tuple[int, int, int]
     rotation_denominator: int
-    conventional_cell_multiplier: int
+    input_area_index: int | None = None
+    orientation_area_index: int | None = None
+
+    input_reduction_index: int | None = field(init=False)
+    conventional_cell_multiplier: int = field(init=False)
 
     def __post_init__(self) -> None:
-        """Validate primitive-cell metadata consistency and normalize stored values.
+        """Validate inputs, normalize stored values, and derive dependent fields.
 
-        :raises BoundarySpecValueError: If basis_mode is invalid, if an area index is not
-            positive, if an area index is not a multiple of primitive_area_index, if a
-            reduction index is inconsistent with its area indices, or if
-            conventional_cell_multiplier is not twice primitive_area_index.
+        :raises BoundarySpecTypeError: If a field contains an invalid scalar type.
+        :raises BoundarySpecValueError: If ``basis_mode`` is invalid, an integer field
+            is nonpositive, ``plane`` is malformed or zero, or ``input_area_index`` is
+            not divisible by ``primitive_area_index``.
         """
         if self.basis_mode not in ("primitive", "supplied"):
             raise BoundarySpecValueError(
@@ -553,10 +558,6 @@ class PrimitiveCellMetadata:
         rotation_denominator = _validate_positive_integer(
             self.rotation_denominator,
             "PrimitiveCellMetadata.rotation_denominator",
-        )
-        conventional_cell_multiplier = _validate_positive_integer(
-            self.conventional_cell_multiplier,
-            "PrimitiveCellMetadata.conventional_cell_multiplier",
         )
         plane = _validate_nonzero_int_vector(
             self.plane,
@@ -574,38 +575,12 @@ class PrimitiveCellMetadata:
             if input_area_index % primitive_area_index != 0:
                 raise BoundarySpecValueError(
                     "PrimitiveCellMetadata.input_area_index must be an integer "
-                    "multiple of primitive_area_index."
+                    "multiple of primitive_area_index; got "
+                    f"input_area_index={input_area_index}, "
+                    f"primitive_area_index={primitive_area_index}."
                 )
-
-            expected_input_reduction_index = input_area_index // primitive_area_index
-            if self.input_reduction_index is None:
-                raise BoundarySpecValueError(
-                    "PrimitiveCellMetadata.input_reduction_index is required when "
-                    "input_area_index is provided."
-                )
-
-            input_reduction_index = _validate_positive_integer(
-                self.input_reduction_index,
-                "PrimitiveCellMetadata.input_reduction_index",
-            )
-            if input_reduction_index != expected_input_reduction_index:
-                raise BoundarySpecValueError(
-                    "PrimitiveCellMetadata.input_reduction_index must equal "
-                    "input_area_index // primitive_area_index; got "
-                    f"{input_reduction_index}, expected {expected_input_reduction_index}."
-                )
-        elif self.input_reduction_index is not None:
-            raise BoundarySpecValueError(
-                "PrimitiveCellMetadata.input_reduction_index must be None when "
-                "input_area_index is None."
-            )
-
-        expected_multiplier = 2 * primitive_area_index
-        if conventional_cell_multiplier != expected_multiplier:
-            raise BoundarySpecValueError(
-                "PrimitiveCellMetadata.conventional_cell_multiplier must equal "
-                f"2 * primitive_area_index; got {conventional_cell_multiplier}, "
-                f"expected {expected_multiplier}."
+            input_reduction_index = (
+                input_area_index // primitive_area_index
             )
 
         orientation_area_index = None
@@ -615,16 +590,36 @@ class PrimitiveCellMetadata:
                 "PrimitiveCellMetadata.orientation_area_index",
             )
 
-        object.__setattr__(self, "input_area_index", input_area_index)
-        object.__setattr__(self, "primitive_area_index", primitive_area_index)
-        object.__setattr__(self, "input_reduction_index", input_reduction_index)
-        object.__setattr__(self, "orientation_area_index", orientation_area_index)
+        object.__setattr__(
+            self,
+            "primitive_area_index",
+            primitive_area_index,
+        )
+        object.__setattr__(
+            self,
+            "rotation_denominator",
+            rotation_denominator,
+        )
         object.__setattr__(self, "plane", plane)
-        object.__setattr__(self, "rotation_denominator", rotation_denominator)
+        object.__setattr__(
+            self,
+            "input_area_index",
+            input_area_index,
+        )
+        object.__setattr__(
+            self,
+            "orientation_area_index",
+            orientation_area_index,
+        )
+        object.__setattr__(
+            self,
+            "input_reduction_index",
+            input_reduction_index,
+        )
         object.__setattr__(
             self,
             "conventional_cell_multiplier",
-            conventional_cell_multiplier,
+            2 * primitive_area_index,
         )
 
 

--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -23,8 +23,11 @@ from GBOpt.BoundarySpec import (
 from GBOpt.crystallography import (
     csl_approx_spec_to_embedding,
     csl_exact_spec_to_embedding,
+    exactify_five_dof,
+    five_dof_spec_to_embedding,
     pq_spec_to_embedding,
 )
+from GBOpt.crystallography.types import CrystallographyError
 from GBOpt.gbmaker_supercell import (
     build_supercell_matrix,
     enumerate_supercell_origins,
@@ -359,7 +362,7 @@ def _miller_row_norm(row: Sequence[object] | np.ndarray) -> float:
 
 
 _VALID_STRAIN_GRAIN = frozenset({"both", "left", "right"})
-_VALID_BOUNDARY_MODES = frozenset({"exact", "approximate"})
+_VALID_BOUNDARY_MODES = frozenset({"exact", "prefer_exact", "approximate"})
 
 
 class GBMaker:
@@ -567,7 +570,7 @@ class GBMaker:
         PQSpec        yes         planned; raises        yes
         CSLExactSpec  yes         planned; raises        yes
         CSLApproxSpec no; raises  yes                    warn -> yes
-        FiveDOFSpec   not yet     yes                    warn -> yes
+        FiveDOFSpec   cubic CSL   yes                    warn -> yes
         ============= =========== ====================== ============
 
         When ``mismatch_tol`` is ``None``, the shared in-plane simulation box is set
@@ -669,19 +672,22 @@ class GBMaker:
             embedding = csl_approx_spec_to_embedding(boundary)
 
         elif isinstance(boundary, FiveDOFSpec):
+            params = np.asarray(boundary.params, dtype=float)
+
             if mode == "exact":
                 try:
-                    P, Q = exactify_five_dof(np.asarray(boundary.params, dtype=float))
-                except NotImplementedError as exc:
-                    raise BoundarySpecError(
-                        "FiveDOFSpec exactification is not yet implemented; "
-                        "use mode='approximate' or mode='prefer_exact'."
-                    ) from exc
-                embedding = pq_spec_to_embedding(PQSpec(P=P, Q=Q))
+                    P, Q = exactify_five_dof(params)
+                except CrystallographyError as exc:
+                    raise BoundarySpecError(str(exc)) from exc
+
+                embedding = pq_spec_to_embedding(
+                    PQSpec(P=P, Q=Q, basis_mode="primitive")
+                )
+
             elif mode == "prefer_exact":
                 try:
-                    P, Q = exactify_five_dof(np.asarray(boundary.params, dtype=float))
-                except (BoundarySpecError, NotImplementedError) as exc:
+                    P, Q = exactify_five_dof(params)
+                except (BoundarySpecError, CrystallographyError) as exc:
                     warnings.warn(
                         "FiveDOFSpec exactification failed; falling back to "
                         f"mode='approximate'. Reason: {exc}",
@@ -690,7 +696,10 @@ class GBMaker:
                     )
                     embedding = five_dof_spec_to_embedding(boundary)
                 else:
-                    embedding = pq_spec_to_embedding(PQSpec(P=P, Q=Q))
+                    embedding = pq_spec_to_embedding(
+                        PQSpec(P=P, Q=Q, basis_mode="primitive")
+                    )
+
             else:
                 embedding = five_dof_spec_to_embedding(boundary)
 
@@ -801,10 +810,10 @@ class GBMaker:
     def __validate_boundary_mode(value: str) -> str:
         """Return a validated boundary-spec construction mode.
 
-        :param value: Boundary-spec construction mode. Supported values are ``"exact"``
-            and ``"approximate"``.
+        :param value: Boundary-spec construction mode. Supported values are
+            ``"exact"``, ``"approximate"``, and ``"prefer_exact"``.
         :return: Validated construction mode.
-        :raises GBMakerValueError: If ``value`` is not ``"exact"`` or ``"approximate"``.
+        :raises GBMakerValueError: If ``value`` is not one of the supported modes.
         """
         if not isinstance(value, str):
             raise GBMakerValueError(
@@ -3375,6 +3384,15 @@ class GBMaker:
     def inplane_periodic(self) -> tuple:
         """Read-only view of the in-plane periodicity flags (y, z)."""
         return tuple(bool(v) for v in self.__inplane_periodic)
+
+    @property
+    def uses_exact_construction(self) -> bool:
+        """Read-only flag indicating exact integer P/Q construction is active."""
+        return bool(
+            self.__embedding is not None
+            and self.__embedding.exact
+            and self.__embedding.P is not None
+        )
 
     @property
     def box_dims(self) -> np.ndarray:

--- a/GBOpt/GBMaker.py
+++ b/GBOpt/GBMaker.py
@@ -27,6 +27,10 @@ from GBOpt.crystallography import (
     five_dof_spec_to_embedding,
     pq_spec_to_embedding,
 )
+from GBOpt.crystallography._limits import (
+    DEFAULT_MAX_PQ_DETERMINANT,
+    DEFAULT_MAX_PRIMITIVE_AREA_INDEX,
+)
 from GBOpt.crystallography.types import CrystallographyError
 from GBOpt.gbmaker_supercell import (
     build_supercell_matrix,
@@ -550,6 +554,8 @@ class GBMaker:
         boundary: PQSpec | CSLExactSpec | CSLApproxSpec | FiveDOFSpec,
         mode: str = "exact",
         *,
+        max_primitive_area_index: int = DEFAULT_MAX_PRIMITIVE_AREA_INDEX,
+        max_pq_determinant: int = DEFAULT_MAX_PQ_DETERMINANT,
         gb_thickness: float = 0.0,
         repeat_factor: int | Sequence[int] = 2,
         x_dim_min: float = 50,
@@ -560,84 +566,106 @@ class GBMaker:
         mismatch_max_cells: int = 50,
         strain_grain: str = "both",
     ) -> GBMaker:
-        """Build a GBMaker from a boundary-spec dataclass.
+        """Build a grain boundary from a boundary-spec dataclass.
 
-        Supported boundary types and currently implemented construction modes are:
+        The supported boundary types and construction behavior are:
 
-        ============= =========== ====================== ============
-        Boundary type exact       approximate            prefer_exact
-        ============= =========== ====================== ============
-        PQSpec        yes         planned; raises        yes
-        CSLExactSpec  yes         planned; raises        yes
-        CSLApproxSpec no; raises  yes                    warn -> yes
-        FiveDOFSpec   cubic CSL   yes                    warn -> yes
-        ============= =========== ====================== ============
+        ================ ================ ================== =========================
+        Boundary type    ``exact``        ``approximate``    ``prefer_exact``
+        ================ ================ ================== =========================
+        ``PQSpec``       exact P/Q        not implemented    exact P/Q
+        ``CSLExactSpec`` exact CSL        not implemented    exact CSL
+        ``CSLApproxSpec`` rejected        approximate        warning, then approximate
+        ``FiveDOFSpec``  exactify or fail approximate        exactify; warning fallback
+        ================ ================ ================== =========================
 
-        When ``mismatch_tol`` is ``None``, the shared in-plane simulation box is set
-        from ``repeat_factor`` and the larger left/right in-plane period along each
-        in-plane axis. Exact construction requires the resulting box length to be
-        commensurate with both grains' in-plane periods; otherwise a
-        ``GBMakerValueError`` is raised.
+        For ``FiveDOFSpec``, exact construction is currently available only when the
+        floating-point boundary can be rationalized into a supported cubic CSL within
+        the configured exactification bounds and tolerances. Under ``mode="exact"``,
+        failure is reported as an exception. Under ``mode="prefer_exact"``, failure
+        emits a warning and uses the approximate orientation path.
 
-        When ``mismatch_tol`` is provided, GBMaker searches for integer repeat pairs
-        ``n_left*d_left ~= n_right*d_right`` within the requested tolerance, sets the
-        shared box from the chosen pair, and applies the requested lab-frame in-plane
-        strain policy. Exact construction raises ``GBMakerValueError`` if no
-        commensurate pair is found within ``mismatch_max_cells``. Approximate
-        construction emits a warning and falls back to the legacy repeat-factor box if
-        no commensurate pair is found.
+        ``max_primitive_area_index`` and ``max_pq_determinant`` are separate exact-cell
+        limits. The former bounds the minimal in-plane CSL topology where primitive
+        reconstruction is performed. It does not apply to
+        ``PQSpec(basis_mode="supplied")``. The latter bounds the absolute determinants
+        of the exact P/Q matrices used for grain construction. Both arguments are
+        validated as positive integers on every call, although they affect only
+        exact-construction paths.
 
-        :param a0: Crystal lattice parameter (Angstroms).
-        :param structure: Crystal structure string.
-        :param atom_types: Atom type string or tuple of atom type strings.
-        :param boundary: A boundary-spec dataclass. Currently supported values are
-            ``PQSpec``, ``CSLExactSpec``, ``CSLApproxSpec``, or ``FiveDOFSpec``.
-        :param mode: Construction mode - ``"exact"`` uses exact integer P/Q matrices
-            (requires ``PQSpec`` or ``CSLExactSpec``); ``"approximate"`` uses
-            floating-point rotation matrices (required for ``CSLApproxSpec`` and
-            ``FiveDOFSpec``). ``"prefer_exact"`` uses exact construction when available
-            and warns before falling back to approximate construction otherwise.
-            Optional, defaults to ``"exact"``.
-        :param gb_thickness: Width of the GB region (Angstroms). Keyword parameter,
-            optional, defaults tp ``0.0``.
-        :param repeat_factor: In-plane repeat factor or repeat factors. A single integer
-            applies to both in-plane axes; a two-value sequence applies to y and z
-            respectively. Keyword parameter, optional, defaults to ``2``.
-        :param x_dim_min: Minimum  size of one grain in the x dimension (Angstroms).
-            Keyword parameter, optional, defaults to ``50``.
-        :param vacuum: Vacuum thickness around the grains the x dimension (Angstroms).
-            Keyword parameter, optional, defaults to ``10``.
-        :param interaction_distance: Maximum atom interaction distance (Angstroms).
-            Keyword parameter, optional, defaults to ``15.0``.
-        :param gb_id: Grain boundary identifier. Keyword parameter, optional, defaults
-            to ``1``.
-        :param mismatch_tol: Maximum allowed relative mismatch for commensurate in-plane
-            repeat search. ``None`` disables mismatch accommodation. For example,
-            ``0.005`` permits 0.5% mismatch. Keyword parameter, optional, defaults to
-            ``None``.
+        When ``mismatch_tol`` is ``None``, the shared in-plane simulation box is derived
+        from ``repeat_factor`` and the larger left/right period along each in-plane
+        axis. Exact construction requires that box to be commensurate with both grains.
+
+        When ``mismatch_tol`` is provided, integer repeat pairs satisfying ``n_left *
+        d_left ~= n_right * d_right`` are searched up to ``mismatch_max_cells``. The
+        resulting lengths are reconciled according to ``strain_grain``. Exact
+        construction fails when no admissible pair exists; approximate construction
+        warns and falls back to the repeat-factor box.
+
+        :param a0: Crystal lattice parameter in Angstroms.
+        :param structure: Crystal structure name. Supported values are ``"fcc"``,
+            ``"bcc"``, ``"sc"``, ``"diamond"``, ``"fluorite"``, ``"rocksalt"``, and
+            ``"zincblende"``.
+        :param atom_types: Atom type string or tuple of atom type strings accepted by
+            ``UnitCell``.
+        :param boundary: Boundary specification to construct. Supported values are
+            ``PQSpec``, ``CSLExactSpec``, ``CSLApproxSpec``, and ``FiveDOFSpec``.
+        :param mode: Construction policy: ``"exact"``, ``"approximate"``, or
+            ``"prefer_exact"``. Optional, defaults to ``"exact"``.
+        :param max_primitive_area_index: Maximum permitted minimal in-plane CSL area
+            index for exact primitive reconstruction. This limit does not apply to
+            supplied-mode P/Q embeddings. Keyword argument, optional, defaults to
+            ``10000``.
+        :param max_pq_determinant: Maximum permitted absolute determinant of each exact
+            P/Q matrix used for construction. Keyword argument, optional, defaults to
+            ``10000``.
+        :param gb_thickness: Width of the grain-boundary region in Angstroms. Keyword
+            argument, optional, defaults to ``0.0``.
+        :param repeat_factor: In-plane repeat factor. A single integer applies to both
+            in-plane axes; a two-value sequence applies to y and z respectively. Keyword
+            argument, optional, defaults to ``2``.
+        :param x_dim_min: Minimum size of one grain along x in Angstroms. Keyword
+            argument, optional, defaults to ``50``.
+        :param vacuum: Vacuum thickness around the bicrystal along x in Angstroms.
+            Keyword argument, optional, defaults to ``10``.
+        :param interaction_distance: Maximum atom interaction distance in Angstroms.
+            In-plane dimensions are enlarged when necessary to satisfy twice this
+            distance. Keyword argument, optional, defaults to ``15.0``.
+        :param gb_id: Grain-boundary identifier. Keyword argument, optional, defaults to
+            ``1``.
+        :param mismatch_tol: Maximum permitted relative mismatch for the in-plane
+            commensurate-repeat search. ``None`` disables mismatch accommodation. For
+            example, ``0.005`` permits 0.5 percent mismatch. Keyword argument, optional,
+            defaults to ``None``.
         :param mismatch_max_cells: Maximum repeat count allowed for either grain in each
-            one-dimensional commensurability search. Keyword parameter, optional,
+            one-dimensional commensurability search. Keyword argument, optional,
             defaults to ``50``.
-        :param strain_grain: Grain strain policy used when mismatch accommodation is
-            active. ``"both"`` sets each in-plane box length to the average of the left
-            and right unstrained lengths; ``"left"`` preserves the right-grain length
-            and strains the left grain; ``"right"`` preserves the left-grain length and
-            strains the right grain. Ignored when ``mismatch_tol`` is ``None``. Keyword
-            parameter, optional, defaults to ``"both"``.
-        :return: Fully initialized GBMaker instance.
-        :raises BoundarySpecError: If the requested construction is incompatible with
-            the supplied boundary-spec type, such as ``CSLApproxSpec`` with
-            ``mode="exact"``, or if boundary-spec conversion fails.
-        :raises GBMakerValueError: If ``mode`` is not a string, if ``mismatch_tol``,
-            ``mismatch_max_cells``, or ``strain_grain`` is invalid, or if exact
-            construction cannot produce a commensurate in-plane box.
-        :raises NotImplementedError: If the requested boundary-spec type or construction
-            mode is planned for the boundary-spec API but is not yet implemented.
+        :param strain_grain: In-plane strain policy when mismatch accommodation is
+            active. ``"both"`` uses the average unstrained length, ``"left"`` preserves
+            the right-grain length, and ``"right"`` preserves the left-grain length.
+            Ignored when ``mismatch_tol`` is ``None``. Keyword argument, optional,
+            defaults to ``"both"``.
+        :return: Fully initialized ``GBMaker`` instance.
+        :raises BoundarySpecError: If the requested mode is incompatible with the
+            boundary type, exact boundary conversion or exactification fails, an
+            exact-cell limit is exceeded, or another boundary-spec construction error
+            occurs.
+        :raises NotImplementedError: If the boundary type is unsupported or the
+            requested type/mode combination is recognized but not implemented.
         """
         mode = cls.__validate_boundary_mode(mode)
         mismatch_tol = cls.__validate_mismatch_tol(mismatch_tol)
         mismatch_max_cells = cls.__validate_mismatch_max_cells(mismatch_max_cells)
         strain_grain = cls.__validate_strain_grain(strain_grain)
+        max_primitive_area_index = cls.__validate_exact_limit(
+            max_primitive_area_index,
+            "max_primitive_area_index",
+        )
+        max_pq_determinant = cls.__validate_exact_limit(
+            max_pq_determinant,
+            "max_pq_determinant",
+        )
 
         if isinstance(boundary, PQSpec):
             if mode == "approximate":
@@ -645,7 +673,11 @@ class GBMaker:
                     f"Construction mode '{mode}' is not yet supported for PQSpec; "
                     f"use mode='exact' or mode='prefer_exact'."
                 )
-            embedding = pq_spec_to_embedding(boundary)
+            embedding = pq_spec_to_embedding(
+                boundary,
+                max_primitive_area_index=max_primitive_area_index,
+                max_pq_determinant=max_pq_determinant,
+            )
 
         elif isinstance(boundary, CSLExactSpec):
             if mode == "approximate":
@@ -653,7 +685,11 @@ class GBMaker:
                     f"Construction mode '{mode}' is not yet supported for CSLExactSpec; "
                     f"use mode='exact' or mode='prefer_exact'."
                 )
-            embedding = csl_exact_spec_to_embedding(boundary)
+            embedding = csl_exact_spec_to_embedding(
+                boundary,
+                max_primitive_area_index=max_primitive_area_index,
+                max_pq_determinant=max_pq_determinant,
+            )
 
         elif isinstance(boundary, CSLApproxSpec):
             if mode == "exact":
@@ -676,17 +712,27 @@ class GBMaker:
 
             if mode == "exact":
                 try:
-                    P, Q = exactify_five_dof(params)
+                    P, Q = exactify_five_dof(
+                        params,
+                        max_primitive_area_index=max_primitive_area_index,
+                        max_pq_determinant=max_pq_determinant,
+                    )
                 except CrystallographyError as exc:
                     raise BoundarySpecError(str(exc)) from exc
 
                 embedding = pq_spec_to_embedding(
-                    PQSpec(P=P, Q=Q, basis_mode="primitive")
+                    PQSpec(P=P, Q=Q, basis_mode="primitive"),
+                    max_primitive_area_index=max_primitive_area_index,
+                    max_pq_determinant=max_pq_determinant,
                 )
 
             elif mode == "prefer_exact":
                 try:
-                    P, Q = exactify_five_dof(params)
+                    P, Q = exactify_five_dof(
+                        params,
+                        max_primitive_area_index=max_primitive_area_index,
+                        max_pq_determinant=max_pq_determinant,
+                    )
                 except (BoundarySpecError, CrystallographyError) as exc:
                     warnings.warn(
                         "FiveDOFSpec exactification failed; falling back to "
@@ -697,7 +743,9 @@ class GBMaker:
                     embedding = five_dof_spec_to_embedding(boundary)
                 else:
                     embedding = pq_spec_to_embedding(
-                        PQSpec(P=P, Q=Q, basis_mode="primitive")
+                        PQSpec(P=P, Q=Q, basis_mode="primitive"),
+                        max_primitive_area_index=max_primitive_area_index,
+                        max_pq_determinant=max_pq_determinant,
                     )
 
             else:
@@ -826,6 +874,25 @@ class GBMaker:
             )
 
         return value
+
+    @staticmethod
+    def __validate_exact_limit(value: object, name: str) -> int:
+        """Return a validated positive exact-construction limit."""
+        if isinstance(value, (bool, np.bool_)) or not isinstance(
+            value,
+            (int, np.integer),
+        ):
+            raise GBMakerValueError(
+                f"{name} must be a positive integer; got {value!r}."
+            )
+
+        limit = int(value)
+        if limit <= 0:
+            raise GBMakerValueError(
+                f"{name} must be a positive integer; got {value!r}."
+            )
+
+        return limit
 
     @staticmethod
     def __reduce_integer_row(row: np.ndarray) -> np.ndarray:

--- a/GBOpt/Utils/gb_params.py
+++ b/GBOpt/Utils/gb_params.py
@@ -60,7 +60,7 @@ from GBOpt.crystallography.orientation import (
     validate_orientation_matrix,
 )
 from GBOpt.crystallography.pq import canonicalize_pq_paired
-from GBOpt.crystallography.types import CrystallographyValueError
+from GBOpt.crystallography.types import CrystallographyError
 
 if __package__ in (None, ""):
     repo_root = Path(__file__).resolve().parents[2]
@@ -660,19 +660,19 @@ def _convert_payload(
             )
             if embedding.P is None or embedding.Q is None:
                 raise ValueError("Exact CSL embedding did not provide P/Q matrices.")
-            return _pq_payload(PQSpec(embedding.P, embedding.Q, basis_mode="primitive"))
+            return _pq_payload(
+                PQSpec(
+                    embedding.P,
+                    embedding.Q,
+                    basis_mode="primitive"
+                )
+            )
 
         if isinstance(spec, FiveDOFSpec):
-            try:
-                P, Q = exactify_five_dof(
-                    np.asarray(spec.params, dtype=np.float64),
-                    max_exact_atoms=max_exact_atoms,
-                )
-            except NotImplementedError as exc:
-                raise ValueError(
-                    "Conversion from 'five_dof' to 'pq' requires five_dof "
-                    "exactification, which is not implemented."
-                ) from exc
+            P, Q = exactify_five_dof(
+                np.asarray(spec.params, dtype=np.float64),
+                max_exact_atoms=max_exact_atoms,
+            )
             return _pq_payload(PQSpec(P, Q, basis_mode="primitive"))
 
     raise ValueError(f"Conversion from {source!r} to {target!r} is not available.")
@@ -815,13 +815,10 @@ def _command_exactify(args: argparse.Namespace) -> int:
         exactification is not implemented.
     """
     five_dof = FiveDOFSpec(args.params)
-    try:
-        P, Q = exactify_five_dof(
-            np.asarray(five_dof.params, dtype=np.float64),
-            max_exact_atoms=args.max_exact_atoms,
-        )
-    except NotImplementedError as exc:
-        raise ValueError("five_dof exactification is not implemented.") from exc
+    P, Q = exactify_five_dof(
+        np.asarray(five_dof.params, dtype=np.float64),
+        max_exact_atoms=args.max_exact_atoms,
+    )
 
     _print_payload(_pq_payload(PQSpec(P, Q, basis_mode="primitive")))
     return 0
@@ -978,7 +975,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     exactify = subparsers.add_parser(
         "exactify",
-        help="Exactify five_dof parameters through the exactification hook.",
+        help="Exactify five_dof parameters to canonical P/Q when they describe a cubic CSL.",
     )
     exactify.add_argument(
         "--params",
@@ -1033,7 +1030,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return int(args.handler(args))
     except (
         BoundarySpecError,
-        CrystallographyValueError,
+        CrystallographyError,
         KeyError,
         OSError,
         ValueError,

--- a/GBOpt/Utils/gb_params.py
+++ b/GBOpt/Utils/gb_params.py
@@ -46,6 +46,10 @@ from GBOpt.BoundarySpec import (
     FiveDOFSpec,
     PQSpec,
 )
+from GBOpt.crystallography._limits import (
+    DEFAULT_MAX_PQ_DETERMINANT,
+    DEFAULT_MAX_PRIMITIVE_AREA_INDEX,
+)
 from GBOpt.crystallography.boundary import (
     csl_approx_spec_to_embedding,
     csl_exact_spec_to_embedding,
@@ -577,24 +581,34 @@ def _normalize_core_payload(
 def _embedding_from_spec(
     spec: FiveDOFSpec | PQSpec | CSLExactSpec | CSLApproxSpec,
     *,
-    max_exact_atoms: int,
+    max_primitive_area_index: int,
+    max_pq_determinant: int
 ) -> BoundaryEmbedding:
     """Convert a validated boundary specification to its package embedding.
 
     :param spec: Validated five-DOF, P/Q, exact CSL, or approximate CSL specification.
-    :param max_exact_atoms: Exact-cell size bound forwarded only to exact CSL embedding
-        construction. Keyword-only.
+    :param max_primitive_area_index: Bounds the minimal in-plane CSL area index.
+        Forwarded to exact CSL embedding only. Keyword argument, optional, defaults to
+        ``10000``.
+    :param max_pq_determinant: Bounds abs(det(P)) and abs(det(Q)) for both the selected
+        exact embedding and the final exactly paired P/Q matrices. Keyword argument,
+        optional, defaults to ``10000``.
     :return: Boundary embedding produced by the corresponding crystallography adapter.
     :raises TypeError: If ``spec`` has an unsupported type.
     """
     if isinstance(spec, FiveDOFSpec):
         return five_dof_spec_to_embedding(spec)
     if isinstance(spec, PQSpec):
-        return pq_spec_to_embedding(spec)
+        return pq_spec_to_embedding(
+            spec,
+            max_primitive_area_index=max_primitive_area_index,
+            max_pq_determinant=max_pq_determinant,
+        )
     if isinstance(spec, CSLExactSpec):
         return csl_exact_spec_to_embedding(
             spec,
-            max_exact_atoms=max_exact_atoms,
+            max_primitive_area_index=max_primitive_area_index,
+            max_pq_determinant=max_pq_determinant,
         )
     if isinstance(spec, CSLApproxSpec):
         return csl_approx_spec_to_embedding(spec)
@@ -623,7 +637,8 @@ def _convert_payload(
     payload: object,
     target: str,
     *,
-    max_exact_atoms: int = 10_000,
+    max_primitive_area_index: int = DEFAULT_MAX_PRIMITIVE_AREA_INDEX,
+    max_pq_determinant: int = DEFAULT_MAX_PQ_DETERMINANT,
 ) -> dict[str, Any]:
     """Convert a supported core-format payload to another representation.
 
@@ -633,8 +648,11 @@ def _convert_payload(
 
     :param payload: Input object in ``five_dof``, ``pq``, or ``csl`` core format.
     :param target: Requested output format, currently ``"five_dof"`` or ``"pq"``.
-    :param max_exact_atoms: Exact-cell size bound forwarded to exact CSL embedding and
-        five-DOF exactification operations. Keyword-only, defaults to ``10_000``.
+    :param max_primitive_area_index: Bounds the minimal in-plane CSL area index. Keyword
+        argument, optional, defaults to ``10000``.
+    :param max_pq_determinant: Bounds abs(det(P)) and abs(det(Q)) for both the selected
+        exact embedding and the final exactly paired P/Q matrices. Keyword argument,
+        optional, defaults to ``10000``.
     :return: Normalized JSON-safe payload in ``target`` format. If source and target are
         equal, the normalized source payload is returned.
     :raises ValueError: If ``target`` is unsupported, the requested conversion is
@@ -648,7 +666,8 @@ def _convert_payload(
     if target == "five_dof":
         embedding = _embedding_from_spec(
             spec,
-            max_exact_atoms=max_exact_atoms,
+            max_primitive_area_index=max_primitive_area_index,
+            max_pq_determinant=max_pq_determinant,
         )
         return _five_dof_payload(_five_dof_spec_from_embedding(embedding))
 
@@ -656,7 +675,8 @@ def _convert_payload(
         if isinstance(spec, CSLExactSpec):
             embedding = _embedding_from_spec(
                 spec,
-                max_exact_atoms=max_exact_atoms,
+                max_primitive_area_index=max_primitive_area_index,
+                max_pq_determinant=max_pq_determinant,
             )
             if embedding.P is None or embedding.Q is None:
                 raise ValueError("Exact CSL embedding did not provide P/Q matrices.")
@@ -671,7 +691,8 @@ def _convert_payload(
         if isinstance(spec, FiveDOFSpec):
             P, Q = exactify_five_dof(
                 np.asarray(spec.params, dtype=np.float64),
-                max_exact_atoms=max_exact_atoms,
+                max_primitive_area_index=max_primitive_area_index,
+                max_pq_determinant=max_pq_determinant,
             )
             return _pq_payload(PQSpec(P, Q, basis_mode="primitive"))
 
@@ -772,7 +793,7 @@ def _command_csl(args: argparse.Namespace) -> int:
 
     :param args: Parsed :class:`argparse.Namespace` exposing integer ``axis`` and
         ``plane`` vectors, exactly one of ``quat`` or ``angle``, optional ``sigma``, and
-        the ``max_exact_atoms`` bound.
+        the ``max_primitive_area_index`` and ``max_pq_determinant`` bounds.
     :return: Process status code ``0`` after successful validation and JSON emission.
     """
     spec = _build_csl_spec(
@@ -782,7 +803,11 @@ def _command_csl(args: argparse.Namespace) -> int:
         angle_deg=args.angle,
         sigma=args.sigma,
     )
-    _embedding_from_spec(spec, max_exact_atoms=args.max_exact_atoms)
+    _embedding_from_spec(
+        spec,
+        max_primitive_area_index=args.max_primitive_area_index,
+        max_pq_determinant=args.max_pq_determinant,
+    )
     _print_payload(_csl_payload(spec))
     return 0
 
@@ -791,7 +816,8 @@ def _command_convert(args: argparse.Namespace) -> int:
     """Handle the ``convert`` CLI subcommand.
 
     :param args: Parsed :class:`argparse.Namespace` exposing ``input_file``,
-        ``input_json``, target format ``to``, and ``max_exact_atoms``.
+        ``input_json``, target format ``to``, ``max_primitive_area_index`` and
+        ``max_pq_determinant``.
     :return: Process status code ``0`` after printing the converted JSON payload.
     """
     payload = _load_core_payload(args)
@@ -799,7 +825,8 @@ def _command_convert(args: argparse.Namespace) -> int:
         _convert_payload(
             payload,
             args.to,
-            max_exact_atoms=args.max_exact_atoms,
+            max_primitive_area_index=args.max_primitive_area_index,
+            max_pq_determinant=args.max_pq_determinant,
         )
     )
     return 0
@@ -809,7 +836,8 @@ def _command_exactify(args: argparse.Namespace) -> int:
     """Handle the ``exactify`` CLI subcommand.
 
     :param args: Parsed :class:`argparse.Namespace` exposing five floating-point
-        ``params`` in radians and the ``max_exact_atoms`` bound.
+        ``params`` in radians and the ``max_primitive_area_index`` and
+        ``max_pq_determinant`` bounds.
     :return: Process status code ``0`` after printing the exact P/Q payload.
     :raises ValueError: If parameters cannot be converted to floating point or
         exactification is not implemented.
@@ -817,7 +845,8 @@ def _command_exactify(args: argparse.Namespace) -> int:
     five_dof = FiveDOFSpec(args.params)
     P, Q = exactify_five_dof(
         np.asarray(five_dof.params, dtype=np.float64),
-        max_exact_atoms=args.max_exact_atoms,
+        max_primitive_area_index=args.max_primitive_area_index,
+        max_pq_determinant=args.max_pq_determinant,
     )
 
     _print_payload(_pq_payload(PQSpec(P, Q, basis_mode="primitive")))
@@ -959,7 +988,16 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     csl_kind.add_argument("--angle", type=float, metavar="DEG")
     csl.add_argument("--sigma", type=int, default=None)
-    csl.add_argument("--max-exact-atoms", type=int, default=10_000)
+    csl.add_argument(
+        "--max-primitive-area-index",
+        type=int,
+        default=DEFAULT_MAX_PRIMITIVE_AREA_INDEX,
+    )
+    csl.add_argument(
+        "--max-pq-determinant",
+        type=int,
+        default=DEFAULT_MAX_PQ_DETERMINANT,
+    )
     csl.set_defaults(handler=_command_csl)
 
     convert = subparsers.add_parser(
@@ -970,7 +1008,16 @@ def _build_parser() -> argparse.ArgumentParser:
     convert_input.add_argument("--input-json")
     convert_input.add_argument("--input-file")
     convert.add_argument("--to", choices=("five_dof", "pq"), required=True)
-    convert.add_argument("--max-exact-atoms", type=int, default=10_000)
+    convert.add_argument(
+        "--max-primitive-area-index",
+        type=int,
+        default=DEFAULT_MAX_PRIMITIVE_AREA_INDEX,
+    )
+    convert.add_argument(
+        "--max-pq-determinant",
+        type=int,
+        default=DEFAULT_MAX_PQ_DETERMINANT,
+    )
     convert.set_defaults(handler=_command_convert)
 
     exactify = subparsers.add_parser(
@@ -984,7 +1031,16 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar=("ALPHA", "BETA", "GAMMA", "THETA", "PHI"),
         required=True,
     )
-    exactify.add_argument("--max-exact-atoms", type=int, default=10_000)
+    exactify.add_argument(
+        "--max-primitive-area-index",
+        type=int,
+        default=DEFAULT_MAX_PRIMITIVE_AREA_INDEX,
+    )
+    exactify.add_argument(
+        "--max-pq-determinant",
+        type=int,
+        default=DEFAULT_MAX_PQ_DETERMINANT,
+    )
     exactify.set_defaults(handler=_command_exactify)
 
     canonicalize = subparsers.add_parser(

--- a/GBOpt/__init__.py
+++ b/GBOpt/__init__.py
@@ -1,5 +1,7 @@
 # Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
 
+__version__ = "0.2.0"
+
 from GBOpt.Atom import Atom
 from GBOpt.GBMaker import GBMaker
 from GBOpt.GBManipulator import GBManipulator

--- a/GBOpt/crystallography/__init__.py
+++ b/GBOpt/crystallography/__init__.py
@@ -4,7 +4,7 @@
 
 Import user-facing exact utilities from this package directly, for example::
 
-    from GBOpt.crystallography import csl_exact_spec_to_embedding, ``canonicalize_pq``
+    from GBOpt.crystallography import csl_exact_spec_to_embedding
 """
 
 from .boundary import (
@@ -30,7 +30,6 @@ from .orientation import (
     validate_orientation_matrix,
 )
 from .pq import (
-    canonicalize_pq,
     canonicalize_pq_paired,
     recover_exact_row_rotation_from_paired_pq,
 )
@@ -64,7 +63,6 @@ __all__ = [
     "inclination_from_normal",
     "normalize_direction",
     "validate_orientation_matrix",
-    "canonicalize_pq",
     "canonicalize_pq_paired",
     "recover_exact_row_rotation_from_paired_pq",
     "CoincidenceCheck",

--- a/GBOpt/crystallography/__init__.py
+++ b/GBOpt/crystallography/__init__.py
@@ -10,6 +10,7 @@ Import user-facing exact utilities from this package directly, for example::
 from .boundary import (
     csl_approx_spec_to_embedding,
     csl_exact_spec_to_embedding,
+    five_dof_spec_to_embedding,
     pq_spec_to_embedding,
     primitive_bicrystal_atom_count,
 )
@@ -49,6 +50,7 @@ from .types import (
 __all__ = [
     "csl_approx_spec_to_embedding",
     "csl_exact_spec_to_embedding",
+    "five_dof_spec_to_embedding",
     "pq_spec_to_embedding",
     "primitive_bicrystal_atom_count",
     "csl_from_scaled_rotation",

--- a/GBOpt/crystallography/__init__.py
+++ b/GBOpt/crystallography/__init__.py
@@ -1,11 +1,6 @@
 # Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
 
-"""Public exact boundary and CSL utilities.
-
-Import user-facing exact utilities from this package directly, for example::
-
-    from GBOpt.crystallography import csl_exact_spec_to_embedding
-"""
+"""Public crystallography types, boundary adapters, and construction utilities."""
 
 from .boundary import (
     csl_approx_spec_to_embedding,
@@ -28,6 +23,7 @@ from .orientation import (
     five_dof_from_orientation_matrices,
     inclination_from_normal,
     normalize_direction,
+    orientation_matrices_from_five_dof,
     validate_orientation_matrix,
 )
 from .pq import (
@@ -40,6 +36,11 @@ from .quaternion import (
 )
 from .types import (
     CoincidenceCheck,
+    CrystallographyBackendError,
+    CrystallographyDivisibilityError,
+    CrystallographyError,
+    CrystallographyNotImplementedError,
+    CrystallographyValueError,
     CSLResult,
     DSCBasis,
     InPlaneBasis,
@@ -48,31 +49,52 @@ from .types import (
 )
 
 __all__ = [
-    "csl_approx_spec_to_embedding",
-    "csl_exact_spec_to_embedding",
-    "five_dof_spec_to_embedding",
-    "pq_spec_to_embedding",
-    "primitive_bicrystal_atom_count",
-    "csl_from_scaled_rotation",
-    "dsc_basis",
-    "exactify_five_dof",
-    "build_mixed_orientations",
-    "build_symmetric_tilt_orientations",
-    "build_tilt_orientations",
-    "build_twist_orientations",
-    "five_dof_from_axis_angle",
-    "five_dof_from_orientation_matrices",
-    "inclination_from_normal",
-    "normalize_direction",
-    "validate_orientation_matrix",
-    "canonicalize_pq_paired",
-    "recover_exact_row_rotation_from_paired_pq",
-    "CoincidenceCheck",
-    "CSLResult",
-    "DSCBasis",
-    "InPlaneBasis",
+    # Exceptions
+    "CrystallographyError",
+    "CrystallographyValueError",
+    "CrystallographyBackendError",
+    "CrystallographyDivisibilityError",
+    "CrystallographyNotImplementedError",
+
+    # Result and domain types
     "ScaledRotation",
     "SmithDiagnostics",
+    "CSLResult",
+    "InPlaneBasis",
+    "DSCBasis",
+    "CoincidenceCheck",
+
+    # Boundary-spec adapters
+    "pq_spec_to_embedding",
+    "csl_exact_spec_to_embedding",
+    "csl_approx_spec_to_embedding",
+    "five_dof_spec_to_embedding",
+    "primitive_bicrystal_atom_count",
+
+    # CSL and DSC construction
+    "csl_from_scaled_rotation",
+    "dsc_basis",
+
+    # Exactification
+    "exactify_five_dof",
+
+    # Orientation construction and conversion
+    "normalize_direction",
+    "validate_orientation_matrix",
+    "build_tilt_orientations",
+    "build_symmetric_tilt_orientations",
+    "build_twist_orientations",
+    "build_mixed_orientations",
+    "inclination_from_normal",
+    "five_dof_from_axis_angle",
+    "five_dof_from_orientation_matrices",
+    "orientation_matrices_from_five_dof",
+
+    # P/Q operations
+    "canonicalize_pq_paired",
+    "recover_exact_row_rotation_from_paired_pq",
+
+    # Quaternion operations
     "normalize_integer_quaternion",
     "quaternion_to_scaled_rotation",
 ]

--- a/GBOpt/crystallography/_limits.py
+++ b/GBOpt/crystallography/_limits.py
@@ -1,0 +1,31 @@
+# Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
+
+"""Shared default limits for exact crystallographic construction.
+
+This private module centralizes user-facing default values that are shared across the
+crystallography adapters, five-DOF exactification, ``GBMaker``, and the ``gb_params``
+command-line interface.
+
+The constants define defaults only. Validation and enforcement remain with the entry
+point or construction layer that owns each invariant:
+
+* primitive CSL area-index enforcement belongs to ``embedding.py``;
+* exact P/Q determinant enforcement belongs to ``embedding.py``;
+* adapter-level exception translation belongs to ``boundary.py``;
+* command-line parsing belongs to ``gb_params.py``; and
+* ``GBMaker`` argument validation belongs to ``GBMaker.py``.
+
+The module is private and its constants are not part of
+``GBOpt.crystallography.__init__``.
+"""
+
+from __future__ import annotations
+
+DEFAULT_MAX_PRIMITIVE_AREA_INDEX: int = 10_000
+DEFAULT_MAX_PQ_DETERMINANT: int = 10_000
+
+
+__all__ = [
+    "DEFAULT_MAX_PRIMITIVE_AREA_INDEX",
+    "DEFAULT_MAX_PQ_DETERMINANT",
+]

--- a/GBOpt/crystallography/boundary.py
+++ b/GBOpt/crystallography/boundary.py
@@ -22,17 +22,21 @@ from GBOpt.BoundarySpec import (
     CSLExactSpec,
     FiveDOFSpec,
     PQSpec,
+    PrimitiveCellMetadata,
 )
 from GBOpt.Utils.integer_linalg import cross_int3
 
+from ._limits import (
+    DEFAULT_MAX_PQ_DETERMINANT,
+    DEFAULT_MAX_PRIMITIVE_AREA_INDEX,
+)
 from .csl import csl_from_scaled_rotation
 from .embedding import (
+    _exact_embedding_from_precomputed_csl,
     embedding_from_pq,
     embedding_from_rotation_rows,
-    exact_embedding_from_row_rotation_and_plane,
     orthogonal_embedding_from_row_rotation_and_plane,
     primitive_embedding_from_row_rotation,
-    primitive_metadata,
 )
 from .integer import row_gcd_reduce
 from .orientation import orientation_matrices_from_five_dof
@@ -42,32 +46,41 @@ from .pq import (
     recover_exact_row_rotation_from_paired_pq,
 )
 from .quaternion import quaternion_to_scaled_rotation
-from .types import CrystallographyValueError
+from .rotation import transpose_rotation_convention
+from .types import CrystallographyError, CrystallographyValueError
 
 
-def pq_spec_to_embedding(spec: PQSpec) -> BoundaryEmbedding:
-    """Convert a validated PQSpec to a BoundaryEmbedding.
+def pq_spec_to_embedding(
+    spec: PQSpec,
+    *,
+    max_primitive_area_index: int | None = None,
+    max_pq_determinant: int | None = None,
+) -> BoundaryEmbedding:
+    """Convert a validated ``PQSpec`` to a ``BoundaryEmbedding``.
 
-    ``spec.basis_mode`` controls how P/Q are interpreted:
+    ``spec.basis_mode`` controls how the P/Q matrices are interpreted.
 
-    * ``"primitive"`` requires paired P/Q rows that recover an exact row-convention
-      scaled rotation. The adapter attempts to rebuild the primitive in-plane CSL
-      embedding for that rotation and boundary plane. If the primitive in-plane CSL
-      basis cannot be represented as proper orthogonal GBMaker rotation rows, an exact
-      orthogonal embedding is used instead.
-    * ``"supplied"`` treats P/Q as the caller's supplied paired basis rows. Row
-      correspondence is preserved during canonicalization. Metadata is attached when an
-      exact row rotation can be recovered from the paired rows. In supplied mode,
-      ``exact=True`` means the returned P/Q define exact integer orientation rows and
-      proper left/right rotations. It does not imply that an exact paired row rotation
-      could be recovered; metadata is ``None`` when recovery is unavailable.
+    In ``"primitive"`` mode, the paired rows must recover an exact row-convention scaled
+    rotation. The adapter reconstructs the primitive in-plane CSL embedding for that
+    rotation and boundary plane. If that primitive representation cannot form proper
+    orthogonal orientation rows, an exact orthogonal embedding is used.
+
+    In ``"supplied"`` mode, the caller's paired basis rows are canonicalized without
+    primitive-cell reconstruction. Metadata is attached when an exact row rotation can
+    be recovered. An exact supplied-mode embedding does not imply that rotation recovery
+    succeeded; metadata is ``None`` when it did not.
 
     :param spec: Validated ``PQSpec`` instance.
+    :param max_primitive_area_index: Maximum permitted minimal in-plane CSL area index
+        during primitive reconstruction. This limit is not applied in ``"supplied"``
+        mode. Keyword argument, optional, defaults to ``None``.
+    :param max_pq_determinant: Maximum permitted absolute determinant of each returned
+        exact P/Q matrix. Keyword argument, optional, defaults to ``None``.
     :return: Canonical embedding with ``exact=True``, ``coherent=True``, and
         ``source="pq"``.
     :raises BoundarySpecError: If primitive mode cannot recover an exact paired
-        rotation, or if supplied-mode P/Q rows do not form proper rotations after row
-        normalization.
+        rotation, an exact-cell limit is exceeded, or supplied-mode rows do not produce
+        proper left- and right-grain rotations.
     """
     P_int = np.asarray(spec.P, dtype=object)
     Q_int = np.asarray(spec.Q, dtype=object)
@@ -91,6 +104,8 @@ def pq_spec_to_embedding(spec: PQSpec) -> BoundaryEmbedding:
                 plane_int,
                 source="pq",
                 input_area_index=input_area_index,
+                max_primitive_area_index=max_primitive_area_index,
+                max_pq_determinant=max_pq_determinant,
             )
         except BoundarySpecOrthogonalityError:
             return orthogonal_embedding_from_row_rotation_and_plane(
@@ -98,6 +113,8 @@ def pq_spec_to_embedding(spec: PQSpec) -> BoundaryEmbedding:
                 plane_int,
                 source="pq",
                 input_area_index=input_area_index,
+                max_primitive_area_index=max_primitive_area_index,
+                max_pq_determinant=max_pq_determinant,
             )
 
     # basis_mode == "supplied"
@@ -113,21 +130,26 @@ def pq_spec_to_embedding(spec: PQSpec) -> BoundaryEmbedding:
         input_area_index = inplane_area_index(P_int)
         orientation_area_index = inplane_area_index(P_canon)
 
-        metadata = primitive_metadata(
+        metadata = PrimitiveCellMetadata(
             basis_mode="supplied",
             input_area_index=input_area_index,
             primitive_area_index=orientation_area_index,
             orientation_area_index=orientation_area_index,
-            plane=row_gcd_reduce(P_canon[0]),
-            rotation_denominator=int(row_rotation.denominator),
+            plane=tuple(int(value) for value in row_gcd_reduce(P_canon[0])),
+            rotation_denominator=row_rotation.denominator,
         )
 
     try:
+        # For basis_mode="supplied", max_pq_determinant applies to the returned P/Q
+        # matrices; max_primitive_area_index does not apply because supplied mode
+        # intentionally does not replace the supplied rows with a reconstructed
+        # primitive CSL embedding.
         return embedding_from_pq(
             P_canon,
             Q_canon,
             source="pq",
             metadata=metadata,
+            max_pq_determinant=max_pq_determinant,
         )
     except BoundarySpecOrthogonalityError as exc:
         raise BoundarySpecError(
@@ -137,63 +159,78 @@ def pq_spec_to_embedding(spec: PQSpec) -> BoundaryEmbedding:
 
 
 def csl_exact_spec_to_embedding(
-    spec: CSLExactSpec, *, max_exact_atoms: int = 10_000
+    spec: CSLExactSpec,
+    *,
+    max_primitive_area_index: int = DEFAULT_MAX_PRIMITIVE_AREA_INDEX,
+    max_pq_determinant: int = DEFAULT_MAX_PQ_DETERMINANT,
 ) -> BoundaryEmbedding:
-    """Convert a validated ``CSLExactSpec`` to a ``BoundaryEmbedding``.
+    """Convert a validated exact CSL specification to an exact embedding.
 
-    Assumes cubic symmetry.
+    The specification's integer quaternion is converted to an exact row-convention
+    scaled rotation. Its column-convention transpose is then used to construct the CSL.
+    When ``spec.sigma`` is supplied, it is checked against the Sigma value derived from
+    that CSL.
 
-    Embedding path selection: if the rotation preserves the boundary plane, a primitive
-    paired embedding is attempted first via ``primitive_embedding_from_row_rotation``.
-    If that raises ``BoundarySpecOrthogonalityError``, or if the rotation does not
-    preserve the plane, the orthogonal fallback
-    ``orthogonal_embedding_from_row_rotation_and_plane`` is used instead.
+    Embedding-path selection reuses the already-constructed CSL. A primitive embedding
+    is attempted for a plane-preserving rotation; otherwise, or when the primitive rows
+    are not orthogonal, an exact orthogonal embedding is selected.
 
-    :param spec: A ``CSLExactSpec`` instance.
-    :param max_exact_atoms: Cell-size guard passed to the primitive and orthogonal
-        embedding constructors. Keyword argument, optional, defaults to ``10_000``.
-    :return: ``BoundaryEmbedding`` with ``exact=True``, ``coherent=True``, and
-        ``source="csl"``.
-    :raises BoundarySpecError: If quaternion conversion fails, or if the provided
-        ``sigma`` does not match the CSL sigma derived from the quaternion.
+    :param spec: Validated exact CSL boundary specification.
+    :param max_primitive_area_index: Maximum permitted minimal in-plane CSL area index.
+        Keyword argument, optional, defaults to ``DEFAULT_MAX_PRIMITIVE_AREA_INDEX``.
+    :param max_pq_determinant: Maximum permitted absolute determinant of each returned
+        exact P/Q matrix. Keyword argument, optional, defaults to
+        ``DEFAULT_MAX_PQ_DETERMINANT``.
+    :return: Exact coherent ``BoundaryEmbedding`` with ``source="csl"`` and
+        primitive-cell metadata.
+    :raises BoundarySpecError: If quaternion or CSL construction fails, ``spec.sigma``
+        does not match the derived Sigma value, exact embedding construction fails, or
+        an exact-cell limit is exceeded.
     """
     try:
-        rot = quaternion_to_scaled_rotation(tuple(spec.quat))
-    except CrystallographyValueError as exc:
+        row_rotation = quaternion_to_scaled_rotation(tuple(spec.quat))
+        column_rotation = transpose_rotation_convention(row_rotation)
+        csl = csl_from_scaled_rotation(column_rotation)
+    except CrystallographyError as exc:
         raise BoundarySpecError(str(exc)) from exc
 
-    if spec.sigma is not None:
-        quat_int = rot.quaternion
-        csl_sigma = csl_from_scaled_rotation(rot).sigma
-        if csl_sigma != int(spec.sigma):
-            raise BoundarySpecError(
-                f"Sigma mismatch: quaternion "
-                f"{list(quat_int)} "  # type: ignore[ty:invalid-argument-type]
-                f"gives {csl_sigma=}, but {spec.sigma=} was provided."
-            )
+    if spec.sigma is not None and csl.sigma != spec.sigma:
+        raise BoundarySpecError(
+            f"Sigma mismatch: quaternion {list(row_rotation.quaternion)} "
+            f"gives csl_sigma={csl.sigma}, but spec.sigma={spec.sigma} "
+            "was provided."
+        )
 
-    return exact_embedding_from_row_rotation_and_plane(
-        rot,
-        spec.plane,
-        source="csl",
-        max_exact_atoms=max_exact_atoms,
+    plane_int = row_gcd_reduce(
+        np.asarray(spec.plane, dtype=object)
     )
+
+    try:
+        return _exact_embedding_from_precomputed_csl(
+            row_rotation,
+            plane_int,
+            csl,
+            source="csl",
+            max_primitive_area_index=max_primitive_area_index,
+            max_pq_determinant=max_pq_determinant,
+        )
+    except CrystallographyError as exc:
+        raise BoundarySpecError(str(exc)) from exc
 
 
 def csl_approx_spec_to_embedding(spec: CSLApproxSpec) -> BoundaryEmbedding:
-    """Convert a ``CSLApproxSpec`` to a ``BoundaryEmbedding`` using the approximate
-    path.
+    """Convert a ``CSLApproxSpec`` to an approximate ``BoundaryEmbedding``.
 
-    Constructs floating-point ``R_left`` and ``R_right`` from the given plane and
-    axis/angle misorientation. ``P`` and ``Q`` are set to ``None`` because no exact
-    integer matrices are available.
+    Floating-point ``R_left`` and ``R_right`` matrices are constructed from the
+    specified boundary plane and axis-angle misorientation. ``P`` and ``Q`` are ``None``
+    because this path does not construct exact integer orientation matrices.
 
-    ``R_left`` is built so that its first row is the unit boundary-plane normal. The
-    remaining two rows are an integer null-basis direction of the plane and its
-    cross-product complement, giving a proper rotation. ``R_right = R_left @ R_mis``,
-    where ``R_mis`` is the rotation about the given axis by ``angle_deg``.
+    ``R_left`` is formed with the unit boundary-plane normal as its first row, an
+    integer null-basis direction as its second row, and their cross-product complement
+    as its third row. The right-grain orientation is then computed as ``R_left @
+    R_mis``.
 
-    :param spec: A ``CSLApproxSpec`` instance.
+    :param spec: Validated approximate CSL boundary specification.
     :return: ``BoundaryEmbedding`` with ``exact=False``, ``coherent=False``, and
         ``source="csl"``.
     """
@@ -226,22 +263,21 @@ def csl_approx_spec_to_embedding(spec: CSLApproxSpec) -> BoundaryEmbedding:
 def five_dof_spec_to_embedding(spec: FiveDOFSpec) -> BoundaryEmbedding:
     """Convert a validated ``FiveDOFSpec`` to an approximate embedding.
 
-    The boundary adapter translates the validated five-DOF specification into
-    floating-point row-orientation matrices through
-    :func:`orientation_matrices_from_five_dof`, then delegates ``BoundaryEmbedding``
-    construction and final rotation validation to :func:`embedding_from_rotation_rows`.
+    The validated five-DOF parameters are converted to floating-point left- and
+    right-grain row-orientation matrices by ``orientation_matrices_from_five_dof``.
+    Construction and final validation of the embedding are then delegated to
+    ``embedding_from_rotation_rows``.
 
-    Exactification is intentionally not attempted here. Five-DOF rationalization into
-    exact integer P/Q matrices belongs to the separate exactification path.
+    This adapter intentionally does not attempt exactification. Rationalization of
+    five-DOF values into exact integer P/Q matrices belongs to the separate
+    exactification path.
 
     :param spec: Validated five-DOF boundary specification containing ``[alpha, beta,
         gamma, theta, phi]`` in radians.
     :return: Approximate ``BoundaryEmbedding`` with ``P=None``, ``Q=None``,
         ``exact=False``, ``coherent=False``, and ``source="five_dof"``.
-    :raises BoundarySpecError: If the five-DOF values cannot be translated into proper
+    :raises BoundarySpecError: If the five-DOF values cannot be converted into proper
         floating-point orientation matrices.
-    :raises BoundarySpecOrthogonalityError: If the translated left or right rows do not
-        form a proper orientation matrix during embedding construction.
     """
     try:
         R_left, R_right = orientation_matrices_from_five_dof(spec.params)

--- a/GBOpt/crystallography/boundary.py
+++ b/GBOpt/crystallography/boundary.py
@@ -24,7 +24,6 @@ from GBOpt.BoundarySpec import (
     PQSpec,
     PrimitiveCellMetadata,
 )
-from GBOpt.Utils.integer_linalg import cross_int3
 
 from ._limits import (
     DEFAULT_MAX_PQ_DETERMINANT,
@@ -38,7 +37,7 @@ from .embedding import (
     orthogonal_embedding_from_row_rotation_and_plane,
     primitive_embedding_from_row_rotation,
 )
-from .integer import row_gcd_reduce
+from .integer import cross_int3, row_gcd_reduce
 from .orientation import orientation_matrices_from_five_dof
 from .plane import inplane_area_index, plane_null_basis
 from .pq import (
@@ -79,8 +78,9 @@ def pq_spec_to_embedding(
     :return: Canonical embedding with ``exact=True``, ``coherent=True``, and
         ``source="pq"``.
     :raises BoundarySpecError: If primitive mode cannot recover an exact paired
-        rotation, an exact-cell limit is exceeded, or supplied-mode rows do not produce
-        proper left- and right-grain rotations.
+        rotation, if supplied-mode P/Q rows do not form proper rotations after row
+        normalization, if an exact-cell limit is invalid, or if an exact-cell limit is
+        exceeded.
     """
     P_int = np.asarray(spec.P, dtype=object)
     Q_int = np.asarray(spec.Q, dtype=object)
@@ -95,29 +95,38 @@ def pq_spec_to_embedding(
                 "used as supplied basis rows instead."
             ) from exc
 
-        input_area_index = inplane_area_index(P_int)
-        plane_int = row_gcd_reduce(P_int[0])
+        try:
+            input_area_index = inplane_area_index(P_int)
+            plane_int = row_gcd_reduce(P_int[0])
+        except CrystallographyError as exc:
+            raise BoundarySpecError(str(exc)) from exc
 
         try:
-            return primitive_embedding_from_row_rotation(
-                row_rotation,
-                plane_int,
-                source="pq",
-                input_area_index=input_area_index,
-                max_primitive_area_index=max_primitive_area_index,
-                max_pq_determinant=max_pq_determinant,
-            )
-        except BoundarySpecOrthogonalityError:
-            return orthogonal_embedding_from_row_rotation_and_plane(
-                row_rotation,
-                plane_int,
-                source="pq",
-                input_area_index=input_area_index,
-                max_primitive_area_index=max_primitive_area_index,
-                max_pq_determinant=max_pq_determinant,
-            )
+            try:
+                return primitive_embedding_from_row_rotation(
+                    row_rotation,
+                    plane_int,
+                    source="pq",
+                    input_area_index=input_area_index,
+                    max_primitive_area_index=max_primitive_area_index,
+                    max_pq_determinant=max_pq_determinant,
+                )
+            except BoundarySpecOrthogonalityError:
+                return orthogonal_embedding_from_row_rotation_and_plane(
+                    row_rotation,
+                    plane_int,
+                    source="pq",
+                    input_area_index=input_area_index,
+                    max_primitive_area_index=max_primitive_area_index,
+                    max_pq_determinant=max_pq_determinant,
+                )
+        except CrystallographyError as exc:
+            raise BoundarySpecError(str(exc)) from exc
 
     # basis_mode == "supplied"
+    # doccheck: ignore=DOC115[CrystallographyValueError]
+    #   PQSpec validation guarantees exact nonsingular 3-by-3 integer matrices with no
+    #   zero rows
     P_canon, Q_canon = canonicalize_pq_paired(P_int, Q_int)
 
     metadata = None
@@ -127,15 +136,19 @@ def pq_spec_to_embedding(
         row_rotation = None
 
     if row_rotation is not None:
-        input_area_index = inplane_area_index(P_int)
-        orientation_area_index = inplane_area_index(P_canon)
+        try:
+            input_area_index = inplane_area_index(P_int)
+            orientation_area_index = inplane_area_index(P_canon)
+            plane = tuple(int(value) for value in row_gcd_reduce(P_canon[0]))
+        except CrystallographyError as exc:
+            raise BoundarySpecError(str(exc)) from exc
 
         metadata = PrimitiveCellMetadata(
             basis_mode="supplied",
             input_area_index=input_area_index,
             primitive_area_index=orientation_area_index,
             orientation_area_index=orientation_area_index,
-            plane=tuple(int(value) for value in row_gcd_reduce(P_canon[0])),
+            plane=plane,
             rotation_denominator=row_rotation.denominator,
         )
 
@@ -156,6 +169,8 @@ def pq_spec_to_embedding(
             "R_left or R_right derived from P/Q is not a proper rotation matrix. Ensure "
             "P/Q rows are mutually orthogonal integer Miller directions."
         ) from exc
+    except CrystallographyValueError as exc:
+        raise BoundarySpecError(str(exc)) from exc
 
 
 def csl_exact_spec_to_embedding(
@@ -201,6 +216,8 @@ def csl_exact_spec_to_embedding(
             "was provided."
         )
 
+    # doccheck: ignore=DOC115[CrystallographyValueError]
+    #   spec.plane is a validated nonzero integer three-vector
     plane_int = row_gcd_reduce(
         np.asarray(spec.plane, dtype=object)
     )
@@ -233,6 +250,8 @@ def csl_approx_spec_to_embedding(spec: CSLApproxSpec) -> BoundaryEmbedding:
     :param spec: Validated approximate CSL boundary specification.
     :return: ``BoundaryEmbedding`` with ``exact=False``, ``coherent=False``, and
         ``source="csl"``.
+    :raises BoundarySpecError: If the validated plane cannot be converted into a proper
+        approximate orientation embedding.
     """
     plane = np.asarray(spec.plane, dtype=float)
     plane_unit = plane / np.linalg.norm(plane)
@@ -241,9 +260,14 @@ def csl_approx_spec_to_embedding(spec: CSLApproxSpec) -> BoundaryEmbedding:
     axis_unit = axis / np.linalg.norm(axis)
     R_mis = Rotation.from_rotvec(axis_unit * np.deg2rad(spec.angle_deg)).as_matrix()
 
-    plane_int = row_gcd_reduce(np.asarray(spec.plane, dtype=object))
-    e1, _unused = plane_null_basis(plane_int)
-    e2 = row_gcd_reduce(np.asarray(cross_int3(plane_int, e1), dtype=object))
+    try:
+        plane_int = row_gcd_reduce(np.asarray(spec.plane, dtype=object))
+        e1, _unused = plane_null_basis(plane_int)
+        e2 = row_gcd_reduce(
+            np.asarray(cross_int3(plane_int, e1), dtype=object)
+        )
+    except CrystallographyError as exc:
+        raise BoundarySpecError(str(exc)) from exc
 
     e1_float = e1.astype(float)
     e2_float = e2.astype(float)

--- a/GBOpt/crystallography/boundary.py
+++ b/GBOpt/crystallography/boundary.py
@@ -29,13 +29,14 @@ from .csl import csl_from_scaled_rotation
 from .embedding import (
     embedding_from_pq,
     embedding_from_rotation_rows,
+    exact_embedding_from_row_rotation_and_plane,
     orthogonal_embedding_from_row_rotation_and_plane,
     primitive_embedding_from_row_rotation,
     primitive_metadata,
 )
 from .integer import row_gcd_reduce
 from .orientation import orientation_matrices_from_five_dof
-from .plane import inplane_area_index, plane_null_basis, rotation_preserves_plane
+from .plane import inplane_area_index, plane_null_basis
 from .pq import (
     canonicalize_pq_paired,
     recover_exact_row_rotation_from_paired_pq,
@@ -171,24 +172,9 @@ def csl_exact_spec_to_embedding(
                 f"gives {csl_sigma=}, but {spec.sigma=} was provided."
             )
 
-    plane_int = row_gcd_reduce(np.asarray(spec.plane, dtype=object))
-
-    if rotation_preserves_plane(rot, plane_int):
-        try:
-            return primitive_embedding_from_row_rotation(
-                rot,
-                plane_int,
-                source="csl",
-                max_exact_atoms=max_exact_atoms,
-            )
-        except BoundarySpecOrthogonalityError:
-            # Fall through to the orthogonal construction for plane-preserving rotations
-            # whose primitive in-plane CSL basis is not row-orthogonal.
-            pass
-
-    return orthogonal_embedding_from_row_rotation_and_plane(
+    return exact_embedding_from_row_rotation_and_plane(
         rot,
-        plane_int,
+        spec.plane,
         source="csl",
         max_exact_atoms=max_exact_atoms,
     )

--- a/GBOpt/crystallography/csl.py
+++ b/GBOpt/crystallography/csl.py
@@ -20,7 +20,13 @@ from GBOpt.Utils.integer_normal_forms import (
     smith_normal_form_3x3,
 )
 
-from .integer import as_int_array, as_int_vector, integer_adj3, integer_det3
+from .integer import (
+    as_int_array,
+    as_int_vector,
+    as_positive_int,
+    integer_adj3,
+    integer_det3,
+)
 from .reduction import lll_reduce
 from .types import (
     CoincidenceCheck,
@@ -51,11 +57,8 @@ def sigma_from_snf_diagonal(denominator: int, diagonal: Int3) -> tuple[int, Int3
         is the per-axis kernel modulus ``denominator / gcd(diagonal[i], denominator)``.
     :raises CrystallographyValueError: If ``denominator`` is not positive.
     """
-    denom = int(denominator)
-    if denom <= 0:
-        raise CrystallographyValueError(
-            f"denominator must be positive; got {denom}."
-        )
+    denom = as_positive_int(denominator, "denominator")
+
     diag = as_int_vector(diagonal, 3, "diagonal")
     m1, m2, m3 = (
         denom // math.gcd(abs(d), denom)
@@ -153,11 +156,7 @@ def dsc_basis(
             "non-cubic lattice bases are not implemented"
         )
     int_matrix = as_int_array(csl_basis, (3, 3), "csl_basis")
-    if not isinstance(sigma, (int, np.integer)) or sigma <= 0:
-        raise CrystallographyValueError(
-            f"sigma must be a positive integer; got {sigma}."
-        )
-    sigma = int(sigma)
+    sigma = as_positive_int(sigma, "sigma")
     det = integer_det3(int_matrix)
     abs_det = abs(det)
     if abs_det != sigma:
@@ -198,17 +197,11 @@ def verify_coincidence_basis(
     """
     int_rotation = as_int_array(rotation.matrix, (3, 3), "rotation.matrix")
     int_basis = as_int_array(csl_basis, (3, 3), "csl_basis")
-    denominator = int(rotation.denominator)
-    if denominator <= 0:
-        raise CrystallographyValueError(
-            f"rotation.denominator must be positive; got {rotation.denominator}."
-        )
+    denominator = rotation.denominator
+
     if sigma is not None:
-        if not isinstance(sigma, (int, np.integer)) or sigma <= 0:
-            raise CrystallographyValueError(
-                f"sigma must be a positive integer; got {sigma}."
-            )
-        sigma = int(sigma)
+        sigma = as_positive_int(sigma, "sigma")
+
     residual = (int_rotation @ int_basis) % denominator
     det_basis = abs(integer_det3(int_basis))
     ok = bool(np.all(residual == 0))

--- a/GBOpt/crystallography/embedding.py
+++ b/GBOpt/crystallography/embedding.py
@@ -25,7 +25,7 @@ from GBOpt.Utils.integer_linalg import cross_int3, dot_int
 from .csl import csl_from_scaled_rotation
 from .integer import as_int_array, integer_det3, row_gcd_reduce
 from .orientation import validate_orientation_matrix
-from .plane import inplane_area_index, inplane_basis_from_csl
+from .plane import inplane_area_index, inplane_basis_from_csl, rotation_preserves_plane
 from .pq import (
     canonicalize_pq_paired,
     recover_exact_row_rotation_from_paired_pq,
@@ -489,10 +489,68 @@ def orthogonal_embedding_from_row_rotation_and_plane(
     )
 
 
+def exact_embedding_from_row_rotation_and_plane(
+    row_rotation: ScaledRotation,
+    plane: np.ndarray,
+    *,
+    source: str,
+    input_area_index: int | None = None,
+    max_exact_atoms: int | None = None,
+) -> BoundaryEmbedding:
+    """Select an exact embedding path for a row rotation and boundary plane.
+
+    A primitive CSL embedding is attempted when ``row_rotation`` preserves the supplied
+    boundary plane. If the primitive rows do not form proper orthogonal orientation
+    frames, construction falls back to the orthogonal embedding path. Rotations that do
+    not preserve the plane use the orthogonal path directly.
+
+    Cell-size errors raised by either construction path are propagated rather than
+    causing a fallback.
+
+    :param row_rotation: Exact row-convention scaled rotation.
+    :param plane: Integer-valued boundary-plane normal in the reference grain.
+    :param source: Label identifying the upstream boundary representation. Keyword
+        argument, required.
+    :param input_area_index: In-plane area index of caller-supplied ``P`` rows, when
+        available. Keyword argument, optional, defaults to ``None``.
+    :param max_exact_atoms: Upper bound passed to the selected exact embedding
+        constructor. Keyword argument, optional, defaults to ``None``.
+    :return: Exact coherent ``BoundaryEmbedding`` constructed through the primitive path
+        when possible, otherwise through the orthogonal path.
+    :raises BoundarySpecError: If the selected exact embedding exceeds
+        ``max_exact_atoms`` or exact CSL construction otherwise fails.
+    :raises BoundarySpecOrthogonalityError: If the orthogonal fallback cannot produce
+        proper orientation frames.
+    :raises CrystallographyValueError: If ``plane`` is not a valid integer direction.
+    """
+    plane_int = row_gcd_reduce(np.asarray(plane, dtype=object))
+
+    if rotation_preserves_plane(row_rotation, plane_int):
+        try:
+            return primitive_embedding_from_row_rotation(
+                row_rotation,
+                plane_int,
+                source=source,
+                input_area_index=input_area_index,
+                max_exact_atoms=max_exact_atoms,
+            )
+        except BoundarySpecOrthogonalityError:
+            pass
+
+    return orthogonal_embedding_from_row_rotation_and_plane(
+        row_rotation,
+        plane_int,
+        source=source,
+        input_area_index=input_area_index,
+        max_exact_atoms=max_exact_atoms,
+    )
+
+
 __all__ = [
     "primitive_metadata",
     "embedding_from_pq",
     "embedding_from_rotation_rows",
     "primitive_embedding_from_row_rotation",
     "orthogonal_embedding_from_row_rotation_and_plane",
+    "exact_embedding_from_row_rotation_and_plane",
 ]

--- a/GBOpt/crystallography/embedding.py
+++ b/GBOpt/crystallography/embedding.py
@@ -41,7 +41,13 @@ from .rotation import (
     _scaled_row_images,
     transpose_rotation_convention,
 )
-from .types import CrystallographyValueError, CSLResult, InPlaneBasis, ScaledRotation
+from .types import (
+    CrystallographyError,
+    CrystallographyValueError,
+    CSLResult,
+    InPlaneBasis,
+    ScaledRotation,
+)
 
 
 def _validated_exact_orientation_rows(
@@ -280,7 +286,7 @@ def _csl_from_row_rotation(row_rotation: ScaledRotation) -> CSLResult:
     try:
         column_rotation = transpose_rotation_convention(row_rotation)
         return csl_from_scaled_rotation(column_rotation)
-    except CrystallographyValueError as exc:
+    except CrystallographyError as exc:
         raise BoundarySpecError(str(exc)) from exc
 
 
@@ -313,6 +319,7 @@ def _inplane_from_row_rotation(row_rotation: ScaledRotation, plane_int: np.ndarr
     :param row_rotation: Exact row-convention scaled rotation.
     :param plane_int: Primitive boundary-plane normal as a length-3 integer array.
     :return: In-plane CSL basis for the given plane.
+    :raises BoundarySpecError: If CSL construction or in-plane basis construction fails.
     """
     csl = _csl_from_row_rotation(row_rotation)
     return _inplane_from_csl(csl, plane_int)
@@ -341,6 +348,11 @@ def embedding_from_pq(
     :return: ``BoundaryEmbedding`` with ``exact=True``, ``coherent=True``, and
         ``source`` as supplied. ``R_left`` and ``R_right`` are constructed by
         normalizing and validating the rows of ``P_canon`` and ``Q_canon``.
+    :raises CrystallographyValueError: If ``max_pq_determinant`` is invalid or either
+        P/Q matrix fails exact integer validation.
+    :raises BoundarySpecError: If either P/Q determinant exceeds ``max_pq_determinant``.
+    :raises BoundarySpecOrthogonalityError: If the normalized P or Q rows do not form a
+        proper rotation frame.
     """
     _enforce_pq_determinant_limit(
         P_canon,
@@ -383,6 +395,8 @@ def embedding_from_rotation_rows(
         construction. Keyword argument, optional, defaults to ``True``.
     :return: Approximate ``BoundaryEmbedding`` with normalized ``R_left`` and
         ``R_right``, ``P=None``, ``Q=None``, and ``exact=False``.
+    :raises BoundarySpecOrthogonalityError: If either matrix is malformed, non-finite,
+        degenerate, nonorthogonal after row normalization, or not right-handed.
     """
     R_left = _validated_rotation_rows(R_left, "R_left")
     R_right = _validated_rotation_rows(R_right, "R_right")
@@ -434,6 +448,12 @@ def _primitive_embedding_from_inplane(
         defaults to ``None``.
     :return: Exact coherent primitive ``BoundaryEmbedding`` with primitive-cell
         metadata.
+    :raises CrystallographyValueError: If exact integer input, area-index calculation,
+        or limit validation fails.
+    :raises CrystallographyDivisibilityError: If an in-plane CSL direction does not have
+        an exactly integral image under ``row_rotation``.
+    :raises BoundarySpecError: If an exact-cell limit is exceeded or the resulting P/Q
+        matrices cannot form a valid embedding.
     """
     p1 = inplane.basis[:, 0]
     p2 = inplane.basis[:, 1]
@@ -501,6 +521,10 @@ def primitive_embedding_from_row_rotation(
         exact embedding and the final exactly paired P/Q matrices. Keyword argument,
         optional, defaults to ``None``.
     :return: Exact coherent ``BoundaryEmbedding`` with primitive-cell metadata.
+    :raises CrystallographyValueError: If the plane, exact integer data, or an exact
+        construction limit is malformed.
+    :raises BoundarySpecError: If CSL or in-plane construction fails, an exact-cell
+        limit is exceeded, or proper P/Q orientation frames cannot be constructed.
     """
     plane_int = row_gcd_reduce(np.asarray(plane, dtype=object))
     inplane = _inplane_from_row_rotation(row_rotation, plane_int)
@@ -553,6 +577,10 @@ def _orthogonal_embedding_from_inplane(
         defaults to ``None``.
     :return: Exact coherent orthogonal ``BoundaryEmbedding`` with primitive-cell
         metadata.
+    :raises CrystallographyValueError: If exact integer validation, basis reduction, or
+        area-index construction fails.
+    :raises BoundarySpecError: If an exact-cell limit is exceeded or the resulting P/Q
+        matrices cannot form a valid embedding.
     """
     v1 = inplane.basis[:, 0]
     v2 = inplane.basis[:, 1]
@@ -629,6 +657,10 @@ def orthogonal_embedding_from_row_rotation_and_plane(
         exact embedding and the final exactly paired P/Q matrices. Keyword argument,
         optional, defaults to ``None``.
     :return: Exact coherent ``BoundaryEmbedding`` with primitive-cell metadata.
+    :raises CrystallographyValueError: If the plane, exact integer data, or an exact
+        construction limit is malformed.
+    :raises BoundarySpecError: If CSL or in-plane construction fails, an exact-cell
+        limit is exceeded, or proper P/Q orientation frames cannot be constructed.
     """
     plane_int = row_gcd_reduce(np.asarray(plane_normal, dtype=object))
     inplane = _inplane_from_row_rotation(row_rotation, plane_int)
@@ -674,8 +706,10 @@ def _exact_embedding_from_precomputed_csl(
         optional, defaults to ``None``.
     :return: Exact coherent ``BoundaryEmbedding`` constructed through the primitive path
         when possible, otherwise through the orthogonal path.
-    :raises BoundarySpecOrthogonalityError: If the orthogonal path cannot produce proper
-        orientation frames.
+    :raises CrystallographyValueError: If exact plane, area, or P/Q construction data is
+        invalid.
+    :raises BoundarySpecError: If in-plane construction fails, an exact-cell limit is
+        exceeded, or neither embedding path can construct proper orientation frames.
     """
     inplane = _inplane_from_csl(csl, plane_int)
 
@@ -741,6 +775,10 @@ def exact_embedding_from_row_rotation_and_plane(
         optional, defaults to ``None``.
     :return: Exact coherent ``BoundaryEmbedding`` constructed through the primitive path
         when possible, otherwise through the orthogonal path.
+    :raises CrystallographyValueError: If the plane, exact integer data, or an exact
+        construction limit is malformed.
+    :raises BoundarySpecError: If CSL or in-plane construction fails, an exact-cell
+        limit is exceeded, or proper P/Q orientation frames cannot be constructed.
     """
     plane_int = row_gcd_reduce(np.asarray(plane, dtype=object))
     csl = _csl_from_row_rotation(row_rotation)

--- a/GBOpt/crystallography/embedding.py
+++ b/GBOpt/crystallography/embedding.py
@@ -10,7 +10,6 @@ belongs in csl.py.
 from __future__ import annotations
 
 import math
-from typing import Literal
 
 import numpy as np
 
@@ -20,10 +19,16 @@ from GBOpt.BoundarySpec import (
     BoundarySpecOrthogonalityError,
     PrimitiveCellMetadata,
 )
-from GBOpt.Utils.integer_linalg import cross_int3, dot_int
 
 from .csl import csl_from_scaled_rotation
-from .integer import as_int_array, integer_det3, row_gcd_reduce
+from .integer import (
+    as_int_array,
+    as_positive_int,
+    cross_int3,
+    dot_int,
+    integer_det3,
+    row_gcd_reduce,
+)
 from .orientation import validate_orientation_matrix
 from .plane import inplane_area_index, inplane_basis_from_csl, rotation_preserves_plane
 from .pq import (
@@ -36,7 +41,121 @@ from .rotation import (
     _scaled_row_images,
     transpose_rotation_convention,
 )
-from .types import CrystallographyValueError, InPlaneBasis, ScaledRotation
+from .types import CrystallographyValueError, CSLResult, InPlaneBasis, ScaledRotation
+
+
+def _validated_exact_orientation_rows(
+    matrix: object,
+    name: str,
+) -> np.ndarray:
+    """Return a validated exact integer row-orientation matrix.
+
+    The candidate is converted to a 3 by 3 object-dtype array of Python integers and
+    validated entirely with exact integer arithmetic. Each row must be nonzero, all
+    row pairs must have exact dot product zero, and the exact determinant must be
+    positive.
+
+    Unlike :func:`validate_orientation_matrix`, this helper does not convert the matrix
+    to floating point or normalize its rows. It is intended for exact crystallographic
+    direction matrices whose components may exceed the floating-point range.
+
+    :param matrix: Candidate 3 by 3 integer-valued row-orientation matrix.
+    :param name: Human-readable matrix name used in validation error messages.
+    :return: Object-dtype 3 by 3 NumPy array containing Python integers.
+    :raises CrystallographyValueError: If ``matrix`` has the wrong shape, contains a
+        non-integer entry or zero row, has nonorthogonal rows, or is not right-handed.
+    """
+    rows = as_int_array(matrix, (3, 3), name)
+
+    for row_index, row in enumerate(rows):
+        if all(int(value) == 0 for value in row):
+            raise CrystallographyValueError(
+                f"{name} row {row_index} must be nonzero."
+            )
+
+    for first, second in ((0, 1), (0, 2), (1, 2)):
+        exact_dot = dot_int(rows[first], rows[second])
+        if exact_dot != 0:
+            raise CrystallographyValueError(
+                f"{name} rows {first} and {second} have exact dot product "
+                f"{exact_dot}; expected 0."
+            )
+
+    determinant = integer_det3(rows)
+    if determinant <= 0:
+        raise CrystallographyValueError(
+            f"{name} must be right-handed; exact determinant is {determinant}."
+        )
+
+    return rows
+
+
+def _enforce_primitive_area_index_limit(
+    primitive_area_index: int,
+    *,
+    max_primitive_area_index: int | None,
+) -> None:
+    """Enforce the primitive in-plane CSL area-index limit.
+
+    :param primitive_area_index: Primitive in-plane CSL area index to check.
+    :param max_primitive_area_index: Maximum permitted primitive area index, or ``None``
+        to disable the limit. Keyword argument.
+    :return: ``None``.
+    :raises CrystallographyValueError: If ``max_primitive_area_index`` is not a positive
+        integer when supplied.
+    :raises BoundarySpecError: If ``primitive_area_index`` exceeds the configured limit.
+    """
+    if max_primitive_area_index is None:
+        return
+
+    limit = as_positive_int(
+        max_primitive_area_index,
+        "max_primitive_area_index",
+    )
+    if primitive_area_index > limit:
+        raise BoundarySpecError(
+            "Primitive CSL area index exceeds "
+            f"max_primitive_area_index={limit}: "
+            f"primitive_area_index={primitive_area_index}."
+        )
+
+
+def _enforce_pq_determinant_limit(
+    P: object,
+    Q: object,
+    *,
+    max_pq_determinant: int | None,
+) -> None:
+    """Enforce the absolute determinant limit on exact P/Q matrices.
+
+    :param P: Candidate exact left-grain 3 by 3 integer orientation matrix.
+    :param Q: Candidate exact right-grain 3 by 3 integer orientation matrix.
+    :param max_pq_determinant: Maximum permitted value of ``abs(det(P))`` and
+        ``abs(det(Q))``, or ``None`` to disable the limit. Keyword argument.
+    :return: ``None``.
+    :raises CrystallographyValueError: If the limit is invalid or either matrix fails
+        exact 3 by 3 integer validation.
+    :raises BoundarySpecError: If either absolute determinant exceeds the configured
+        limit.
+    """
+    if max_pq_determinant is None:
+        return
+
+    limit = as_positive_int(
+        max_pq_determinant,
+        "max_pq_determinant",
+    )
+    P_int = as_int_array(P, (3, 3), "P")
+    Q_int = as_int_array(Q, (3, 3), "Q")
+    det_P = abs(integer_det3(P_int))
+    det_Q = abs(integer_det3(Q_int))
+
+    if max(det_P, det_Q) > limit:
+        raise BoundarySpecError(
+            "Exact P/Q determinant exceeds "
+            f"max_pq_determinant={limit}: "
+            f"|det(P)|={det_P}, |det(Q)|={det_Q}."
+        )
 
 
 def _paired_pq_from_direction_rows(
@@ -44,46 +163,43 @@ def _paired_pq_from_direction_rows(
     row_rotation: ScaledRotation,
     *,
     primitive_area_index: int,
+    max_pq_determinant: int | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Build exact paired P/Q orientation matrices from reference directions.
 
     Each row in ``direction_rows`` is paired with its exact image under
-    ``row_rotation`` by :func:`_exact_paired_row`. The resulting ``P`` and ``Q`` rows
-    therefore satisfy the same exact row-convention rotation without relying on
-    floating-point inversion.
+    ``row_rotation``. If necessary, the second row of both matrices is enlarged by the
+    smallest common factor that makes the resulting in-plane area index divisible by
+    ``primitive_area_index``.
 
-    Primitive ``PQSpec`` re-embedding requires the supplied in-plane area index to be an
-    integer multiple of the primitive CSL area index. When the minimally paired rows do
-    not satisfy that divisibility invariant, the second row of both matrices is enlarged
-    by the smallest common integer factor that makes the input area index divisible by
-    ``primitive_area_index``. Applying the same factor to both rows preserves their
-    exact pairing.
+    All orientation-frame validation is performed with exact integer arithmetic.
 
-    The completed matrices are required to be proper row-wise orientation frames, and
-    their exactly recovered rotation is compared with ``row_rotation`` by integer cross
-    multiplication so equivalent numerator/denominator representations compare without
-    floating-point error.
-
-    :param direction_rows: Three integer-valued reference-grain directions arranged as
-        a 3 by 3 row matrix. Row 0 is the boundary normal and rows 1 and 2 are in-plane
-        directions forming a proper orientation frame after pairing and any area
-        adjustment.
-    :param row_rotation: Valid exact row-convention scaled rotation mapping each ``P``
-        row to the corresponding ``Q`` row.
-    :param primitive_area_index: Positive primitive CSL in-plane area index that the
-        returned ``P`` matrix must contain as an integer divisor of its own in-plane area
-        index. Keyword argument, required.
-    :return: ``(P, Q)`` as object-dtype 3 by 3 integer matrices with exact row pairing,
-        proper orientation-frame geometry, and a ``P`` in-plane area index divisible by
-        ``primitive_area_index``.
-    :raises CrystallographyValueError: If the input rows cannot be paired exactly, the
-        resulting matrices do not form proper row-wise orientation frames, an in-plane
-        area index cannot be computed, or exact recovery from ``P`` and ``Q`` does not
-        reproduce ``row_rotation``.
+    :param direction_rows: Three integer-valued reference directions arranged as a 3 by
+        3 row matrix.
+    :param row_rotation: Exact row-convention scaled rotation.
+    :param primitive_area_index: Positive primitive CSL in-plane area index. Keyword
+        argument.
+    :param max_pq_determinant: Maximum permitted value of ``abs(det(P))`` and
+        ``abs(det(Q))``. Keyword argument, optional, defaults to ``None``.
+    :return: Exact object-dtype integer matrices ``(P, Q)``.
+    :raises CrystallographyValueError: If an argument is malformed, the completed rows
+        are not proper exact orientation frames, or exact rotation recovery fails.
+    :raises BoundarySpecError: If ``abs(det(P))`` or ``abs(det(Q))`` exceeds
+        ``max_pq_determinant``.
     """
+    direction_rows = as_int_array(
+        direction_rows,
+        (3, 3),
+        "direction_rows",
+    )
+    primitive_area_index = as_positive_int(
+        primitive_area_index,
+        "primitive_area_index",
+    )
+
     paired_rows = [
         _minimal_integral_row_pair(row, row_rotation)
-        for row in np.asarray(direction_rows, dtype=object)
+        for row in direction_rows
     ]
     P = np.array([pair[0] for pair in paired_rows], dtype=object)
     Q = np.array([pair[1] for pair in paired_rows], dtype=object)
@@ -97,20 +213,25 @@ def _paired_pq_from_direction_rows(
         P[1] *= area_factor
         Q[1] *= area_factor
 
-    validate_orientation_matrix(P, "P")
-    validate_orientation_matrix(Q, "Q")
+    P = _validated_exact_orientation_rows(P, "P")
+    Q = _validated_exact_orientation_rows(Q, "Q")
 
     recovered = recover_exact_row_rotation_from_paired_pq(P, Q)
     recovered_numerator = (
-        np.asarray(recovered.matrix, dtype=object) * row_rotation.denominator
+        np.asarray(recovered.matrix, dtype=object)
+        * row_rotation.denominator
     )
     expected_numerator = (
-        np.asarray(row_rotation.matrix, dtype=object) * recovered.denominator
+        np.asarray(row_rotation.matrix, dtype=object)
+        * recovered.denominator
     )
     if not np.array_equal(recovered_numerator, expected_numerator):
         raise CrystallographyValueError(
-            "Internal error: exact paired P/Q rows changed the recovered rotation."
+            "Internal error: exact paired P/Q rows changed the recovered "
+            "rotation."
         )
+
+    _enforce_pq_determinant_limit(P, Q, max_pq_determinant=max_pq_determinant)
 
     return P, Q
 
@@ -121,11 +242,11 @@ def _validated_rotation_rows(
 ) -> np.ndarray:
     """Return normalized proper rotation rows with embedding-layer exceptions.
 
-    Delegates floating-point row-orientation validation to
-    :func:`GBOpt.crystallography.orientation.validate_orientation_matrix`. This keeps
-    normalization, shape checking, finite-value checking, orthogonality checking, and
-    handedness checking in the orientation module while preserving the exception type
-    expected by boundary-embedding callers.
+    Floating-point row-orientation validation is delegated to
+    ``validate_orientation_matrix``. This keeps normalization, shape validation,
+    finite-value validation, orthogonality checks, and handedness checks in the
+    orientation module while preserving the exception type expected by embedding
+    callers.
 
     :param matrix: Candidate 3 by 3 row-orientation matrix. Rows may have arbitrary
         nonzero magnitudes but must be finite, mutually orthogonal after normalization,
@@ -147,105 +268,54 @@ def _validated_rotation_rows(
         raise BoundarySpecOrthogonalityError(message) from exc
 
 
-def _csl_inplane(row_rotation: ScaledRotation, plane_int: np.ndarray) -> InPlaneBasis:
-    """Build a CSL and return its in-plane basis for a given plane.
-
-    Transposes ``row_rotation`` to column convention, constructs the CSL, and returns
-    the in-plane basis for ``plane_int``.
+def _csl_from_row_rotation(row_rotation: ScaledRotation) -> CSLResult:
+    """Construct the column-convention CSL for a row-convention rotation.
 
     :param row_rotation: Exact row-convention scaled rotation.
-    :param plane_int: Primitive boundary-plane normal as a length-3 integer array.
-    :return: In-plane CSL basis for the given plane.
-    :raises BoundarySpecError: If the rotation or plane is invalid, or no CSL in-plane
-        basis exists for the given inputs.
+    :return: Canonical CSL constructed from the column-convention transpose of
+        ``row_rotation``.
+    :raises BoundarySpecError: If rotation conversion or CSL construction rejects the
+        supplied rotation.
     """
     try:
         column_rotation = transpose_rotation_convention(row_rotation)
-        csl = csl_from_scaled_rotation(column_rotation)
-        return inplane_basis_from_csl(csl.basis_hnf, tuple(int(x) for x in plane_int))
+        return csl_from_scaled_rotation(column_rotation)
     except CrystallographyValueError as exc:
         raise BoundarySpecError(str(exc)) from exc
 
 
-def primitive_metadata(
-    *,
-    basis_mode: Literal["primitive", "supplied"],
-    primitive_area_index: int,
-    plane: np.ndarray,
-    rotation_denominator: int,
-    input_area_index: int | None = None,
-    orientation_area_index: int | None = None,
-) -> PrimitiveCellMetadata:
-    """Build primitive-cell metadata for an exact boundary embedding.
+def _inplane_from_csl(csl: CSLResult, plane_int: np.ndarray) -> InPlaneBasis:
+    """Return the in-plane basis of a precomputed CSL.
 
-    The metadata separates primitive CSL topology from orientation-row bookkeeping.
-    ``primitive_area_index`` is the minimal CSL in-plane area for the exact rotation and
-    boundary plane. ``input_area_index`` records the area of caller-provided ``P`` rows
-    when available. ``orientation_area_index`` records the area of the returned
-    ``BoundaryEmbedding.P`` rows when useful, but it is descriptive only and is not
-    required to be an integer multiple of ``primitive_area_index``.
+    ``csl`` must correspond to the column-convention transpose of the row rotation used
+    by the eventual embedding constructor. Keeping this operation separate allows an
+    exactification caller that already needs the CSL sigma to reuse the same exact CSL
+    construction during embedding.
 
-    :param basis_mode: ``"primitive"`` for a primitive CSL embedding or ``"supplied"``
-        for caller-supplied ``P``/``Q`` rows. Keyword argument, required.
-    :param primitive_area_index: Minimal in-plane CSL area index for the exact rotation
-        and boundary plane. Keyword argument, required.
-    :param plane: Primitive boundary-plane normal as a length-3 integer array. Keyword
-        argument, required.
-    :param rotation_denominator: Denominator ``N`` of the exact scaled rotation ``R = M
-        / N`` associated with this boundary. Keyword argument, required.
-    :param input_area_index: In-plane area index of caller-provided ``P`` rows, when
-        available. Must be an integer multiple of ``primitive_area_index`` when
-        supplied. Keyword argument, optional, defaults to ``None``.
-    :param orientation_area_index: In-plane area index of the returned
-        ``BoundaryEmbedding.P`` orientation rows, when useful to report. This value is
-        not required to be related by divisibility to ``primitive_area_index``. Keyword
-        argument, optional, defaults to ``None``.
-    :return: Boundary metadata attached to ``BoundaryEmbedding``.
-    :raises BoundarySpecError: If an area index is not positive, if ``input_area_index``
-        is supplied but is not an integer multiple of ``primitive_area_index``, or if
-        metadata construction fails validation.
+    :param csl: Precomputed CSL in column-vector convention.
+    :param plane_int: Primitive boundary-plane normal as a length-3 integer array.
+    :return: In-plane CSL basis for ``plane_int``.
+    :raises BoundarySpecError: If no valid in-plane CSL basis exists for the supplied
+        CSL and plane.
     """
-    if basis_mode not in ("primitive", "supplied"):
-        raise BoundarySpecError(
-            f"basis_mode must be 'primitive' or 'supplied'; got {basis_mode!r}."
+    try:
+        return inplane_basis_from_csl(
+            csl.basis_hnf,
+            tuple(int(value) for value in plane_int),
         )
+    except CrystallographyValueError as exc:
+        raise BoundarySpecError(str(exc)) from exc
 
-    if primitive_area_index <= 0:
-        raise BoundarySpecError(
-            f"primitive_area_index must be positive; got {primitive_area_index}."
-        )
 
-    input_reduction_index = None
-    if input_area_index is not None:
-        if input_area_index <= 0:
-            raise BoundarySpecError(
-                f"input_area_index must be positive; got {input_area_index}."
-            )
-        if input_area_index % primitive_area_index != 0:
-            raise BoundarySpecError(
-                "input_area_index must be an integer multiple of primitive_area_index "
-                "when reporting primitive-cell metadata; got "
-                f"{input_area_index=}, {primitive_area_index=}."
-            )
-        input_reduction_index = input_area_index // primitive_area_index
+def _inplane_from_row_rotation(row_rotation: ScaledRotation, plane_int: np.ndarray) -> InPlaneBasis:
+    """Build a CSL and return its in-plane basis for a given plane.
 
-    if orientation_area_index is not None and orientation_area_index <= 0:
-        raise BoundarySpecError(
-            f"orientation_area_index must be positive; got {orientation_area_index}."
-        )
-
-    h, k, l = (int(plane[0]), int(plane[1]), int(plane[2]))
-
-    return PrimitiveCellMetadata(
-        basis_mode=basis_mode,
-        input_area_index=input_area_index,
-        primitive_area_index=primitive_area_index,
-        input_reduction_index=input_reduction_index,
-        orientation_area_index=orientation_area_index,
-        plane=(h, k, l),
-        rotation_denominator=int(rotation_denominator),
-        conventional_cell_multiplier=int(2 * primitive_area_index),
-    )
+    :param row_rotation: Exact row-convention scaled rotation.
+    :param plane_int: Primitive boundary-plane normal as a length-3 integer array.
+    :return: In-plane CSL basis for the given plane.
+    """
+    csl = _csl_from_row_rotation(row_rotation)
+    return _inplane_from_csl(csl, plane_int)
 
 
 def embedding_from_pq(
@@ -254,6 +324,7 @@ def embedding_from_pq(
     *,
     source: str,
     metadata: PrimitiveCellMetadata | None = None,
+    max_pq_determinant: int | None = None,
 ) -> BoundaryEmbedding:
     """Build a ``BoundaryEmbedding`` from canonical P and Q matrices.
 
@@ -264,14 +335,22 @@ def embedding_from_pq(
         argument, required.
     :param metadata: Primitive-cell metadata to attach to the embedding, or ``None`` if
         no metadata is available. Keyword argument, optional, defaults to ``None``.
+    :param max_pq_determinant: Bounds abs(det(P)) and abs(det(Q)) for both the selected
+        exact embedding and the final exactly paired P/Q matrices. Keyword argument,
+        optional, defaults to ``None``.
     :return: ``BoundaryEmbedding`` with ``exact=True``, ``coherent=True``, and
         ``source`` as supplied. ``R_left`` and ``R_right`` are constructed by
         normalizing and validating the rows of ``P_canon`` and ``Q_canon``.
-    :raises BoundarySpecOrthogonalityError: If either matrix has malformed, non-finite,
-        zero, non-orthogonal, or left-handed rows.
     """
+    _enforce_pq_determinant_limit(
+        P_canon,
+        Q_canon,
+        max_pq_determinant=max_pq_determinant,
+    )
+
     R_left = _validated_rotation_rows(P_canon, "R_left")
     R_right = _validated_rotation_rows(Q_canon, "R_right")
+
     return BoundaryEmbedding(
         P=P_canon,
         Q=Q_canon,
@@ -304,8 +383,6 @@ def embedding_from_rotation_rows(
         construction. Keyword argument, optional, defaults to ``True``.
     :return: Approximate ``BoundaryEmbedding`` with normalized ``R_left`` and
         ``R_right``, ``P=None``, ``Q=None``, and ``exact=False``.
-    :raises BoundarySpecOrthogonalityError: If either matrix has malformed, non-finite,
-        zero, non-orthogonal, or left-handed rows.
     """
     R_left = _validated_rotation_rows(R_left, "R_left")
     R_right = _validated_rotation_rows(R_right, "R_right")
@@ -321,38 +398,43 @@ def embedding_from_rotation_rows(
     )
 
 
-def primitive_embedding_from_row_rotation(
+def _primitive_embedding_from_inplane(
     row_rotation: ScaledRotation,
-    plane: np.ndarray,
+    plane_int: np.ndarray,
+    inplane: InPlaneBasis,
     *,
     source: str,
     input_area_index: int | None = None,
-    max_exact_atoms: int | None = None,
+    max_primitive_area_index: int | None = None,
+    max_pq_determinant: int | None = None,
 ) -> BoundaryEmbedding:
-    """Build a primitive paired P/Q embedding from a row-convention rotation.
+    """Build a primitive exact embedding from a precomputed in-plane CSL basis.
 
-    The CSL is built from the column-convention transpose of ``row_rotation`` because
-    ``csl_from_scaled_rotation`` expects column-vector convention. The boundary-normal
-    image row ``q0`` is computed with ``allow_inexact=True`` because non-preserving
-    planes map to a rational direction that is GCD-reduced to its primitive integer
-    representative; the two in-plane image rows ``q1`` and ``q2`` require exact
-    divisibility and raise if the CSL membership check fails.
+    ``plane_int`` and ``inplane`` must describe the same primitive boundary plane. The
+    boundary-normal image may be rational and is reduced to its primitive integer
+    direction. The two in-plane rows are CSL vectors and therefore must have exact
+    integer images under ``row_rotation``.
+
+    The minimal in-plane CSL area index is calculated before P/Q canonicalization and
+    stored as ``PrimitiveCellMetadata.primitive_area_index``. The area index of the
+    returned canonical P rows is stored separately as ``orientation_area_index``.
 
     :param row_rotation: Exact row-convention scaled rotation.
-    :param plane: Boundary-plane normal in the reference grain.
-    :param source: String label describing the upstream boundary spec type, stored on
-        the returned ``BoundaryEmbedding``. Keyword argument, required.
-    :param input_area_index: In-plane area index of the caller-provided ``P`` rows, when
+    :param plane_int: Primitive integer boundary-plane normal in the reference grain.
+    :param inplane: In-plane basis derived from the column-convention CSL associated
+        with ``row_rotation`` and ``plane_int``.
+    :param source: Label identifying the upstream boundary representation. Keyword
+        argument, required.
+    :param input_area_index: In-plane area index of caller-provided P rows, when
         available. Keyword argument, optional, defaults to ``None``.
-    :param max_exact_atoms: Upper bound on the primitive in-plane area index. Keyword
-        argument, optional, defaults to ``None``.
-    :return: Exact coherent ``BoundaryEmbedding`` with primitive-cell metadata.
-    :raises BoundarySpecError: If the computed primitive area index exceeds
-        ``max_exact_atoms``.
+    :param max_primitive_area_index: Maximum permitted minimal in-plane CSL area index.
+        ``None`` disables this limit. Keyword argument, optional, defaults to ``None``.
+    :param max_pq_determinant: Maximum permitted absolute determinant of each returned
+        exact P/Q matrix. ``None`` disables this limit. Keyword argument, optional,
+        defaults to ``None``.
+    :return: Exact coherent primitive ``BoundaryEmbedding`` with primitive-cell
+        metadata.
     """
-    plane_int = row_gcd_reduce(np.asarray(plane, dtype=object))
-    inplane = _csl_inplane(row_rotation, plane_int)
-
     p1 = inplane.basis[:, 0]
     p2 = inplane.basis[:, 1]
     q0, q1, q2 = _scaled_row_images(
@@ -365,75 +447,122 @@ def primitive_embedding_from_row_rotation(
     Q_int = np.array([q0, q1, q2], dtype=object)
 
     primitive_area_index = inplane_area_index(P_int)
-    if max_exact_atoms is not None and primitive_area_index > max_exact_atoms:
-        raise BoundarySpecError(
-            f"Exact in-plane CSL area index ({primitive_area_index}) exceeds "
-            f"{max_exact_atoms=}. Use mode='approximate' or increase the limit."
-        )
+    _enforce_primitive_area_index_limit(
+        primitive_area_index,
+        max_primitive_area_index=max_primitive_area_index,
+    )
 
     P_canon, Q_canon = canonicalize_pq_paired(P_int, Q_int)
     orientation_area_index = inplane_area_index(P_canon)
 
-    metadata = primitive_metadata(
+    metadata = PrimitiveCellMetadata(
         basis_mode="primitive",
         input_area_index=input_area_index,
         primitive_area_index=primitive_area_index,
         orientation_area_index=orientation_area_index,
-        plane=plane_int,
-        rotation_denominator=int(row_rotation.denominator),
+        plane=tuple(int(value) for value in plane_int),
+        rotation_denominator=row_rotation.denominator,
     )
 
-    return embedding_from_pq(P_canon, Q_canon, source=source, metadata=metadata)
+    return embedding_from_pq(
+        P_canon,
+        Q_canon,
+        source=source,
+        metadata=metadata,
+        max_pq_determinant=max_pq_determinant,
+    )
 
 
-def orthogonal_embedding_from_row_rotation_and_plane(
+def primitive_embedding_from_row_rotation(
     row_rotation: ScaledRotation,
-    plane_normal: np.ndarray,
+    plane: np.ndarray,
     *,
     source: str,
     input_area_index: int | None = None,
-    max_exact_atoms: int | None = None,
+    max_primitive_area_index: int | None = None,
+    max_pq_determinant: int | None = None,
 ) -> BoundaryEmbedding:
-    """Build a BoundaryEmbedding whose P rows are mutually orthogonal.
+    """Build a primitive paired P/Q embedding from a row-convention rotation.
 
-    Row 0 is the primitive boundary-plane normal. Row 1 is chosen from the in-plane CSL
-    basis after Gauss reduction. Row 2 is ``cross(plane_normal, row1)``, giving an
-    orthogonal P-frame. The corresponding Q rows are constructed exactly from the
-    row-rotation numerator and GCD-reduced as integer directions.
-
-    The returned metadata records both the primitive CSL area and the larger orthogonal
-    embedding area when the orthogonal fallback expands the returned cell.
+    The CSL is built from the column-convention transpose of ``row_rotation`` because
+    ``csl_from_scaled_rotation`` expects column-vector convention. The boundary-normal
+    image row may be rational and is reduced to its primitive integer direction; both
+    in-plane rows are CSL vectors and therefore require exact divisibility.
 
     :param row_rotation: Exact row-convention scaled rotation.
-    :param plane_normal: Primitive boundary-plane normal as a length-3 integer array.
+    :param plane: Boundary-plane normal in the reference grain.
     :param source: String label describing the upstream boundary spec type, stored on
         the returned ``BoundaryEmbedding``. Keyword argument, required.
-    :param input_area_index: In-plane area index of the caller-provided ``P`` rows, when
+    :param input_area_index: In-plane area index of caller-provided ``P`` rows, when
         available. Keyword argument, optional, defaults to ``None``.
-    :param max_exact_atoms: Upper bound on cell size used for raw in-plane CSL area and
-        post-canonicalization determinant checks. Keyword argument, optional, defaults
-        to ``None``.
+    :param max_primitive_area_index: Bounds the minimal in-plane CSL area index. Keyword
+            argument, optional, defaults to ``None``.
+    :param max_pq_determinant: Bounds abs(det(P)) and abs(det(Q)) for both the selected
+        exact embedding and the final exactly paired P/Q matrices. Keyword argument,
+        optional, defaults to ``None``.
     :return: Exact coherent ``BoundaryEmbedding`` with primitive-cell metadata.
-    :raises BoundarySpecError: If the raw squared in-plane CSL cell area exceeds
-        ``max_exact_atoms**2``, or if ``max(abs(det(P)), abs(det(Q)))`` exceeds
-        ``max_exact_atoms`` after canonicalization.
     """
-    plane_int = row_gcd_reduce(np.asarray(plane_normal, dtype=object))
-    inplane = _csl_inplane(row_rotation, plane_int)
+    plane_int = row_gcd_reduce(np.asarray(plane, dtype=object))
+    inplane = _inplane_from_row_rotation(row_rotation, plane_int)
+    return _primitive_embedding_from_inplane(
+        row_rotation,
+        plane_int,
+        inplane,
+        source=source,
+        input_area_index=input_area_index,
+        max_primitive_area_index=max_primitive_area_index,
+        max_pq_determinant=max_pq_determinant,
+    )
 
+
+def _orthogonal_embedding_from_inplane(
+    row_rotation: ScaledRotation,
+    plane_int: np.ndarray,
+    inplane: InPlaneBasis,
+    *,
+    source: str,
+    input_area_index: int | None = None,
+    max_primitive_area_index: int | None = None,
+    max_pq_determinant: int | None = None,
+) -> BoundaryEmbedding:
+    """Build an orthogonal exact embedding from a precomputed in-plane CSL basis.
+
+    The minimal in-plane CSL cell is used only to determine ``primitive_area_index``. A
+    Gauss-reduced CSL direction is selected for the first in-plane orientation row, and
+    the second is constructed as its exact cross product with ``plane_int``. This
+    produces a mutually orthogonal reference-grain frame. Corresponding right-grain
+    directions are constructed from the exact row-rotation numerator and canonicalized
+    as a paired P/Q representation.
+
+    The returned orthogonal orientation cell may differ in area from the minimal CSL
+    cell. These values are recorded separately as ``primitive_area_index`` and
+    ``orientation_area_index``.
+
+    :param row_rotation: Exact row-convention scaled rotation.
+    :param plane_int: Primitive integer boundary-plane normal in the reference grain.
+    :param inplane: In-plane basis derived from the column-convention CSL associated
+        with ``row_rotation`` and ``plane_int``.
+    :param source: Label identifying the upstream boundary representation. Keyword
+        argument, required.
+    :param input_area_index: In-plane area index of caller-provided P rows, when
+        available. Keyword argument, optional, defaults to ``None``.
+    :param max_primitive_area_index: Maximum permitted minimal in-plane CSL area index.
+        ``None`` disables this limit. Keyword argument, optional, defaults to ``None``.
+    :param max_pq_determinant: Maximum permitted absolute determinant of each returned
+        exact P/Q matrix. ``None`` disables this limit. Keyword argument, optional,
+        defaults to ``None``.
+    :return: Exact coherent orthogonal ``BoundaryEmbedding`` with primitive-cell
+        metadata.
+    """
     v1 = inplane.basis[:, 0]
     v2 = inplane.basis[:, 1]
 
     primitive_P = np.array([plane_int, v1, v2], dtype=object)
     primitive_area_index = inplane_area_index(primitive_P)
-
-    cross = cross_int3(v1, v2)
-    area_sq = dot_int(cross, cross)
-    if max_exact_atoms is not None and area_sq > max_exact_atoms**2:
-        raise BoundarySpecError(
-            f"Exact squared in-plane CSL cell area ({area_sq}) exceeds "
-            f"{max_exact_atoms**2=}. Use mode='approximate' or increase the limit."
-        )
+    _enforce_primitive_area_index_limit(
+        primitive_area_index,
+        max_primitive_area_index=max_primitive_area_index,
+    )
 
     r1, _ = gauss_reduce_2d(v1, v2)
     e1 = row_gcd_reduce(r1)
@@ -449,43 +578,133 @@ def orthogonal_embedding_from_row_rotation_and_plane(
 
     P_canon, Q_canon = canonicalize_pq_paired(P_int, Q_int)
 
-    # Validate the returned orientation frames before computing optional metadata
-    # from those rows. This preserves BoundarySpecOrthogonalityError for malformed
-    # canonical rows.
-    R_left = _validated_rotation_rows(P_canon, "R_left")
-    R_right = _validated_rotation_rows(Q_canon, "R_right")
-
     orientation_area_index = inplane_area_index(P_canon)
 
-    if max_exact_atoms is not None:
-        P_check = as_int_array(P_canon, (3, 3), "P_canon")
-        Q_check = as_int_array(Q_canon, (3, 3), "Q_canon")
-        det_P = abs(integer_det3(P_check))
-        det_Q = abs(integer_det3(Q_check))
-        if max(det_P, det_Q) > max_exact_atoms:
-            raise BoundarySpecError(
-                f"CSL supercell exceeds {max_exact_atoms=}: "
-                f"|det(P)|={det_P}, |det(Q)|={det_Q}."
-            )
-
-    metadata = primitive_metadata(
+    metadata = PrimitiveCellMetadata(
         basis_mode="primitive",
         input_area_index=input_area_index,
         primitive_area_index=primitive_area_index,
         orientation_area_index=orientation_area_index,
-        plane=plane_int,
-        rotation_denominator=int(row_rotation.denominator),
+        plane=tuple(int(value) for value in plane_int),
+        rotation_denominator=row_rotation.denominator,
     )
 
-    return BoundaryEmbedding(
-        P=P_canon,
-        Q=Q_canon,
-        R_left=R_left,
-        R_right=R_right,
-        exact=True,
-        coherent=True,
+    return embedding_from_pq(
+        P_canon,
+        Q_canon,
         source=source,
         metadata=metadata,
+        max_pq_determinant=max_pq_determinant,
+    )
+
+
+def orthogonal_embedding_from_row_rotation_and_plane(
+    row_rotation: ScaledRotation,
+    plane_normal: np.ndarray,
+    *,
+    source: str,
+    input_area_index: int | None = None,
+    max_primitive_area_index: int | None = None,
+    max_pq_determinant: int | None = None,
+) -> BoundaryEmbedding:
+    """Build a ``BoundaryEmbedding`` whose P rows are mutually orthogonal.
+
+    Row 0 is the primitive boundary-plane normal. Row 1 is chosen from a Gauss-reduced
+    in-plane CSL basis. Row 2 is ``cross(plane_normal, row1)``, giving an orthogonal
+    P-frame. Corresponding Q rows are constructed exactly from the row-rotation
+    numerator and GCD-reduced as integer directions.
+
+    The returned metadata records both the primitive CSL area and the larger orthogonal
+    embedding area when the orthogonal construction expands the returned cell.
+
+    :param row_rotation: Exact row-convention scaled rotation.
+    :param plane_normal: Boundary-plane normal in the reference grain.
+    :param source: String label describing the upstream boundary spec type, stored on
+        the returned ``BoundaryEmbedding``. Keyword argument, required.
+    :param input_area_index: In-plane area index of caller-provided ``P`` rows, when
+        available. Keyword argument, optional, defaults to ``None``.
+    :param max_primitive_area_index: Bounds the minimal in-plane CSL area index. Keyword
+            argument, optional, defaults to ``None``.
+    :param max_pq_determinant: Bounds abs(det(P)) and abs(det(Q)) for both the selected
+        exact embedding and the final exactly paired P/Q matrices. Keyword argument,
+        optional, defaults to ``None``.
+    :return: Exact coherent ``BoundaryEmbedding`` with primitive-cell metadata.
+    """
+    plane_int = row_gcd_reduce(np.asarray(plane_normal, dtype=object))
+    inplane = _inplane_from_row_rotation(row_rotation, plane_int)
+    return _orthogonal_embedding_from_inplane(
+        row_rotation,
+        plane_int,
+        inplane,
+        source=source,
+        input_area_index=input_area_index,
+        max_primitive_area_index=max_primitive_area_index,
+        max_pq_determinant=max_pq_determinant,
+    )
+
+
+def _exact_embedding_from_precomputed_csl(
+    row_rotation: ScaledRotation,
+    plane_int: np.ndarray,
+    csl: CSLResult,
+    *,
+    source: str,
+    input_area_index: int | None = None,
+    max_primitive_area_index: int | None = None,
+    max_pq_determinant: int | None = None,
+) -> BoundaryEmbedding:
+    """Select an exact embedding path using an already-constructed CSL.
+
+    ``csl`` must have been constructed from the column-convention transpose of
+    ``row_rotation``. The in-plane basis is computed once and reused if a
+    plane-preserving primitive construction must fall back to the orthogonal path.
+
+    :param row_rotation: Exact row-convention scaled rotation.
+    :param plane_int: Primitive boundary-plane normal in the reference grain.
+    :param csl: CSL constructed from the column-convention transpose of
+        ``row_rotation``.
+    :param source: Label identifying the upstream boundary representation. Keyword
+        argument, required.
+    :param input_area_index: In-plane area index of caller-supplied ``P`` rows, when
+        available. Keyword argument, optional, defaults to ``None``.
+    :param max_primitive_area_index: Bounds the minimal in-plane CSL area index. Keyword
+            argument, optional, defaults to ``None``.
+    :param max_pq_determinant: Bounds abs(det(P)) and abs(det(Q)) for both the selected
+        exact embedding and the final exactly paired P/Q matrices. Keyword argument,
+        optional, defaults to ``None``.
+    :return: Exact coherent ``BoundaryEmbedding`` constructed through the primitive path
+        when possible, otherwise through the orthogonal path.
+    :raises BoundarySpecOrthogonalityError: If the orthogonal path cannot produce proper
+        orientation frames.
+    """
+    inplane = _inplane_from_csl(csl, plane_int)
+
+    if rotation_preserves_plane(
+        row_rotation,
+        plane_int,
+        allow_antiparallel=True
+    ):
+        try:
+            return _primitive_embedding_from_inplane(
+                row_rotation,
+                plane_int,
+                inplane,
+                source=source,
+                input_area_index=input_area_index,
+                max_primitive_area_index=max_primitive_area_index,
+                max_pq_determinant=max_pq_determinant,
+            )
+        except BoundarySpecOrthogonalityError:
+            pass
+
+    return _orthogonal_embedding_from_inplane(
+        row_rotation,
+        plane_int,
+        inplane,
+        source=source,
+        input_area_index=input_area_index,
+        max_primitive_area_index=max_primitive_area_index,
+        max_pq_determinant=max_pq_determinant,
     )
 
 
@@ -495,14 +714,16 @@ def exact_embedding_from_row_rotation_and_plane(
     *,
     source: str,
     input_area_index: int | None = None,
-    max_exact_atoms: int | None = None,
+    max_primitive_area_index: int | None = None,
+    max_pq_determinant: int | None = None,
 ) -> BoundaryEmbedding:
     """Select an exact embedding path for a row rotation and boundary plane.
 
-    A primitive CSL embedding is attempted when ``row_rotation`` preserves the supplied
-    boundary plane. If the primitive rows do not form proper orthogonal orientation
-    frames, construction falls back to the orthogonal embedding path. Rotations that do
-    not preserve the plane use the orthogonal path directly.
+    The CSL and its in-plane basis are each constructed once. A primitive embedding is
+    attempted when ``row_rotation`` preserves the supplied plane. If the primitive rows
+    do not form proper orthogonal orientation frames, construction falls back to the
+    orthogonal path while reusing the same in-plane basis. Rotations that do not
+    preserve the plane use the orthogonal path directly.
 
     Cell-size errors raised by either construction path are propagated rather than
     causing a fallback.
@@ -513,41 +734,28 @@ def exact_embedding_from_row_rotation_and_plane(
         argument, required.
     :param input_area_index: In-plane area index of caller-supplied ``P`` rows, when
         available. Keyword argument, optional, defaults to ``None``.
-    :param max_exact_atoms: Upper bound passed to the selected exact embedding
-        constructor. Keyword argument, optional, defaults to ``None``.
+    :param max_primitive_area_index: Bounds the minimal in-plane CSL area index. Keyword
+            argument, optional, defaults to ``None``.
+    :param max_pq_determinant: Bounds abs(det(P)) and abs(det(Q)) for both the selected
+        exact embedding and the final exactly paired P/Q matrices. Keyword argument,
+        optional, defaults to ``None``.
     :return: Exact coherent ``BoundaryEmbedding`` constructed through the primitive path
         when possible, otherwise through the orthogonal path.
-    :raises BoundarySpecError: If the selected exact embedding exceeds
-        ``max_exact_atoms`` or exact CSL construction otherwise fails.
-    :raises BoundarySpecOrthogonalityError: If the orthogonal fallback cannot produce
-        proper orientation frames.
-    :raises CrystallographyValueError: If ``plane`` is not a valid integer direction.
     """
     plane_int = row_gcd_reduce(np.asarray(plane, dtype=object))
-
-    if rotation_preserves_plane(row_rotation, plane_int):
-        try:
-            return primitive_embedding_from_row_rotation(
-                row_rotation,
-                plane_int,
-                source=source,
-                input_area_index=input_area_index,
-                max_exact_atoms=max_exact_atoms,
-            )
-        except BoundarySpecOrthogonalityError:
-            pass
-
-    return orthogonal_embedding_from_row_rotation_and_plane(
+    csl = _csl_from_row_rotation(row_rotation)
+    return _exact_embedding_from_precomputed_csl(
         row_rotation,
         plane_int,
+        csl,
         source=source,
         input_area_index=input_area_index,
-        max_exact_atoms=max_exact_atoms,
+        max_primitive_area_index=max_primitive_area_index,
+        max_pq_determinant=max_pq_determinant,
     )
 
 
 __all__ = [
-    "primitive_metadata",
     "embedding_from_pq",
     "embedding_from_rotation_rows",
     "primitive_embedding_from_row_rotation",

--- a/GBOpt/crystallography/embedding.py
+++ b/GBOpt/crystallography/embedding.py
@@ -7,6 +7,9 @@ bases, plane covectors, P/Q matrices) and return ``BoundaryEmbedding`` objects.
 Boundary-spec parsing and user-facing validation belong in boundary.py; CSL arithmetic
 belongs in csl.py.
 """
+from __future__ import annotations
+
+import math
 from typing import Literal
 
 import numpy as np
@@ -23,13 +26,93 @@ from .csl import csl_from_scaled_rotation
 from .integer import as_int_array, integer_det3, row_gcd_reduce
 from .orientation import validate_orientation_matrix
 from .plane import inplane_area_index, inplane_basis_from_csl
-from .pq import canonicalize_pq, canonicalize_pq_paired
+from .pq import (
+    canonicalize_pq_paired,
+    recover_exact_row_rotation_from_paired_pq,
+)
 from .reduction import gauss_reduce_2d
 from .rotation import (
+    _minimal_integral_row_pair,
     _scaled_row_images,
     transpose_rotation_convention,
 )
 from .types import CrystallographyValueError, InPlaneBasis, ScaledRotation
+
+
+def _paired_pq_from_direction_rows(
+    direction_rows: np.ndarray,
+    row_rotation: ScaledRotation,
+    *,
+    primitive_area_index: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build exact paired P/Q orientation matrices from reference directions.
+
+    Each row in ``direction_rows`` is paired with its exact image under
+    ``row_rotation`` by :func:`_exact_paired_row`. The resulting ``P`` and ``Q`` rows
+    therefore satisfy the same exact row-convention rotation without relying on
+    floating-point inversion.
+
+    Primitive ``PQSpec`` re-embedding requires the supplied in-plane area index to be an
+    integer multiple of the primitive CSL area index. When the minimally paired rows do
+    not satisfy that divisibility invariant, the second row of both matrices is enlarged
+    by the smallest common integer factor that makes the input area index divisible by
+    ``primitive_area_index``. Applying the same factor to both rows preserves their
+    exact pairing.
+
+    The completed matrices are required to be proper row-wise orientation frames, and
+    their exactly recovered rotation is compared with ``row_rotation`` by integer cross
+    multiplication so equivalent numerator/denominator representations compare without
+    floating-point error.
+
+    :param direction_rows: Three integer-valued reference-grain directions arranged as
+        a 3 by 3 row matrix. Row 0 is the boundary normal and rows 1 and 2 are in-plane
+        directions forming a proper orientation frame after pairing and any area
+        adjustment.
+    :param row_rotation: Valid exact row-convention scaled rotation mapping each ``P``
+        row to the corresponding ``Q`` row.
+    :param primitive_area_index: Positive primitive CSL in-plane area index that the
+        returned ``P`` matrix must contain as an integer divisor of its own in-plane area
+        index. Keyword argument, required.
+    :return: ``(P, Q)`` as object-dtype 3 by 3 integer matrices with exact row pairing,
+        proper orientation-frame geometry, and a ``P`` in-plane area index divisible by
+        ``primitive_area_index``.
+    :raises CrystallographyValueError: If the input rows cannot be paired exactly, the
+        resulting matrices do not form proper row-wise orientation frames, an in-plane
+        area index cannot be computed, or exact recovery from ``P`` and ``Q`` does not
+        reproduce ``row_rotation``.
+    """
+    paired_rows = [
+        _minimal_integral_row_pair(row, row_rotation)
+        for row in np.asarray(direction_rows, dtype=object)
+    ]
+    P = np.array([pair[0] for pair in paired_rows], dtype=object)
+    Q = np.array([pair[1] for pair in paired_rows], dtype=object)
+
+    input_area_index = inplane_area_index(P)
+    area_factor = primitive_area_index // math.gcd(
+        input_area_index,
+        primitive_area_index,
+    )
+    if area_factor > 1:
+        P[1] *= area_factor
+        Q[1] *= area_factor
+
+    validate_orientation_matrix(P, "P")
+    validate_orientation_matrix(Q, "Q")
+
+    recovered = recover_exact_row_rotation_from_paired_pq(P, Q)
+    recovered_numerator = (
+        np.asarray(recovered.matrix, dtype=object) * row_rotation.denominator
+    )
+    expected_numerator = (
+        np.asarray(row_rotation.matrix, dtype=object) * recovered.denominator
+    )
+    if not np.array_equal(recovered_numerator, expected_numerator):
+        raise CrystallographyValueError(
+            "Internal error: exact paired P/Q rows changed the recovered rotation."
+        )
+
+    return P, Q
 
 
 def _validated_rotation_rows(
@@ -364,7 +447,7 @@ def orthogonal_embedding_from_row_rotation_and_plane(
         dtype=object,
     )
 
-    P_canon, Q_canon = canonicalize_pq(P_int, Q_int)
+    P_canon, Q_canon = canonicalize_pq_paired(P_int, Q_int)
 
     # Validate the returned orientation frames before computing optional metadata
     # from those rows. This preserves BoundarySpecOrthogonalityError for malformed

--- a/GBOpt/crystallography/exactification.py
+++ b/GBOpt/crystallography/exactification.py
@@ -257,6 +257,9 @@ def exactify_five_dof(
         derived Sigma value is too large, or exact embedding construction does not
         produce the required integer rows and metadata.
     :raises CrystallographyNotImplementedError: If ``lattice_metric`` is not ``None``.
+    :raises CrystallographyBackendError: If exact CSL normal-form construction fails.
+    :raises BoundarySpecError: If exact embedding construction fails or an exact-cell
+        limit is exceeded.
     """
     _require_cubic(lattice_metric)
     max_primitive_area_index = as_positive_int(

--- a/GBOpt/crystallography/exactification.py
+++ b/GBOpt/crystallography/exactification.py
@@ -15,7 +15,7 @@ from ._guards import _require_cubic
 from .csl import csl_from_scaled_rotation
 from .embedding import (
     _paired_pq_from_direction_rows,
-    orthogonal_embedding_from_row_rotation_and_plane,
+    exact_embedding_from_row_rotation_and_plane,
 )
 from .integer import as_positive_int, row_gcd_reduce
 from .orientation import orientation_matrices_from_five_dof
@@ -249,7 +249,7 @@ def exactify_five_dof(
         name="boundary plane normal",
     )
 
-    embedding = orthogonal_embedding_from_row_rotation_and_plane(
+    embedding = exact_embedding_from_row_rotation_and_plane(
         row_rotation,
         plane,
         source="five_dof",

--- a/GBOpt/crystallography/exactification.py
+++ b/GBOpt/crystallography/exactification.py
@@ -4,28 +4,266 @@
 
 from __future__ import annotations
 
-import numpy as np
+import math
+from fractions import Fraction
+from numbers import Real
 
-from .types import CrystallographyNotImplementedError
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from ._guards import _require_cubic
+from .csl import csl_from_scaled_rotation
+from .embedding import (
+    _paired_pq_from_direction_rows,
+    orthogonal_embedding_from_row_rotation_and_plane,
+)
+from .integer import as_positive_int, row_gcd_reduce
+from .orientation import orientation_matrices_from_five_dof
+from .quaternion import integer_quaternion_from_unit, quaternion_to_scaled_rotation
+from .rotation import transpose_rotation_convention
+from .types import CrystallographyValueError
+
+_DEFAULT_MAX_SIGMA = 10_000
+_DEFAULT_MAX_DENOMINATOR = 10_001
+_DEFAULT_ANGLE_TOL = 1.0e-9
+_DEFAULT_PLANE_TOL = 1.0e-9
+
+
+def _positive_tolerance(value: object, name: str) -> float:
+    """Validate and return a finite, strictly positive tolerance.
+
+    Python and NumPy real scalars are accepted and converted to a Python ``float``.
+    Boolean scalars, non-real values, NaN, infinity, and values less than or equal to
+    zero are rejected. No upper bound is imposed: these tolerances are absolute error
+    thresholds rather than fractions or probabilities, so values greater than or equal
+    to one remain well-defined even though they may make an exactification check very
+    permissive.
+
+    :param value: Candidate scalar tolerance to validate.
+    :param name: Parameter name used to identify the invalid value in error messages.
+    :return: ``value`` converted to a finite, strictly positive Python ``float``.
+    :raises CrystallographyValueError: If ``value`` is Boolean, is not a real scalar,
+        cannot be represented as a finite ``float``, or is less than or equal to zero.
+    """
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise CrystallographyValueError(
+            f"{name} must be a finite positive real number; got {value!r}."
+        )
+    result = float(value)
+    if not math.isfinite(result) or result <= 0.0:
+        raise CrystallographyValueError(
+            f"{name} must be a finite positive real number; got {value!r}."
+        )
+    return result
+
+
+def _rationalize_direction(
+    direction: object,
+    *,
+    max_denominator: int,
+    tol: float,
+    name: str,
+) -> np.ndarray:
+    """Recover a primitive integer direction from a floating-point vector.
+
+    The input is interpreted as a direction, so its magnitude is discarded. Component
+    ratios are formed relative to the largest-magnitude normalized component, which
+    avoids dividing by a small coordinate, and each ratio is approximated by a
+    :class:`fractions.Fraction` whose denominator does not exceed ``max_denominator``.
+    The ratios are lifted to a common integer vector, reduced by the GCD of its
+    components, and oriented to point into the same hemisphere as the input vector.
+
+    The recovered primitive direction is accepted only when its normalized components
+    differ from the normalized input by no more than ``tol`` in the infinity norm.
+    ``max_denominator`` and ``tol`` are expected to have been validated by the public
+    caller before this private helper is invoked.
+
+    :param direction: Array-like floating-point direction with shape ``(3,)``. The
+        vector must contain only finite values and must be nonzero.
+    :param max_denominator: Largest denominator permitted for each rationalized
+        component ratio. Keyword argument, required.
+    :param tol: Maximum permitted absolute component error between the normalized input
+        direction and normalized recovered integer direction. Keyword argument,
+        required.
+    :param name: Human-readable parameter name used in validation and exactification
+        error messages. Keyword argument, required.
+    :return: Primitive object-dtype integer vector with shape ``(3,)`` and a sign chosen
+        so that its dot product with the normalized input direction is nonnegative.
+    :raises CrystallographyValueError: If ``direction`` cannot be converted to a finite
+        three-component vector, is the zero vector, or cannot be rationalized within
+        ``tol`` using denominators bounded by ``max_denominator``.
+    """
+    try:
+        vector = np.asarray(direction, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise CrystallographyValueError(
+            f"{name} must be a finite three-component direction."
+        ) from exc
+
+    if vector.shape != (3,):
+        raise CrystallographyValueError(
+            f"{name} must have shape (3,); got {vector.shape}."
+        )
+    if not np.all(np.isfinite(vector)):
+        raise CrystallographyValueError(f"{name} must contain only finite values.")
+
+    norm = float(np.linalg.norm(vector))
+    if norm == 0.0:
+        raise CrystallographyValueError(f"{name} must be nonzero.")
+    target = vector / norm
+
+    reference_index = int(np.argmax(np.abs(target)))
+    reference = float(target[reference_index])
+    fractions = [
+        Fraction(float(component) / reference).limit_denominator(max_denominator)
+        for component in target
+    ]
+    denominator_lcm = math.lcm(*(fraction.denominator for fraction in fractions))
+    integer_direction = np.array(
+        [int(fraction * denominator_lcm) for fraction in fractions],
+        dtype=object,
+    )
+    integer_direction = row_gcd_reduce(integer_direction)
+
+    recovered = np.asarray(integer_direction, dtype=np.float64)
+    recovered /= np.linalg.norm(recovered)
+    if float(np.dot(recovered, target)) < 0.0:
+        integer_direction = -integer_direction
+        recovered = -recovered
+
+    error = float(np.max(np.abs(recovered - target)))
+    if error > tol:
+        raise CrystallographyValueError(
+            f"{name} could not be exactified within {tol=}; "
+            f"maximum component error is {error:.3e}."
+        )
+
+    return integer_direction
 
 
 def exactify_five_dof(
-    params: np.ndarray,
+    params: object,
     *,
     max_exact_atoms: int = 10_000,
+    max_sigma: int = _DEFAULT_MAX_SIGMA,
+    max_denominator: int = _DEFAULT_MAX_DENOMINATOR,
+    angle_tol: float = _DEFAULT_ANGLE_TOL,
+    plane_tol: float = _DEFAULT_PLANE_TOL,
+    lattice_metric: np.ndarray | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Convert five-DOF boundary parameters to exact canonical P/Q matrices.
+    """Exactify five-DOF boundary parameters into paired integer P/Q matrices.
 
-    :param params: Five-DOF parameters ``[alpha, beta, gamma, theta, phi]`` in radians.
-    :param max_exact_atoms: Maximum permitted size of the resulting exact cell. Keyword
-        argument, optional, defaults to ``10000``.
-    :return: Canonical integer orientation matrices ``(P, Q)``.
-    :raises CrystallographyNotImplementedError: Five-DOF exactification is not yet
-        implemented.
+    ``params`` is first converted to left- and right-grain row-orientation matrices using
+    the package five-DOF convention. Their relative misorientation is rationalized
+    through an integer Hamilton quaternion, converted to an exact row-convention scaled
+    rotation, and rejected unless its angular error and CSL sigma satisfy the requested
+    bounds. The left-grain boundary normal is independently rationalized to a primitive
+    integer direction. An orthogonal exact embedding supplies suitable boundary-plane
+    and in-plane directions, which are finally rescaled into exactly paired ``P`` and
+    ``Q`` rows.
+
+    The returned matrices are proper row-wise integer orientation frames and satisfy
+    ``Q == P @ R`` exactly for the recovered rational row rotation ``R``. Equivalently,
+    :func:`recover_exact_row_rotation_from_paired_pq` recovers the same scaled rotation
+    used during construction. The matrices are suitable for
+    ``PQSpec(P=P, Q=Q, basis_mode="primitive")``.
+
+    :param params: Five-DOF parameters ``[alpha, beta, gamma, theta, phi]`` in radians,
+        interpreted by :func:`orientation_matrices_from_five_dof`.
+    :param max_exact_atoms: Positive upper bound used by the orthogonal embedding path
+        for the exact in-plane cell and the absolute determinants of the candidate P/Q
+        supercells. Keyword argument, optional, defaults to ``10000``.
+    :param max_sigma: Positive upper bound on the coincidence-site-lattice sigma of the
+        exactified misorientation. Keyword argument, optional, defaults to ``10000``.
+    :param max_denominator: Positive upper bound used both when recovering the integer
+        quaternion and when rationalizing boundary-normal component ratios. Keyword
+        argument, optional, defaults to ``10001``.
+    :param angle_tol: Finite, strictly positive maximum geodesic rotation error, in
+        radians, between the approximate five-DOF misorientation and the recovered exact
+        misorientation. Keyword argument, optional, defaults to ``1e-9``.
+    :param plane_tol: Finite, strictly positive maximum absolute component error between
+        the normalized floating-point boundary normal and normalized recovered primitive
+        integer normal. Keyword argument, optional, defaults to ``1e-9``.
+    :param lattice_metric: Reserved lattice metric argument. Only ``None``, representing
+        the currently supported implicit cubic metric, is accepted. Keyword argument,
+        optional, defaults to ``None``.
+    :return: ``(P, Q)`` as object-dtype 3 by 3 integer matrices suitable for primitive
+        ``PQSpec`` construction and exactly paired under the recovered row rotation.
+    :raises CrystallographyValueError: If a bound or tolerance is invalid; if ``params``
+        is malformed; if the misorientation cannot be rationalized within
+        ``max_denominator`` and ``angle_tol``; if its CSL sigma exceeds ``max_sigma``;
+        if the boundary normal cannot be rationalized within ``plane_tol``; or if final
+        exact P/Q pairing validation fails.
+    :raises CrystallographyNotImplementedError: If ``lattice_metric`` is not ``None``.
+    :raises BoundarySpecError: If the exact in-plane cell or candidate P/Q supercell
+        exceeds ``max_exact_atoms`` in the orthogonal embedding path.
     """
-    raise CrystallographyNotImplementedError(
-        "Conversion from five-DOF parameters to exact canonical P/Q matrices "
-        "is not implemented."
+    _require_cubic(lattice_metric)
+    max_exact_atoms = as_positive_int(max_exact_atoms, "max_exact_atoms")
+    max_sigma = as_positive_int(max_sigma, "max_sigma")
+    max_denominator = as_positive_int(max_denominator, "max_denominator")
+    angle_tol = _positive_tolerance(angle_tol, "angle_tol")
+    plane_tol = _positive_tolerance(plane_tol, "plane_tol")
+
+    left, right = orientation_matrices_from_five_dof(params)
+    approximate_rotation = left.T @ right
+
+    scalar_last = Rotation.from_matrix(approximate_rotation).as_quat()
+    unit_quaternion = scalar_last[[3, 0, 1, 2]]
+    try:
+        integer_quaternion = integer_quaternion_from_unit(
+            unit_quaternion,
+            max_denominator=max_denominator,
+        )
+    except CrystallographyValueError as exc:
+        raise CrystallographyValueError(
+            "Five-DOF misorientation could not be exactified within "
+            f"{max_denominator=}."
+        ) from exc
+
+    row_rotation = quaternion_to_scaled_rotation(integer_quaternion)
+    exact_rotation = (
+        np.asarray(row_rotation.matrix, dtype=np.float64)
+        / row_rotation.denominator
+    )
+    angular_error = float(
+        Rotation.from_matrix(exact_rotation.T @ approximate_rotation).magnitude()
+    )
+    if angular_error > angle_tol:
+        raise CrystallographyValueError(
+            "Five-DOF misorientation could not be exactified within "
+            f"{angle_tol=}; angular error is {angular_error:.3e} radians."
+        )
+
+    column_rotation = transpose_rotation_convention(row_rotation)
+    csl = csl_from_scaled_rotation(column_rotation)
+    if csl.sigma > max_sigma:
+        raise CrystallographyValueError(
+            f"Exactified CSL sigma {csl.sigma} exceeds {max_sigma=}."
+        )
+
+    plane = _rationalize_direction(
+        left[0],
+        max_denominator=max_denominator,
+        tol=plane_tol,
+        name="boundary plane normal",
+    )
+
+    embedding = orthogonal_embedding_from_row_rotation_and_plane(
+        row_rotation,
+        plane,
+        source="five_dof",
+        max_exact_atoms=max_exact_atoms,
+    )
+    if embedding.P is None or embedding.metadata is None:
+        raise CrystallographyValueError(
+            "Orthogonal exactification did not produce P rows and primitive metadata."
+        )
+
+    return _paired_pq_from_direction_rows(
+        embedding.P,
+        row_rotation,
+        primitive_area_index=embedding.metadata.primitive_area_index,
     )
 
 

--- a/GBOpt/crystallography/exactification.py
+++ b/GBOpt/crystallography/exactification.py
@@ -7,19 +7,27 @@ from __future__ import annotations
 import math
 from fractions import Fraction
 from numbers import Real
+from typing import Sequence
 
 import numpy as np
 from scipy.spatial.transform import Rotation
 
 from ._guards import _require_cubic
+from ._limits import (
+    DEFAULT_MAX_PQ_DETERMINANT,
+    DEFAULT_MAX_PRIMITIVE_AREA_INDEX,
+)
 from .csl import csl_from_scaled_rotation
 from .embedding import (
+    _exact_embedding_from_precomputed_csl,
     _paired_pq_from_direction_rows,
-    exact_embedding_from_row_rotation_and_plane,
 )
 from .integer import as_positive_int, row_gcd_reduce
 from .orientation import orientation_matrices_from_five_dof
-from .quaternion import integer_quaternion_from_unit, quaternion_to_scaled_rotation
+from .quaternion import (
+    _integer_quaternion_candidate_from_unit,
+    quaternion_to_scaled_rotation,
+)
 from .rotation import transpose_rotation_convention
 from .types import CrystallographyValueError
 
@@ -32,23 +40,17 @@ _DEFAULT_PLANE_TOL = 1.0e-9
 def _positive_tolerance(value: object, name: str) -> float:
     """Validate and return a finite, strictly positive tolerance.
 
-    Python and NumPy real scalars are accepted and converted to a Python ``float``.
-    Boolean scalars, non-real values, NaN, infinity, and values less than or equal to
-    zero are rejected. No upper bound is imposed: these tolerances are absolute error
-    thresholds rather than fractions or probabilities, so values greater than or equal
-    to one remain well-defined even though they may make an exactification check very
-    permissive.
-
     :param value: Candidate scalar tolerance to validate.
-    :param name: Parameter name used to identify the invalid value in error messages.
+    :param name: Parameter name used in validation errors.
     :return: ``value`` converted to a finite, strictly positive Python ``float``.
-    :raises CrystallographyValueError: If ``value`` is Boolean, is not a real scalar,
-        cannot be represented as a finite ``float``, or is less than or equal to zero.
+    :raises CrystallographyValueError: If ``value`` is Boolean, non-real, non-finite,
+        or less than or equal to zero.
     """
     if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
         raise CrystallographyValueError(
             f"{name} must be a finite positive real number; got {value!r}."
         )
+
     result = float(value)
     if not math.isfinite(result) or result <= 0.0:
         raise CrystallographyValueError(
@@ -57,41 +59,19 @@ def _positive_tolerance(value: object, name: str) -> float:
     return result
 
 
-def _rationalize_direction(
-    direction: object,
-    *,
-    max_denominator: int,
-    tol: float,
-    name: str,
-) -> np.ndarray:
-    """Recover a primitive integer direction from a floating-point vector.
+def _unit_float_direction(direction: object, name: str) -> np.ndarray:
+    """Return a scale-safe unit vector for a finite nonzero 3-vector.
 
-    The input is interpreted as a direction, so its magnitude is discarded. Component
-    ratios are formed relative to the largest-magnitude normalized component, which
-    avoids dividing by a small coordinate, and each ratio is approximated by a
-    :class:`fractions.Fraction` whose denominator does not exceed ``max_denominator``.
-    The ratios are lifted to a common integer vector, reduced by the GCD of its
-    components, and oriented to point into the same hemisphere as the input vector.
+    The vector is divided by its largest absolute component before its Euclidean norm is
+    evaluated. This prevents overflow for very large finite vectors and underflow for
+    nonzero subnormal vectors. Magnitude is intentionally ignored: exactification treats
+    the input only as a direction and therefore applies no minimum-norm threshold.
 
-    The recovered primitive direction is accepted only when its normalized components
-    differ from the normalized input by no more than ``tol`` in the infinity norm.
-    ``max_denominator`` and ``tol`` are expected to have been validated by the public
-    caller before this private helper is invoked.
-
-    :param direction: Array-like floating-point direction with shape ``(3,)``. The
-        vector must contain only finite values and must be nonzero.
-    :param max_denominator: Largest denominator permitted for each rationalized
-        component ratio. Keyword argument, required.
-    :param tol: Maximum permitted absolute component error between the normalized input
-        direction and normalized recovered integer direction. Keyword argument,
-        required.
-    :param name: Human-readable parameter name used in validation and exactification
-        error messages. Keyword argument, required.
-    :return: Primitive object-dtype integer vector with shape ``(3,)`` and a sign chosen
-        so that its dot product with the normalized input direction is nonnegative.
+    :param direction: Candidate three-component direction.
+    :param name: Human-readable argument name used in validation errors.
+    :return: Unit-length ``float64`` vector with shape ``(3,)``.
     :raises CrystallographyValueError: If ``direction`` cannot be converted to a finite
-        three-component vector, is the zero vector, or cannot be rationalized within
-        ``tol`` using denominators bounded by ``max_denominator``.
+        three-component vector or is exactly zero.
     """
     try:
         vector = np.asarray(direction, dtype=np.float64)
@@ -107,10 +87,68 @@ def _rationalize_direction(
     if not np.all(np.isfinite(vector)):
         raise CrystallographyValueError(f"{name} must contain only finite values.")
 
-    norm = float(np.linalg.norm(vector))
-    if norm == 0.0:
+    scale = float(np.max(np.abs(vector)))
+    if scale == 0.0:
         raise CrystallographyValueError(f"{name} must be nonzero.")
-    target = vector / norm
+
+    scaled = vector / scale
+    return scaled / np.linalg.norm(scaled)
+
+
+def _unit_integer_vector(values: Sequence[int]) -> np.ndarray:
+    """Return a scale-safe unit vector for a nonzero integer sequence.
+
+    The values are scaled by their largest absolute component before normalization,
+    avoiding unnecessary overflow during conversion to floating point.
+
+    :param values: Nonzero sequence of integer components.
+    :return: Unit-length ``float64`` vector with the same number of components as
+        ``values``.
+    :raises CrystallographyValueError: If every component is zero.
+    """
+    integers = tuple(int(value) for value in values)
+    scale = max(map(abs, integers))
+    if scale == 0:
+        raise CrystallographyValueError("integer direction must be nonzero.")
+
+    scaled = np.fromiter(
+        (value / scale for value in integers),
+        dtype=np.float64,
+        count=len(integers),
+    )
+    return scaled / np.linalg.norm(scaled)
+
+
+def _rationalize_direction(
+    direction: object,
+    *,
+    max_denominator: int,
+    tol: float,
+    name: str,
+) -> np.ndarray:
+    """Recover a primitive integer direction from a floating-point vector.
+
+    The input magnitude is discarded. Component ratios are formed relative to the
+    largest-magnitude unit-vector component, rationalized with bounded denominators,
+    lifted to a common integer vector, and GCD-reduced. The candidate is accepted only
+    when its unit direction differs from the requested direction by no more than ``tol``
+    in the infinity norm.
+
+    ``max_denominator`` and ``tol`` are assumed to have been validated by the caller.
+
+    :param direction: Finite nonzero array-like direction with shape ``(3,)``.
+    :param max_denominator: Largest denominator permitted for each component ratio.
+        Keyword argument.
+    :param tol: Maximum permitted unit-component error in the infinity norm. Keyword
+        argument.
+    :param name: Human-readable argument name used in validation errors. Keyword
+        argument.
+    :return: Primitive object-dtype integer direction with the input hemisphere
+        retained.
+    :raises CrystallographyValueError: If the direction is invalid or cannot be
+        rationalized within the requested bounds.
+    """
+    target = _unit_float_direction(direction, name)
 
     reference_index = int(np.argmax(np.abs(target)))
     reference = float(target[reference_index])
@@ -119,14 +157,14 @@ def _rationalize_direction(
         for component in target
     ]
     denominator_lcm = math.lcm(*(fraction.denominator for fraction in fractions))
-    integer_direction = np.array(
-        [int(fraction * denominator_lcm) for fraction in fractions],
-        dtype=object,
+    integer_direction = row_gcd_reduce(
+        np.array(
+            [int(fraction * denominator_lcm) for fraction in fractions],
+            dtype=object,
+        )
     )
-    integer_direction = row_gcd_reduce(integer_direction)
 
-    recovered = np.asarray(integer_direction, dtype=np.float64)
-    recovered /= np.linalg.norm(recovered)
+    recovered = _unit_integer_vector(integer_direction)
     if float(np.dot(recovered, target)) < 0.0:
         integer_direction = -integer_direction
         recovered = -recovered
@@ -141,10 +179,33 @@ def _rationalize_direction(
     return integer_direction
 
 
+def _quaternion_angular_error(
+    target: np.ndarray,
+    integer_quaternion: Sequence[int],
+) -> float:
+    """Return the geodesic rotation error for an integer quaternion candidate.
+
+    Quaternion sign equivalence is accounted for before the error is calculated.
+
+    :param target: Target unit quaternion in Hamilton scalar-first order.
+    :param integer_quaternion: Nonzero integer quaternion candidate in Hamilton
+        scalar-first order.
+    :return: Geodesic rotation error in radians.
+    :raises CrystallographyValueError: If ``integer_quaternion`` is the zero quaternion.
+    """
+    recovered = _unit_integer_vector(integer_quaternion)
+    if float(np.dot(recovered, target)) < 0.0:
+        recovered = -recovered
+
+    chord = float(np.linalg.norm(recovered - target))
+    return 4.0 * math.asin(min(1.0, 0.5 * chord))
+
+
 def exactify_five_dof(
     params: object,
     *,
-    max_exact_atoms: int = 10_000,
+    max_primitive_area_index: int = DEFAULT_MAX_PRIMITIVE_AREA_INDEX,
+    max_pq_determinant: int = DEFAULT_MAX_PQ_DETERMINANT,
     max_sigma: int = _DEFAULT_MAX_SIGMA,
     max_denominator: int = _DEFAULT_MAX_DENOMINATOR,
     angle_tol: float = _DEFAULT_ANGLE_TOL,
@@ -153,53 +214,59 @@ def exactify_five_dof(
 ) -> tuple[np.ndarray, np.ndarray]:
     """Exactify five-DOF boundary parameters into paired integer P/Q matrices.
 
-    ``params`` is first converted to left- and right-grain row-orientation matrices using
-    the package five-DOF convention. Their relative misorientation is rationalized
-    through an integer Hamilton quaternion, converted to an exact row-convention scaled
-    rotation, and rejected unless its angular error and CSL sigma satisfy the requested
-    bounds. The left-grain boundary normal is independently rationalized to a primitive
-    integer direction. An orthogonal exact embedding supplies suitable boundary-plane
-    and in-plane directions, which are finally rescaled into exactly paired ``P`` and
-    ``Q`` rows.
+    The five-DOF parameters are first converted to floating-point left- and right-grain
+    row-orientation matrices. Their relative misorientation is represented as a unit
+    quaternion and rationalized to a bounded-denominator primitive integer quaternion.
+    The candidate is accepted only when its geodesic rotation error does not exceed
+    ``angle_tol``.
 
-    The returned matrices are proper row-wise integer orientation frames and satisfy
-    ``Q == P @ R`` exactly for the recovered rational row rotation ``R``. Equivalently,
-    :func:`recover_exact_row_rotation_from_paired_pq` recovers the same scaled rotation
-    used during construction. The matrices are suitable for
-    ``PQSpec(P=P, Q=Q, basis_mode="primitive")``.
+    The accepted quaternion defines an exact row-convention scaled rotation. Its
+    column-convention transpose is used to construct a CSL whose Sigma value must not
+    exceed ``max_sigma``. The left-grain boundary normal is independently rationalized
+    to a primitive integer direction whose unit-component error must not exceed
+    ``plane_tol``.
 
-    :param params: Five-DOF parameters ``[alpha, beta, gamma, theta, phi]`` in radians,
-        interpreted by :func:`orientation_matrices_from_five_dof`.
-    :param max_exact_atoms: Positive upper bound used by the orthogonal embedding path
-        for the exact in-plane cell and the absolute determinants of the candidate P/Q
-        supercells. Keyword argument, optional, defaults to ``10000``.
-    :param max_sigma: Positive upper bound on the coincidence-site-lattice sigma of the
-        exactified misorientation. Keyword argument, optional, defaults to ``10000``.
-    :param max_denominator: Positive upper bound used both when recovering the integer
-        quaternion and when rationalizing boundary-normal component ratios. Keyword
-        argument, optional, defaults to ``10001``.
-    :param angle_tol: Finite, strictly positive maximum geodesic rotation error, in
-        radians, between the approximate five-DOF misorientation and the recovered exact
-        misorientation. Keyword argument, optional, defaults to ``1e-9``.
-    :param plane_tol: Finite, strictly positive maximum absolute component error between
-        the normalized floating-point boundary normal and normalized recovered primitive
-        integer normal. Keyword argument, optional, defaults to ``1e-9``.
-    :param lattice_metric: Reserved lattice metric argument. Only ``None``, representing
-        the currently supported implicit cubic metric, is accepted. Keyword argument,
-        optional, defaults to ``None``.
-    :return: ``(P, Q)`` as object-dtype 3 by 3 integer matrices suitable for primitive
-        ``PQSpec`` construction and exactly paired under the recovered row rotation.
-    :raises CrystallographyValueError: If a bound or tolerance is invalid; if ``params``
-        is malformed; if the misorientation cannot be rationalized within
-        ``max_denominator`` and ``angle_tol``; if its CSL sigma exceeds ``max_sigma``;
-        if the boundary normal cannot be rationalized within ``plane_tol``; or if final
-        exact P/Q pairing validation fails.
+    An exact embedding is selected from the constructed CSL. Its directions are then
+    converted into minimally scaled paired P/Q rows that recover the same exact row
+    rotation. ``max_primitive_area_index`` bounds the minimal in-plane CSL topology,
+    while ``max_pq_determinant`` bounds both the selected embedding matrices and the
+    final paired matrices.
+
+    :param params: Five-DOF parameters ``[alpha, beta, gamma, theta, phi]`` in radians.
+    :param max_primitive_area_index: Maximum permitted minimal in-plane CSL area index.
+        Keyword argument, optional, defaults to ``DEFAULT_MAX_PRIMITIVE_AREA_INDEX``.
+    :param max_pq_determinant: Maximum permitted absolute determinant of each exact P/Q
+        matrix produced during embedding selection and final row pairing. Keyword
+        argument, optional, defaults to ``DEFAULT_MAX_PQ_DETERMINANT``.
+    :param max_sigma: Maximum permitted CSL coincidence index. Keyword argument,
+        optional, defaults to ``_DEFAULT_MAX_SIGMA``.
+    :param max_denominator: Maximum denominator used when rationalizing quaternion and
+        boundary-normal component ratios. Keyword argument, optional, defaults to
+        ``_DEFAULT_MAX_DENOMINATOR``.
+    :param angle_tol: Maximum permitted geodesic misorientation error in radians.
+        Keyword argument, optional, defaults to ``_DEFAULT_ANGLE_TOL``.
+    :param plane_tol: Maximum permitted infinity-norm component error between the
+        requested unit boundary normal and its recovered primitive integer direction.
+        Keyword argument, optional, defaults to ``_DEFAULT_PLANE_TOL``.
+    :param lattice_metric: Reserved non-cubic lattice metric. Only ``None`` is currently
+        supported. Keyword argument, optional, defaults to ``None``.
+    :return: Exactly paired object-dtype integer matrices ``(P, Q)`` suitable for
+        ``PQSpec(P=P, Q=Q, basis_mode="primitive")``.
+    :raises CrystallographyValueError: If a bound or tolerance is invalid, the
+        misorientation or plane cannot be exactified within the requested limits, the
+        derived Sigma value is too large, or exact embedding construction does not
+        produce the required integer rows and metadata.
     :raises CrystallographyNotImplementedError: If ``lattice_metric`` is not ``None``.
-    :raises BoundarySpecError: If the exact in-plane cell or candidate P/Q supercell
-        exceeds ``max_exact_atoms`` in the orthogonal embedding path.
     """
     _require_cubic(lattice_metric)
-    max_exact_atoms = as_positive_int(max_exact_atoms, "max_exact_atoms")
+    max_primitive_area_index = as_positive_int(
+        max_primitive_area_index,
+        "max_primitive_area_index",
+    )
+    max_pq_determinant = as_positive_int(
+        max_pq_determinant,
+        "max_pq_determinant",
+    )
     max_sigma = as_positive_int(max_sigma, "max_sigma")
     max_denominator = as_positive_int(max_denominator, "max_denominator")
     angle_tol = _positive_tolerance(angle_tol, "angle_tol")
@@ -211,30 +278,25 @@ def exactify_five_dof(
     scalar_last = Rotation.from_matrix(approximate_rotation).as_quat()
     unit_quaternion = scalar_last[[3, 0, 1, 2]]
     try:
-        integer_quaternion = integer_quaternion_from_unit(
+        integer_quaternion = _integer_quaternion_candidate_from_unit(
             unit_quaternion,
             max_denominator=max_denominator,
         )
     except CrystallographyValueError as exc:
         raise CrystallographyValueError(
-            "Five-DOF misorientation could not be exactified within "
-            f"{max_denominator=}."
+            "Five-DOF misorientation could not produce an integer quaternion "
+            f"candidate with {max_denominator=}: {exc}"
         ) from exc
 
-    row_rotation = quaternion_to_scaled_rotation(integer_quaternion)
-    exact_rotation = (
-        np.asarray(row_rotation.matrix, dtype=np.float64)
-        / row_rotation.denominator
-    )
-    angular_error = float(
-        Rotation.from_matrix(exact_rotation.T @ approximate_rotation).magnitude()
-    )
+    angular_error = _quaternion_angular_error(unit_quaternion, integer_quaternion)
     if angular_error > angle_tol:
         raise CrystallographyValueError(
-            "Five-DOF misorientation could not be exactified within "
-            f"{angle_tol=}; angular error is {angular_error:.3e} radians."
+            "Five-DOF misorientation could not be exactified with "
+            f"{max_denominator=} within {angle_tol=}; angular error is "
+            f"{angular_error:.3e} radians."
         )
 
+    row_rotation = quaternion_to_scaled_rotation(integer_quaternion)
     column_rotation = transpose_rotation_convention(row_rotation)
     csl = csl_from_scaled_rotation(column_rotation)
     if csl.sigma > max_sigma:
@@ -249,21 +311,25 @@ def exactify_five_dof(
         name="boundary plane normal",
     )
 
-    embedding = exact_embedding_from_row_rotation_and_plane(
+    embedding = _exact_embedding_from_precomputed_csl(
         row_rotation,
         plane,
+        csl,
         source="five_dof",
-        max_exact_atoms=max_exact_atoms,
+        max_primitive_area_index=max_primitive_area_index,
+        max_pq_determinant=max_pq_determinant,
     )
     if embedding.P is None or embedding.metadata is None:
         raise CrystallographyValueError(
-            "Orthogonal exactification did not produce P rows and primitive metadata."
+            "Exact embedding did not produce integer direction rows and primitive "
+            "cell metadata."
         )
 
     return _paired_pq_from_direction_rows(
         embedding.P,
         row_rotation,
         primitive_area_index=embedding.metadata.primitive_area_index,
+        max_pq_determinant=max_pq_determinant,
     )
 
 

--- a/GBOpt/crystallography/integer.py
+++ b/GBOpt/crystallography/integer.py
@@ -10,6 +10,7 @@ rank-deficient inputs rather than silently rounding.
 
 from __future__ import annotations
 
+import operator
 from collections.abc import Callable
 from typing import TypeVar
 
@@ -65,6 +66,37 @@ def as_int_vector(values: ArrayLike, length: int, name: str) -> tuple[int, ...]:
     return _translate_exact_error(ilinalg.as_int_vector, values, length, name)
 
 
+def as_positive_int(value: object, name: str) -> int:
+    """Return a positive Python integer from an integer scalar.
+
+    Boolean values are rejected even though ``bool`` is a subclass of ``int``.
+
+    :param value: Candidate Python or NumPy integer scalar.
+    :param name: Parameter name used in validation error messages.
+    :return: Validated value converted to a Python ``int``.
+    :raises CrystallographyValueError: If ``value`` is not an integer scalar or is
+        less than or equal to zero.
+    """
+    if isinstance(value, (bool, np.bool_)):
+        raise CrystallographyValueError(
+            f"{name} must be a positive integer; got {value!r}."
+        )
+
+    try:
+        result = operator.index(value)  # type: ignore[ty:invalid-argument-type]
+    except TypeError as exc:
+        raise CrystallographyValueError(
+            f"{name} must be a positive integer; got {value!r}."
+        ) from exc
+
+    if result <= 0:
+        raise CrystallographyValueError(
+            f"{name} must be a positive integer; got {value!r}."
+        )
+
+    return int(result)
+
+
 def row_gcd_reduce(row: np.ndarray) -> np.ndarray:
     """Divide an integer-valued row by the GCD of its absolute components.
 
@@ -116,6 +148,7 @@ def integer_adj3(matrix: ArrayLike) -> list[list[int]]:
 __all__ = [
     "as_int_array",
     "as_int_vector",
+    "as_positive_int",
     "row_gcd_reduce",
     "dot_int",
     "cross_int3",

--- a/GBOpt/crystallography/integer.py
+++ b/GBOpt/crystallography/integer.py
@@ -48,6 +48,8 @@ def as_int_array(array: ArrayLike, shape: tuple[int, ...], name: str) -> np.ndar
         or 2D tuple ``(m, n)``.
     :param name: Name used in error messages.
     :return: Object-dtype ndarray of Python integers.
+    :raises CrystallographyValueError: If ``array`` has the wrong shape or contains an
+        entry that is not exactly integer-valued.
     """
     return _translate_exact_error(ilinalg.as_int_array, array, shape, name)
 
@@ -62,6 +64,8 @@ def as_int_vector(values: ArrayLike, length: int, name: str) -> tuple[int, ...]:
     :param length: Expected number of elements.
     :param name: Name used in error messages.
     :return: Tuple of Python ints.
+    :raises CrystallographyValueError: If ``values`` has the wrong length or contains an
+        entry that is not exactly integer-valued.
     """
     return _translate_exact_error(ilinalg.as_int_vector, values, length, name)
 
@@ -103,6 +107,8 @@ def row_gcd_reduce(row: np.ndarray) -> np.ndarray:
     :param row: One-dimensional integer-valued row.
     :return: GCD-reduced row as object-dtype array of Python integers. An all-zero row
         is returned unchanged.
+    :raises CrystallographyValueError: If ``row`` is malformed or contains a value that
+        is not exactly integer-valued.
     """
     return _translate_exact_error(ilinalg.row_gcd_reduce, row)
 
@@ -113,6 +119,8 @@ def dot_int(x: ArrayLike, y: ArrayLike) -> int:
     :param x: First array-like vector.
     :param y: Second array-like vector.
     :return: Exact Python-int dot product.
+    :raises CrystallographyValueError: If either operand is malformed, contains a
+        non-integer value, or the operands have unequal lengths.
     """
     return _translate_exact_error(ilinalg.dot_int, x, y)
 
@@ -123,6 +131,8 @@ def cross_int3(x: ArrayLike, y: ArrayLike) -> np.ndarray:
     :param x: First length-3 array-like vector.
     :param y: Second length-3 array-like vector.
     :return: Length-3 object-dtype cross product.
+    :raises CrystallographyValueError: If either operand is not an exact integer vector
+        of length three.
     """
     return _translate_exact_error(ilinalg.cross_int3, x, y)
 
@@ -132,6 +142,8 @@ def integer_det3(matrix: ArrayLike) -> int:
 
     :param matrix: 3 by 3 integer-valued matrix.
     :return: Exact Python-int determinant.
+    :raises CrystallographyValueError: If ``matrix`` is not an exact integer matrix with
+        shape ``(3, 3)``.
     """
     return _translate_exact_error(ilinalg.det3_int, matrix)
 
@@ -141,6 +153,8 @@ def integer_adj3(matrix: ArrayLike) -> list[list[int]]:
 
     :param matrix: 3 by 3 integer-valued matrix.
     :return: 3 by 3 list-of-lists representing ``adj(matrix)``.
+    :raises CrystallographyValueError: If ``matrix`` is not an exact integer matrix with
+        shape ``(3, 3)``.
     """
     return _translate_exact_error(ilinalg.adjugate3_int, matrix)
 

--- a/GBOpt/crystallography/orientation.py
+++ b/GBOpt/crystallography/orientation.py
@@ -669,16 +669,21 @@ def _zxz_euler_angles(rotation: np.ndarray) -> np.ndarray:
     :return: A ``numpy.ndarray`` with shape ``(3,)`` containing ``[alpha, beta, gamma]``
         in radians. At a gimbal-lock singularity, the returned values are SciPy's
         canonical representative and are not a unique Euler decomposition.
-    :raises ValueError: If ``rotation`` does not have an acceptable matrix shape or
-        cannot be interpreted by SciPy as a valid rotation.
+    :raises CrystallographyValueError: If SciPy cannot interpret ``rotation`` as a valid
+        rotation or convert it to intrinsic ZXZ Euler angles.
     """
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message="Gimbal lock detected.*",
-            category=UserWarning,
-        )
-        return Rotation.from_matrix(rotation).as_euler("ZXZ")
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Gimbal lock detected.*",
+                category=UserWarning,
+            )
+            return Rotation.from_matrix(rotation).as_euler("ZXZ")
+    except ValueError as exc:
+        raise CrystallographyValueError(
+            "rotation could not be converted to intrinsic ZXZ Euler angles."
+        ) from exc
 
 
 def five_dof_from_axis_angle(
@@ -708,8 +713,6 @@ def five_dof_from_axis_angle(
     :raises CrystallographyValueError: If ``tol`` is invalid, either direction is
         malformed, non-finite, or zero, or ``angle_deg`` is Boolean, non-real, or
         non-finite.
-    :raises ValueError: If SciPy cannot convert the constructed rotation matrix to an
-        intrinsic ZXZ Euler-angle representation.
     """
     tol = _validated_tolerance(tol, "tol")
     _, rotation, _ = _axis_angle_rotation(rotation_axis, angle_deg, tol=tol)

--- a/GBOpt/crystallography/orientation.py
+++ b/GBOpt/crystallography/orientation.py
@@ -135,22 +135,20 @@ def _normalize_direction(
     *,
     tol: float,
 ) -> np.ndarray:
-    """Normalize a three-component direction using a prevalidated tolerance.
+    """Normalize a direction using a prevalidated tolerance.
 
-    This internal helper converts ``direction`` to a finite ``float64`` vector, verifies
-    that its Euclidean norm is greater than ``tol``, and returns the corresponding unit
-    vector. Unlike :func:`normalize_direction`, it does not validate ``tol``; callers
-    should use it only after validating a shared tolerance value.
+    The direction is converted to a finite ``float64`` vector, checked against the
+    minimum permitted norm, and normalized. Unlike ``normalize_direction``, this helper
+    does not validate ``tol``.
 
     :param direction: Array-like object containing exactly three finite numeric
-        components. The direction need not already have unit length.
+        components.
     :param name: Human-readable argument name used in validation error messages.
-    :param tol: Prevalidated, finite, strictly positive lower bound for the direction's
-        Euclidean norm.
-    :return: Unit-length ``numpy.float64`` vector with shape ``(3,)``.
-    :raises CrystallographyValueError: If ``direction`` cannot be converted to a
-        three-component numeric vector, contains a non-finite value, or has a norm less
-        than or equal to ``tol``.
+    :param tol: Prevalidated finite, strictly positive lower bound for the vector norm.
+        Keyword argument.
+    :return: Unit-length ``float64`` vector with shape ``(3,)``.
+    :raises CrystallographyValueError: If ``direction`` is malformed, contains a
+        non-finite value, or has norm less than or equal to ``tol``.
     """
     vector = _vector3(direction, name)
     norm = float(np.linalg.norm(vector))
@@ -170,16 +168,18 @@ def validate_orientation_matrix(
     """Return a normalized, validated row-wise orientation matrix.
 
     Rows identify the crystal directions aligned with the lab-frame x, y, and z axes.
-    The rows must be finite, nonzero, mutually orthogonal, and right-handed. Row lengths
+    They must be finite, nonzero, mutually orthogonal, and right-handed. Row lengths
     need not be one on input; the returned matrix is row-normalized.
 
     :param matrix: Candidate row-wise orientation matrix.
-    :param name: Matrix name used in error messages. Optional.
-    :param tol: Absolute orthogonality and determinant tolerance. Keyword parameter,
-        optional, defaults to ``1e-10``.
+    :param name: Matrix name used in error messages. Optional, defaults to
+        ``"orientation matrix"``.
+    :param tol: Absolute tolerance used for row norms, orthogonality, and determinant
+        validation. Keyword argument, optional, defaults to
+        ``_DEFAULT_ORIENTATION_TOL``.
     :return: Normalized ``float64`` matrix with shape ``(3, 3)``.
-    :raises CrystallographyValueError: If the matrix is malformed or is not a proper
-        row-wise orientation matrix.
+    :raises CrystallographyValueError: If ``tol`` is invalid or ``matrix`` is malformed,
+        non-finite, degenerate, nonorthogonal, or not right-handed.
     """
     tol = _validated_tolerance(tol, "tol")
     return _validate_orientation_matrix(matrix, name, tol=tol)
@@ -193,27 +193,19 @@ def _validate_orientation_matrix(
 ) -> np.ndarray:
     """Normalize and validate a row-wise orientation matrix.
 
-    Each row identifies the crystal direction aligned with one Cartesian laboratory
-    axis. The candidate matrix is converted to ``float64``, checked for the required
-    shape and finite values, and normalized row by row. The normalized rows must form a
-    mutually orthogonal, right-handed frame.
+    The candidate is converted to ``float64``, checked for shape and finite values, and
+    normalized row by row. The normalized rows must form a mutually orthogonal,
+    right-handed frame. This helper assumes that ``tol`` has already been validated.
 
-    Unlike :func:`validate_orientation_matrix`, this internal helper assumes that
-    ``tol`` has already been validated as finite and strictly positive. It is intended
-    for call paths that reuse one tolerance across multiple validation operations.
-
-    :param matrix: Array-like candidate orientation matrix with shape ``(3, 3)``. Its
-        rows may have arbitrary nonzero magnitudes but must become mutually orthogonal
-        and right-handed after normalization.
+    :param matrix: Candidate orientation matrix with shape ``(3, 3)``. Its rows may have
+        arbitrary nonzero magnitudes.
     :param name: Human-readable matrix name used in validation error messages.
-    :param tol: Prevalidated absolute tolerance used for minimum row norms, Gram-matrix
-        orthogonality error, and deviation of the normalized determinant from ``+1``.
-    :return: Row-normalized ``numpy.float64`` matrix with shape ``(3, 3)`` whose rows
-        form a proper right-handed orthonormal frame.
-    :raises CrystallographyValueError: If ``matrix`` cannot be converted to a numeric
-        array, does not have shape ``(3, 3)``, contains non-finite values, contains a
-        row whose norm is less than or equal to ``tol``, is not orthogonal within
-        ``tol``, or is not right-handed within ``tol``.
+    :param tol: Prevalidated absolute tolerance used for row norms, Gram-matrix error,
+        and determinant error. Keyword argument.
+    :return: Row-normalized ``float64`` matrix with shape ``(3, 3)``.
+    :raises CrystallographyValueError: If ``matrix`` cannot be converted, has the wrong
+        shape, contains non-finite or zero rows, is not orthogonal within ``tol``, or is
+        not right-handed within ``tol``.
     """
     try:
         candidate = np.asarray(matrix, dtype=np.float64)
@@ -271,25 +263,21 @@ def _project_into_plane(
 ) -> np.ndarray:
     """Project a direction into the plane perpendicular to a unit normal.
 
-    The supplied direction is validated, projected directly, and the remaining in-plane
-    component is normalized.
+    The direction is validated, projected directly, and normalized. This helper assumes
+    that ``normal`` is a finite unit vector with shape ``(3,)`` and that ``tol`` has
+    already been validated.
 
-    This private helper assumes that ``normal`` is a finite unit vector with shape
-    ``(3,)`` and that ``tol`` is finite and strictly positive.
-
-    :param direction: Array-like three-component direction to project. It need not be
-        normalized, but it must be finite and nonzero.
-    :param normal: Validated unit vector with shape ``(3,)`` defining the normal of the
-        target plane.
-    :param name: Human-readable name for ``direction``. This value is included in
-        validation error messages to identify the invalid argument.
-    :param tol: Strictly positive numerical tolerance used when validating the direction
-        magnitude and determining whether the projected component is effectively zero.
-    :return: A unit-length ``numpy.float64`` vector with shape ``(3,)`` that lies in the
-        plane perpendicular to ``normal``.
-    :raises CrystallographyValueError: If ``direction`` cannot be interpreted as a
-        finite, nonzero three-component vector, or if it is parallel to ``normal``
-        within ``tol`` and therefore has no nonzero in-plane projection.
+    :param direction: Three-component direction to project. It need not be normalized,
+        but it must be finite and nonzero.
+    :param normal: Unit vector with shape ``(3,)`` defining the target plane.
+    :param name: Human-readable name for ``direction`` used in validation errors.
+        Keyword argument.
+    :param tol: Positive tolerance used to detect zero input and a vanishing projected
+        component. Keyword argument.
+    :return: Unit-length ``float64`` vector with shape ``(3,)`` lying in the plane
+        perpendicular to ``normal``.
+    :raises CrystallographyValueError: If ``direction`` is malformed, non-finite,
+        effectively zero, or parallel to ``normal`` within ``tol``.
     """
     vector = _vector3(direction, name)
     vector_norm = float(np.linalg.norm(vector))
@@ -312,24 +300,19 @@ def _default_in_plane_reference(
     *,
     tol: float,
 ) -> np.ndarray:
-    """Choose a stable default direction in the plane perpendicular to a normal.
+    """Choose a stable default direction perpendicular to a unit normal.
 
-    The Cartesian basis vector least aligned with ``normal`` is selected as a seed. That
-    seed is projected into the plane perpendicular to ``normal`` and normalized.
-    Selecting the least-aligned basis vector avoids an unstable projection from a seed
-    that is nearly parallel to the normal.
+    The Cartesian basis vector least aligned with ``normal`` is selected as a seed,
+    projected into the perpendicular plane, and normalized. This helper assumes that
+    ``normal`` is a finite unit vector and that ``tol`` has already been validated.
 
-    This private helper assumes that ``normal`` is a finite unit vector with shape
-    ``(3,)`` and that ``tol`` is finite and strictly positive.
-
-    :param normal: Validated unit vector with shape ``(3,)`` defining the boundary-plane
-        normal.
-    :param tol: Strictly positive numerical tolerance used when projecting and
-        normalizing the selected Cartesian seed.
-    :return: A unit-length ``numpy.float64`` vector with shape ``(3,)`` lying in the
-        plane perpendicular to ``normal``.
-    :raises CrystallographyValueError: If the selected Cartesian seed cannot be
-        projected to a nonzero in-plane direction within ``tol``.
+    :param normal: Unit boundary-plane normal with shape ``(3,)``.
+    :param tol: Positive tolerance used while projecting and normalizing the selected
+        seed. Keyword argument.
+    :return: Unit-length ``float64`` vector with shape ``(3,)`` perpendicular to
+        ``normal``.
+    :raises CrystallographyValueError: If the selected seed cannot be projected to a
+        nonzero direction within ``tol``.
     """
     seed = np.zeros(3, dtype=np.float64)
     seed[int(np.argmin(np.abs(normal)))] = 1.0
@@ -371,26 +354,21 @@ def _axis_angle_rotation(
 ) -> tuple[np.ndarray, np.ndarray, float]:
     """Validate an axis-angle description and construct its rotation matrix.
 
-    The rotation axis is converted to a finite three-component vector and normalized.
-    The angle is validated as a finite, non-boolean real scalar in degrees. SciPy's
-    rotation-vector convention is then used to construct the corresponding proper
-    rotation matrix.
+    The rotation axis is normalized, the angle is validated as a finite non-boolean real
+    value in degrees, and SciPy's rotation-vector convention is used to construct the
+    corresponding proper rotation matrix. This helper assumes that ``tol`` has already
+    been validated as finite and strictly positive.
 
-    :param rotation_axis: Array-like three-component rotation axis in crystal
-        coordinates. It need not be normalized, but it must be finite and nonzero.
-    :param angle_deg: Rotation angle in degrees. It must be a finite, non-boolean real
-        scalar.
-    :param tol: Strictly positive numerical tolerance used when validating and
-        normalizing ``rotation_axis``.
-    :return: A tuple ``(axis_hat, rotation, angle)`` where ``axis_hat`` is the
-        normalized ``numpy.float64`` rotation axis with shape ``(3,)``, ``rotation`` is
-        the corresponding proper ``numpy.float64`` rotation matrix with shape ``(3,
-        3)``, and ``angle`` is the validated angle as a Python ``float`` in degrees.
-    This private helper assumes that ``tol`` is finite and strictly positive.
-
-    :raises CrystallographyValueError: If ``rotation_axis`` cannot be interpreted as a
-        finite, nonzero three-component vector, or if ``angle_deg`` is boolean,
-        non-real, or non-finite.
+    :param rotation_axis: Three-component rotation axis in crystal coordinates. It need
+        not be normalized, but it must be finite and nonzero.
+    :param angle_deg: Rotation angle in degrees.
+    :param tol: Positive tolerance used when normalizing ``rotation_axis``. Keyword
+        argument.
+    :return: Tuple ``(axis_hat, rotation, angle)`` containing the normalized ``float64``
+        axis, the corresponding 3 by 3 rotation matrix, and the validated angle as a
+        Python ``float``.
+    :raises CrystallographyValueError: If ``rotation_axis`` is malformed, non-finite, or
+        zero, or if ``angle_deg`` is Boolean, non-real, or non-finite.
     """
     axis = _normalize_direction(rotation_axis, "rotation axis", tol=tol)
     angle = _finite_float(angle_deg, "angle_deg")
@@ -412,20 +390,22 @@ def build_tilt_orientations(
 ) -> tuple[np.ndarray, np.ndarray]:
     """Build row-orientation matrices for a general pure-tilt boundary.
 
-    ``left_boundary_normal`` is the boundary normal expressed in the left crystal. The
-    tilt axis must lie in the boundary plane. The right orientation is generated by the
-    requested relative rotation. This constructor does not label the result symmetric;
-    symmetry requires an independently specified median plane and is handled by
-    :func:`build_symmetric_tilt_orientations`.
+    ``left_boundary_normal`` is expressed in the left crystal, and ``tilt_axis`` must
+    lie in its boundary plane. The right orientation is generated by the requested
+    relative rotation. Symmetric placement around a median plane is handled separately
+    by ``build_symmetric_tilt_orientations``.
 
-    The returned floating-point matrices are suitable for five-DOF conversion. They are
+    The returned floating-point matrices are suitable for five-DOF conversion but are
     not guaranteed to be exact integer ``PQSpec`` input.
 
     :param left_boundary_normal: Boundary normal in left-grain crystal coordinates.
     :param tilt_axis: Common tilt axis in crystal coordinates.
     :param angle_deg: Relative misorientation angle in degrees.
-    :param tol: Numerical tolerance. Keyword parameter, optional.
-    :return: ``(P, Q)`` normalized row-orientation matrices.
+    :param tol: Numerical tolerance used for vector and geometric validation. Keyword
+        argument, optional, defaults to ``_DEFAULT_ORIENTATION_TOL``.
+    :return: Tuple ``(P, Q)`` of normalized row-orientation matrices.
+    :raises CrystallographyValueError: If an input is invalid or the normalized tilt
+        axis does not lie in the boundary plane within ``tol``.
     """
     tol = _validated_tolerance(tol, "tol")
     normal = _normalize_direction(
@@ -456,18 +436,21 @@ def build_symmetric_tilt_orientations(
     """Build a geometrically symmetric pure-tilt orientation pair.
 
     ``median_boundary_normal`` is the bisector normal about which the left and right
-    crystal boundary normals are placed at equal and opposite half angles. For example,
-    a median normal ``[1, 0, 0]``, tilt axis ``[0, 0, 1]``, and angle ``2*atan(1/5)``
-    produce normals parallel to ``[5, 1, 0]`` and ``[5, -1, 0]``.
+    boundary normals are placed at equal and opposite half angles. For example, median
+    normal ``[1, 0, 0]``, tilt axis ``[0, 0, 1]``, and angle ``2*atan(1/5)`` produce
+    normals parallel to ``[5, 1, 0]`` and ``[5, -1, 0]``.
 
     The returned floating-point matrices are not exact integer ``PQSpec`` input unless a
     separate exactification step succeeds.
 
     :param median_boundary_normal: Symmetry-bisector boundary normal.
-    :param tilt_axis: Common tilt axis, perpendicular to the median normal.
+    :param tilt_axis: Common tilt axis perpendicular to the median normal.
     :param angle_deg: Total left-to-right misorientation angle in degrees.
-    :param tol: Numerical tolerance. Keyword parameter, optional.
-    :return: ``(P, Q)`` normalized row-orientation matrices.
+    :param tol: Numerical tolerance used for vector and invariant validation. Keyword
+        argument, optional, defaults to ``_DEFAULT_ORIENTATION_TOL``.
+    :return: Tuple ``(P, Q)`` of normalized row-orientation matrices.
+    :raises CrystallographyValueError: If an input is invalid, the tilt axis is not
+        perpendicular to the median normal, or a symmetric-construction invariant fails.
     """
     tol = _validated_tolerance(tol, "tol")
     median = _normalize_direction(
@@ -531,10 +514,15 @@ def build_twist_orientations(
 
     :param boundary_normal: Common boundary normal and twist axis.
     :param angle_deg: Relative twist angle in degrees.
-    :param in_plane_reference: Optional direction used to define the left in-plane
-        basis. It is projected into the boundary plane.
-    :param tol: Numerical tolerance. Keyword parameter, optional.
-    :return: ``(P, Q)`` normalized row-orientation matrices.
+    :param in_plane_reference: Direction used to define the left-grain in-plane basis.
+        The direction is projected into the boundary plane. Keyword argument, optional,
+        defaults to ``None``.
+    :param tol: Numerical tolerance used for vector and invariant validation. Keyword
+        argument, optional, defaults to ``_DEFAULT_ORIENTATION_TOL``.
+    :return: Tuple ``(P, Q)`` of normalized row-orientation matrices.
+    :raises CrystallographyValueError: If an input is invalid, the supplied in-plane
+        reference has no nonzero projection, or the constructed rotation fails to
+        preserve the boundary normal.
     """
     tol = _validated_tolerance(tol, "tol")
     normal = _normalize_direction(boundary_normal, "boundary normal", tol=tol)
@@ -572,15 +560,20 @@ def build_mixed_orientations(
 
     A mixed boundary requires the rotation axis to have both a component normal to the
     boundary and a component in its plane. By default, the in-plane projection of the
-    rotation axis defines the left lab-y direction. A different in-plane reference may
-    be supplied explicitly.
+    rotation axis defines the left-grain lab-y direction. A different reference may be
+    supplied explicitly.
 
     :param left_boundary_normal: Boundary normal in left-grain crystal coordinates.
     :param rotation_axis: Mixed-character misorientation axis.
     :param angle_deg: Relative misorientation angle in degrees.
-    :param in_plane_reference: Optional left-grain in-plane basis seed.
-    :param tol: Numerical tolerance. Keyword parameter, optional.
-    :return: ``(P, Q)`` normalized row-orientation matrices.
+    :param in_plane_reference: Optional left-grain in-plane basis seed. Keyword
+        argument, optional, defaults to ``None``.
+    :param tol: Numerical tolerance used for vector and character validation. Keyword
+        argument, optional, defaults to ``_DEFAULT_ORIENTATION_TOL``.
+    :return: Tuple ``(P, Q)`` of normalized row-orientation matrices.
+    :raises CrystallographyValueError: If an input is invalid, the rotation axis lacks
+        either a tilt or twist component, or the selected reference has no nonzero
+        in-plane projection.
     """
     tol = _validated_tolerance(tol, "tol")
     normal = _normalize_direction(
@@ -623,14 +616,18 @@ def inclination_from_normal(
     *,
     tol: float = _DEFAULT_VECTOR_TOL,
 ) -> tuple[float, float]:
-    """Return GBMaker inclination angles ``(theta, phi)`` for a boundary normal.
+    """Return GBMaker inclination angles for a boundary normal.
 
-    GBMaker uses ``Rincl = Rz(phi) @ Ry(theta)`` and row-vector coordinates. Under that
-    convention the first row of ``Rincl`` is the crystal direction aligned with lab x.
+    GBMaker uses ``Rincl = Rz(phi) @ Ry(theta)`` with row-vector coordinates. Under that
+    convention, the first row of ``Rincl`` is the crystal direction aligned with the
+    lab-frame x-axis.
 
     :param boundary_normal: Boundary normal in crystal coordinates.
-    :param tol: Numerical tolerance. Keyword parameter, optional.
-    :return: ``(theta, phi)`` in radians.
+    :param tol: Numerical tolerance used to validate and normalize the normal. Keyword
+        argument, optional, defaults to ``_DEFAULT_VECTOR_TOL``.
+    :return: Tuple ``(theta, phi)`` in radians.
+    :raises CrystallographyValueError: If ``tol`` is invalid or ``boundary_normal`` is
+        malformed, non-finite, or effectively zero.
     """
     tol = _validated_tolerance(tol, "tol")
     normal = _normalize_direction(boundary_normal, "boundary normal", tol=tol)
@@ -642,7 +639,15 @@ def _inclination_from_unit_normal(
     *,
     tol: float,
 ) -> tuple[float, float]:
-    """Return inclination angles for an already normalized boundary normal."""
+    """Return inclination angles for an already normalized boundary normal.
+
+    At the positive- or negative-y singularity, ``theta`` is set to zero as a canonical
+    representative.
+
+    :param normal: Unit boundary normal with shape ``(3,)``.
+    :param tol: Tolerance used to identify the y-axis singularity. Keyword argument.
+    :return: Tuple ``(theta, phi)`` in radians.
+    """
     nx, ny, nz = normal
     phi = math.asin(np.clip(-ny, -1.0, 1.0))
     theta = 0.0 if abs(abs(ny) - 1.0) <= tol else math.atan2(nz, nx)
@@ -686,28 +691,23 @@ def five_dof_from_axis_angle(
     """Convert an axis-angle boundary description to five-DOF parameters.
 
     The axis-angle pair defines the crystal-frame misorientation. Its proper rotation
-    matrix is decomposed using the intrinsic ZXZ Euler convention to obtain ``alpha``,
-    ``beta``, and ``gamma``. The left-grain boundary normal independently determines the
-    GBMaker inclination angles ``theta`` and ``phi``.
+    matrix is decomposed using intrinsic ZXZ Euler angles to obtain ``alpha``, ``beta``,
+    and ``gamma``. The left-grain boundary normal independently determines the
+    inclination angles ``theta`` and ``phi``.
 
-    The returned array therefore has the form ``[alpha, beta, gamma, theta, phi]``, with
-    all angles expressed in radians.
-
-    :param rotation_axis: Array-like three-component misorientation axis in crystal
+    :param rotation_axis: Three-component misorientation axis in crystal coordinates. It
+        need not be normalized, but it must be finite and nonzero.
+    :param angle_deg: Misorientation angle in degrees.
+    :param boundary_normal: Three-component left-grain boundary normal in crystal
         coordinates. It need not be normalized, but it must be finite and nonzero.
-    :param angle_deg: Misorientation angle in degrees. It must be a finite, non-boolean
-        real scalar.
-    :param boundary_normal: Array-like three-component left-grain boundary normal in
-        crystal coordinates. It need not be normalized, but it must be finite and
-        nonzero.
-    :param tol: Strictly positive numerical tolerance used when validating and
-        normalizing the rotation axis and boundary normal. Keyword-only; defaults to
+    :param tol: Positive numerical tolerance used to validate and normalize the rotation
+        axis and boundary normal. Keyword argument, optional, defaults to
         ``_DEFAULT_ORIENTATION_TOL``.
-    :return: A one-dimensional ``numpy.float64`` array with shape ``(5,)`` containing
-        ``[alpha, beta, gamma, theta, phi]`` in radians.
-    :raises CrystallographyValueError: If ``tol`` is invalid; if ``rotation_axis`` or
-        ``boundary_normal`` cannot be interpreted as a finite, nonzero three-component
-        vector; or if ``angle_deg`` is boolean, non-real, or non-finite.
+    :return: ``float64`` array with shape ``(5,)`` containing ``[alpha, beta, gamma,
+        theta, phi]`` in radians.
+    :raises CrystallographyValueError: If ``tol`` is invalid, either direction is
+        malformed, non-finite, or zero, or ``angle_deg`` is Boolean, non-real, or
+        non-finite.
     :raises ValueError: If SciPy cannot convert the constructed rotation matrix to an
         intrinsic ZXZ Euler-angle representation.
     """
@@ -731,16 +731,22 @@ def five_dof_from_orientation_matrices(
 
     ``P`` and ``Q`` may contain scaled crystallographic directions; each row is
     normalized during validation. ``boundary_normal`` is an optional consistency check
-    only. The inclination is always derived from normalized ``P[0]``.
+    only. Inclination is always derived from normalized ``P[0]``.
 
     :param P: Left-grain row-wise orientation matrix.
     :param Q: Right-grain row-wise orientation matrix.
-    :param boundary_normal: Optional independently supplied boundary normal.
-    :param tol: Numerical tolerance. Keyword parameter, optional.
+    :param boundary_normal: Independently supplied boundary normal used for a
+        consistency warning, or ``None``. Optional, defaults to ``None``.
+    :param tol: Numerical tolerance used for matrix and vector validation. Keyword
+        argument, optional, defaults to ``_DEFAULT_ORIENTATION_TOL``.
     :param normal_warning_deg: Angular discrepancy above which a ``UserWarning`` is
-        emitted for ``boundary_normal``. Keyword parameter, optional, defaults to one
-        degree.
-    :return: Five angles ``[alpha, beta, gamma, theta, phi]`` in radians.
+        emitted for ``boundary_normal``. Keyword argument, optional, defaults to
+        ``_DEFAULT_NORMAL_WARNING_DEG``.
+    :return: ``float64`` array containing ``[alpha, beta, gamma, theta, phi]`` in
+        radians.
+    :raises CrystallographyValueError: If a tolerance is invalid, either matrix is not a
+        proper row-wise orientation matrix, the supplied boundary normal is invalid, or
+        ``normal_warning_deg`` is negative.
     """
     tol = _validated_tolerance(tol, "tol")
     warning_deg = _finite_float(normal_warning_deg, "normal_warning_deg")
@@ -785,25 +791,20 @@ def orientation_matrices_from_five_dof(
 ) -> tuple[np.ndarray, np.ndarray]:
     """Convert GBMaker five-DOF parameters to row-orientation matrices.
 
-    The five parameters use GBMaker's legacy convention
-    ``[alpha, beta, gamma, theta, phi]``. The first three values define the
-    crystal-frame misorientation using intrinsic ZXZ Euler angles. The final two
-    values define the left-grain inclination matrix as
-    ``Rz(phi) @ Ry(theta)``.
+    The five values follow the legacy convention ``[alpha, beta, gamma, theta, phi]``.
+    The first three define the crystal-frame misorientation using intrinsic ZXZ Euler
+    angles. The final two define the left-grain inclination matrix as ``Rz(phi) @
+    Ry(theta)``. The right-grain orientation is constructed as ``R_right = R_left @
+    R_misorientation``.
 
-    The right-grain orientation is constructed as
-    ``R_right = R_left @ R_misorientation``.
-
-    :param params: Array-like sequence containing
-        ``[alpha, beta, gamma, theta, phi]`` in radians.
-    :param tol: Strictly positive numerical tolerance used when validating the
-        resulting row-orientation matrices. Keyword-only, optional, defaults to
-        ``_DEFAULT_ORIENTATION_TOL``.
-    :return: A tuple ``(R_left, R_right)`` containing normalized, proper,
-        row-wise orientation matrices with shape ``(3, 3)``.
-    :raises CrystallographyValueError: If ``params`` cannot be converted to a
-        finite floating-point sequence of length five, if ``tol`` is invalid,
-        or if either resulting matrix fails row-orientation validation.
+    :param params: Sequence containing ``[alpha, beta, gamma, theta, phi]`` in radians.
+    :param tol: Positive numerical tolerance used to validate the resulting orientation
+        matrices. Keyword argument, optional, defaults to ``_DEFAULT_ORIENTATION_TOL``.
+    :return: Tuple ``(R_left, R_right)`` containing normalized proper row-wise
+        orientation matrices with shape ``(3, 3)``.
+    :raises CrystallographyValueError: If ``params`` cannot be converted to a finite
+        sequence of length five, ``tol`` is invalid, or either resulting matrix fails
+        row-orientation validation.
     """
     tol = _validated_tolerance(tol, "tol")
 
@@ -839,14 +840,14 @@ def orientation_matrices_from_five_dof(
 
 
 __all__ = [
-    "build_mixed_orientations",
-    "build_symmetric_tilt_orientations",
+    "normalize_direction",
+    "validate_orientation_matrix",
     "build_tilt_orientations",
+    "build_symmetric_tilt_orientations",
     "build_twist_orientations",
+    "build_mixed_orientations",
+    "inclination_from_normal",
     "five_dof_from_axis_angle",
     "five_dof_from_orientation_matrices",
-    "inclination_from_normal",
-    "normalize_direction",
     "orientation_matrices_from_five_dof",
-    "validate_orientation_matrix",
 ]

--- a/GBOpt/crystallography/plane.py
+++ b/GBOpt/crystallography/plane.py
@@ -16,14 +16,13 @@ import math
 import numpy as np
 from numpy.typing import ArrayLike
 
-from GBOpt.Utils.integer_linalg import cross_int3, dot_int
 from GBOpt.Utils.integer_normal_forms import (
     ExactNormalFormError,
     primitive_integer_null_basis_3d,
 )
 
 from ._guards import _require_cubic
-from .integer import as_int_array, as_int_vector, row_gcd_reduce
+from .integer import as_int_array, as_int_vector, cross_int3, dot_int, row_gcd_reduce
 from .rotation import scaled_row_image
 from .types import (
     CrystallographyDivisibilityError,
@@ -160,6 +159,7 @@ def inplane_basis_from_csl(
     :raises CrystallographyValueError: If projected null-basis construction fails, the
         constructed in-plane CSL vectors are linearly dependent, or the constructed
         basis is not in the plane.
+    :raises CrystallographyNotImplementedError: If ``lattice_metric`` is not ``None``.
     """
     _require_cubic(lattice_metric)
     int_basis = as_int_array(csl_basis, (3, 3), "csl_basis")
@@ -206,6 +206,8 @@ def rotation_preserves_plane(
         Keyword argument, optional, defaults to ``False``.
     :return: ``True`` when the rotation maps the plane to itself, or to its opposite if
         ``allow_antiparallel`` is ``True``.
+    :raises CrystallographyValueError: If ``plane`` is not a valid nonzero integer
+        three-vector or if an exact rotation validation failure occurs.
     """
     plane_int = np.asarray(primitive_plane(plane), dtype=object)
 

--- a/GBOpt/crystallography/pq.py
+++ b/GBOpt/crystallography/pq.py
@@ -153,19 +153,20 @@ def canonicalize_pq_paired(
 
     Corresponding rows may be reduced by different GCD factors. Consequently, the
     returned matrices preserve paired directions but are not guaranteed to satisfy ``Q
-    == P @ R`` for one exact scaled rotation. Use
-    :func:`recover_exact_row_rotation_from_paired_pq` only when the input row scales are
-    known to encode an exact algebraic P/Q pair.
+    == P @ R`` for one exact scaled rotation. Exact rotation recovery should only be
+    attempted when the input row scales are known to encode an exact algebraic P/Q pair.
 
-    This function does not canonicalize the full physical grain-boundary equivalence
-    class; grain exchange, crystal symmetry, and translation equivalences are not
+    This operation does not canonicalize the full physical grain-boundary equivalence
+    class. Grain exchange, crystal symmetry, and translation equivalences are not
     considered.
 
     :param P: 3 by 3 integer-valued reference-grain orientation rows.
-    :param Q: 3 by 3 integer-valued orientation rows corresponding row-by-row with
+    :param Q: 3 by 3 integer-valued orientation rows corresponding row by row with
         ``P``.
     :return: Canonical ``(P, Q)`` directional representations as object-dtype integer
         matrices.
+    :raises CrystallographyValueError: If either matrix fails exact integer validation
+        or a canonical matrix contains a zero row.
     """
     P_int = as_int_array(P, (3, 3), "P")
     Q_int = as_int_array(Q, (3, 3), "Q")

--- a/GBOpt/crystallography/pq.py
+++ b/GBOpt/crystallography/pq.py
@@ -21,7 +21,7 @@ from .integer import (
     integer_det3,
     row_gcd_reduce,
 )
-from .reduction import gauss_reduce_2d, gauss_reduce_2d_paired
+from .reduction import gauss_reduce_2d_paired
 from .rotation import validate_scaled_rotation_matrix
 from .types import CrystallographyValueError, ScaledRotation
 
@@ -124,32 +124,6 @@ def _orient_rows_by_primary(
         flip_rows(2)
 
 
-def _canonicalize_matrix(matrix: np.ndarray) -> np.ndarray:
-    """Return the canonical form of a single 3 by 3 orientation matrix.
-
-    Sign convention:
-
-    - Row 0, the boundary normal, has positive first nonzero component. Row 2 absorbs
-      the compensating negation so the determinant is preserved.
-    - Row 1, the first in-plane direction, has positive first nonzero component. Row 2
-      again absorbs the compensating negation.
-    - Row 2 has no independent sign convention; its sign is fully derived, followed by a
-      final determinant check to ensure right-handedness.
-
-    :param matrix: 3 by 3 integer-valued orientation matrix.
-    :return: Canonical object-dtype matrix with GCD-reduced rows.
-    """
-    rows = [row_gcd_reduce(matrix[i]) for i in range(3)]
-
-    r1, r2 = gauss_reduce_2d(rows[1], rows[2])
-    rows[1] = row_gcd_reduce(r1)
-    rows[2] = row_gcd_reduce(r2)
-
-    _orient_rows_by_primary(rows)
-
-    return np.array(rows, dtype=object)
-
-
 def _assert_no_zero_rows(P: np.ndarray, Q: np.ndarray) -> None:
     """Raise if either canonical orientation matrix contains a zero row.
 
@@ -166,51 +140,32 @@ def _assert_no_zero_rows(P: np.ndarray, Q: np.ndarray) -> None:
             )
 
 
-def canonicalize_pq(
-    P: np.ndarray,
-    Q: np.ndarray,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Return canonical forms of the ``P`` and ``Q`` orientation matrices.
-
-    Canonicalization rules: rows must be integer-valued, each row is divided by the GCD
-    of its absolute components, matrices are made right-handed, row 0 is the boundary
-    normal, rows 1-2 form a deterministic Gauss-reduced in-plane basis, row 1 receives
-    the larger canonical key, and first nonzero components of rows 0 and 1 are positive.
-
-    :param P: Row-wise orientation matrix for the left grain, shape ``(3, 3)``.
-    :param Q: Row-wise orientation matrix for the right grain, shape ``(3, 3)``.
-    :return: ``(P_canon, Q_canon)``, canonicalized orientation matrices as object-dtype
-        integer matrices.
-    """
-    P_int = as_int_array(P, (3, 3), "P")
-    Q_int = as_int_array(Q, (3, 3), "Q")
-
-    P_canon, Q_canon = (_canonicalize_matrix(M) for M in (P_int, Q_int))
-    _assert_no_zero_rows(P_canon, Q_canon)
-
-    return P_canon, Q_canon
-
-
 def canonicalize_pq_paired(
     P: np.ndarray,
     Q: np.ndarray,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Canonicalize orientation rows for a paired ``P``/``Q`` bicrystal.
+    """Canonicalize paired integer orientation directions for a bicrystal.
 
-    Applies the same row operations, including GCD reduction, Gauss reduction, ordering,
-    and sign fixing, to both ``P`` and ``Q`` simultaneously while preserving row-by-row
-    correspondence. Two ``P``/``Q`` pairs that represent the same boundary with
-    different row scalings, sign conventions, or in-plane basis orderings produce
-    identical output.
+    Corresponding ``P`` and ``Q`` rows remain associated while their signs, ordering,
+    and in-plane bases are canonicalized. Equivalent inputs that differ only by row
+    signs, in-plane basis ordering, or nonprimitive row scaling therefore produce the
+    same directional representation.
 
-    This is not a canonical representative of the physical grain-boundary equivalence
-    class: grain exchange, crystal symmetry, and translation equivalences are not
-    resolved.
+    Corresponding rows may be reduced by different GCD factors. Consequently, the
+    returned matrices preserve paired directions but are not guaranteed to satisfy ``Q
+    == P @ R`` for one exact scaled rotation. Use
+    :func:`recover_exact_row_rotation_from_paired_pq` only when the input row scales are
+    known to encode an exact algebraic P/Q pair.
 
-    :param P: 3 by 3 integer-valued reference-grain rows.
-    :param Q: 3 by 3 integer-valued rows paired with ``P``.
-    :return: Canonical ``(P, Q)`` with row correspondence preserved as object-dtype
-        integer matrices.
+    This function does not canonicalize the full physical grain-boundary equivalence
+    class; grain exchange, crystal symmetry, and translation equivalences are not
+    considered.
+
+    :param P: 3 by 3 integer-valued reference-grain orientation rows.
+    :param Q: 3 by 3 integer-valued orientation rows corresponding row-by-row with
+        ``P``.
+    :return: Canonical ``(P, Q)`` directional representations as object-dtype integer
+        matrices.
     """
     P_int = as_int_array(P, (3, 3), "P")
     Q_int = as_int_array(Q, (3, 3), "Q")
@@ -290,7 +245,6 @@ def recover_exact_row_rotation_from_paired_pq(
 
 
 __all__ = [
-    "canonicalize_pq",
     "canonicalize_pq_paired",
     "recover_exact_row_rotation_from_paired_pq",
 ]

--- a/GBOpt/crystallography/pq.py
+++ b/GBOpt/crystallography/pq.py
@@ -13,10 +13,10 @@ import math
 
 import numpy as np
 
-from GBOpt.Utils.integer_linalg import cross_int3, dot_int
-
 from .integer import (
     as_int_array,
+    cross_int3,
+    dot_int,
     integer_adj3,
     integer_det3,
     row_gcd_reduce,
@@ -50,6 +50,9 @@ def _canonical_inplane_key(row: np.ndarray) -> tuple[int, tuple[int, ...]]:
     row_int = np.asarray(row, dtype=object)
     if _first_nonzero_sign(row_int) < 0:
         row_int = -row_int
+
+    # doccheck: ignore=DOC115[CrystallographyValueError]
+    #   row_int comes from validated exact-integer P/Q rows and remains one-dimensional
     return dot_int(row_int, row_int), tuple(int(v) for v in row_int)
 
 
@@ -60,6 +63,9 @@ def _det_sign(rows: list[np.ndarray]) -> int:
         in-plane direction, and second in-plane direction.
     :return: ``1``, ``-1``, or ``0`` for positive, negative, or zero triple product.
     """
+    # doccheck: ignore=DOC115[CrystallographyValueError]
+    #   all project call sites pass three validated length-three exact-integer
+    #   orientation rows
     triple = dot_int(rows[0], cross_int3(rows[1], rows[2]))
     if triple > 0:
         return 1

--- a/GBOpt/crystallography/quaternion.py
+++ b/GBOpt/crystallography/quaternion.py
@@ -18,7 +18,7 @@ from numpy.typing import ArrayLike
 from scipy.spatial.transform import Rotation
 
 from ._guards import _require_cubic
-from .integer import as_int_vector
+from .integer import as_int_vector, as_positive_int
 from .types import (
     CrystallographyValueError,
     Int4,
@@ -107,18 +107,12 @@ def integer_quaternion_from_unit(quat: ArrayLike, *, max_denominator: int = 1000
         integer quaternion does not match the supplied unit quaternion.
     """
     arr = np.asarray(quat, dtype=float)
+    max_denominator = as_positive_int(max_denominator, "max_denominator")
     if arr.shape != (4,):
         raise CrystallographyValueError(f"quat must have shape (4,); got {arr.shape}.")
     if not np.all(np.isfinite(arr)):
         raise CrystallographyValueError("quat must contain only finite values.")
-    if (
-        not isinstance(max_denominator, int)
-        or max_denominator < 1
-        or isinstance(max_denominator, (bool, np.bool_))
-    ):
-        raise CrystallographyValueError(
-            f"max_denominator must be a positive integer, got {max_denominator!r}."
-        )
+
     # 1e-14: numerical zero floor (well below float64 machine epsilon ~2.2e-16 times
     # typical quaternion magnitudes); components smaller than this are treated as
     # exactly zero before computing ratios relative to the largest-magnitude component.

--- a/GBOpt/crystallography/quaternion.py
+++ b/GBOpt/crystallography/quaternion.py
@@ -94,64 +94,183 @@ def quaternion_to_scaled_rotation(
     )
 
 
-def integer_quaternion_from_unit(quat: ArrayLike, *, max_denominator: int = 10001) -> Int4:
-    """Recover a primitive integer quaternion proportional to a unit quaternion.
+def _validated_float_quaternion(quat: ArrayLike) -> np.ndarray:
+    """Return a validated finite floating-point quaternion.
 
-    :param quat: Unit quaternion in Hamilton scalar-first order ``[w, x, y, z]``.
-    :param max_denominator: Maximum rational denominator used when recovering integer
-        ratios from floating-point components. Keyword argument, optional, defaults to
-        ``10001``.
-    :return: Primitive integer quaternion.
-    :raises CrystallographyValueError: If the input is not length 4, is zero, or has
-        non-finite values; max_denominator is not a positive integer; or the recovered
-        integer quaternion does not match the supplied unit quaternion.
+    :param quat: Candidate quaternion in Hamilton scalar-first order ``[w, x, y, z]``.
+    :return: Finite ``float64`` array with shape ``(4,)``.
+    :raises CrystallographyValueError: If ``quat`` cannot be converted to floating
+        point, does not have shape ``(4,)``, or contains a non-finite value.
     """
-    arr = np.asarray(quat, dtype=float)
-    max_denominator = as_positive_int(max_denominator, "max_denominator")
-    if arr.shape != (4,):
-        raise CrystallographyValueError(f"quat must have shape (4,); got {arr.shape}.")
-    if not np.all(np.isfinite(arr)):
-        raise CrystallographyValueError("quat must contain only finite values.")
+    try:
+        arr = np.asarray(quat, dtype=np.float64)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise CrystallographyValueError(
+            "quat must be a finite four-component quaternion."
+        ) from exc
 
-    # 1e-14: numerical zero floor (well below float64 machine epsilon ~2.2e-16 times
-    # typical quaternion magnitudes); components smaller than this are treated as
-    # exactly zero before computing ratios relative to the largest-magnitude component.
-    zero_tol = 1e-14
+    if arr.shape != (4,):
+        raise CrystallographyValueError(
+            f"quat must have shape (4,); got {arr.shape}."
+        )
+    if not np.all(np.isfinite(arr)):
+        raise CrystallographyValueError(
+            "quat must contain only finite values."
+        )
+
+    return arr
+
+
+def _integer_quaternion_candidate_from_unit(
+    quat: ArrayLike,
+    *,
+    max_denominator: int = 10001,
+) -> Int4:
+    """Return a bounded-denominator integer candidate for a quaternion direction.
+
+    The candidate is primitive and uses the canonical quaternion sign convention.
+    This helper deliberately performs no reconstruction-accuracy check. Callers are
+    responsible for applying the error metric and tolerance appropriate to their
+    operation.
+
+    :param quat: Quaternion direction in Hamilton scalar-first order
+        ``[w, x, y, z]``. The input need not be exactly unit length.
+    :param max_denominator: Maximum denominator used when rationalizing component
+        ratios. Keyword argument, optional, defaults to ``10001``.
+    :return: Primitive canonical integer quaternion.
+    :raises CrystallographyValueError: If ``quat`` cannot be converted to a finite
+        four-component vector, is effectively zero, or ``max_denominator`` is not a
+        positive integer.
+    """
+    try:
+        arr = np.asarray(quat, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise CrystallographyValueError(
+            "quat must be a finite four-component quaternion."
+        ) from exc
+
+    max_denominator = as_positive_int(
+        max_denominator,
+        "max_denominator",
+    )
+
+    if arr.shape != (4,):
+        raise CrystallographyValueError(
+            f"quat must have shape (4,); got {arr.shape}."
+        )
+    if not np.all(np.isfinite(arr)):
+        raise CrystallographyValueError(
+            "quat must contain only finite values."
+        )
+
+    # Components below this numerical floor are treated as exact zeros when
+    # constructing ratios relative to the largest-magnitude component.
+    zero_tol = 1.0e-14
     abs_arr = np.abs(arr)
     if not np.any(abs_arr > zero_tol):
-        raise CrystallographyValueError("quat is the zero quaternion.")
+        raise CrystallographyValueError(
+            "quat is the zero quaternion."
+        )
 
     reference_index = int(np.argmax(abs_arr))
     reference = float(arr[reference_index])
 
     fractions = [
-        Fraction(0, 1)
-        if abs(float(v)) <= zero_tol
-        else Fraction(float(v) / reference).limit_denominator(max_denominator)
-        for v in arr
+        (
+            Fraction(0, 1)
+            if abs(float(component)) <= zero_tol
+            else Fraction(float(component) / reference).limit_denominator(
+                max_denominator
+            )
+        )
+        for component in arr
     ]
 
-    denominator_lcm = math.lcm(*(value.denominator for value in fractions))
-    int_components = [int(value * denominator_lcm) for value in fractions]
-    int_quat = normalize_integer_quaternion(tuple(int_components))
+    denominator_lcm = math.lcm(
+        *(fraction.denominator for fraction in fractions)
+    )
+    components = tuple(
+        int(fraction * denominator_lcm)
+        for fraction in fractions
+    )
 
-    int_quat_arr = np.asarray(int_quat, dtype=float)
-    recovered = int_quat_arr / np.linalg.norm(int_quat_arr)
+    return normalize_integer_quaternion(components)
 
-    # arr may not be exactly unit-norm due to floating-point; renormalize defensively
-    target = arr / np.linalg.norm(arr)
-    if np.dot(recovered, target) < 0:
+
+def integer_quaternion_from_unit(
+    quat: ArrayLike,
+    *,
+    max_denominator: int = 10001,
+) -> Int4:
+    """Recover a primitive integer quaternion proportional to a unit quaternion.
+
+    This public convenience function constructs a bounded-denominator candidate and
+    verifies that its normalized quaternion direction matches the supplied direction
+    within a fixed componentwise tolerance. Callers that require a different error
+    metric should use their own operation-specific policy around the private candidate
+    constructor.
+
+    :param quat: Unit quaternion in Hamilton scalar-first order ``[w, x, y, z]``.
+    :param max_denominator: Maximum rational denominator used when recovering integer
+        ratios from floating-point components. Keyword argument, optional, defaults to
+        ``10001``.
+    :return: Primitive canonical integer quaternion.
+    :raises CrystallographyValueError: If validation or rationalization fails, or if
+        the recovered integer quaternion does not reproduce the supplied quaternion
+        direction within the fixed public-function tolerance.
+    """
+    int_quat = _integer_quaternion_candidate_from_unit(
+        quat,
+        max_denominator=max_denominator,
+    )
+
+    # Candidate construction has already validated conversion, shape, finiteness,
+    # and nonzero magnitude.
+    target = np.asarray(quat, dtype=np.float64)
+    target /= np.linalg.norm(target)
+
+    int_quat_array = np.asarray(int_quat, dtype=np.float64)
+    recovered = int_quat_array / np.linalg.norm(int_quat_array)
+
+    if float(np.dot(recovered, target)) < 0.0:
         recovered = -recovered
 
-    # 1e-9: reconstruction accuracy tolerance; verifies that the recovered integer
-    # quaternion, when renormalized, reproduces the original unit quaternion direction
-    # to within acceptable float64 round-trip error.
-    if not np.allclose(recovered, target, atol=1e-9, rtol=0.0):
+    if not np.allclose(
+        recovered,
+        target,
+        atol=1.0e-9,
+        rtol=0.0,
+    ):
         raise CrystallographyValueError(
-            "Recovered integer quaternion does not match the supplied unit quaternion."
+            "Recovered integer quaternion does not match the supplied "
+            "unit quaternion."
         )
 
     return int_quat
+
+
+def _unit_integer_quaternion(values: tuple[int, int, int, int]) -> np.ndarray:
+    """Return a scale-safe unit vector for a nonzero integer quaternion.
+
+    The integer components are divided by their largest absolute value before
+    normalization to avoid unnecessary floating-point overflow.
+
+    :param values: Integer quaternion in Hamilton scalar-first order ``(w, x, y, z)``.
+    :return: Unit-length ``float64`` quaternion with shape ``(4,)``.
+    :raises CrystallographyValueError: If ``values`` is the zero quaternion.
+    """
+    scale = max(map(abs, values))
+    if scale == 0:
+        raise CrystallographyValueError(
+            "Quaternion must be non-zero."
+        )
+
+    scaled = np.fromiter(
+        (value / scale for value in values),
+        dtype=np.float64,
+        count=4,
+    )
+    return scaled / np.linalg.norm(scaled)
 
 
 def quaternion_to_rotation_matrix(quat: ArrayLike) -> np.ndarray:
@@ -169,29 +288,24 @@ def quaternion_to_rotation_matrix(quat: ArrayLike) -> np.ndarray:
     :raises CrystallographyValueError: If the shape is invalid, the quaternion is
         non-finite or zero, or a non-unit quaternion is not integer-valued.
     """
-    quat_array = np.asarray(quat, dtype=float)
-    if quat_array.shape != (4,):
-        raise CrystallographyValueError(
-            f"Quaternion must be a 1-D array of length 4; got shape {quat_array.shape}."
-        )
-    norm = float(np.linalg.norm(quat_array))
-    if not np.isfinite(norm) or norm == 0.0:
-        raise CrystallographyValueError("Quaternion must be non-zero and finite.")
-    # 1e-12: tight tolerance for unit-norm check; properly normalized quaternions
-    # from scipy or explicit normalization should be within a few ULPs of 1.
-    if not np.isclose(norm, 1.0, atol=1e-12, rtol=0.0):
-        # 1e-9: looser tolerance for integer-valuedness; integer-valued floats
-        # can carry small rounding errors from upstream arithmetic.
-        if not np.allclose(quat_array, np.round(quat_array), atol=1e-9, rtol=0.0):
+    try:
+        int_quat = as_int_vector(quat, 4, "quat")
+    except CrystallographyValueError:
+        quat_array = _validated_float_quaternion(quat)
+        norm = float(np.linalg.norm(quat_array))
+        if norm == 0.0:
             raise CrystallographyValueError(
-                f"Quaternion components must be integer-valued; got {quat_array}. "
+                "Quaternion must be non-zero."
+            )
+        if not np.isclose(norm, 1.0, atol=1.0e-12, rtol=0.0):
+            raise CrystallographyValueError(
                 "Non-unit quaternions must be exact integer quaternions."
             )
-        int_q = np.round(quat_array).astype(int)
-        quat_array = int_q.astype(float) / np.sqrt(float(np.dot(int_q, int_q)))
+        quat_array = quat_array / norm
+    else:
+        quat_array = _unit_integer_quaternion(int_quat)
 
-    scalar_last = quat_array[[1, 2, 3, 0]]
-    return Rotation.from_quat(scalar_last).as_matrix()
+    return Rotation.from_quat(quat_array[[1, 2, 3, 0]]).as_matrix()
 
 
 __all__ = [

--- a/GBOpt/crystallography/quaternion.py
+++ b/GBOpt/crystallography/quaternion.py
@@ -63,7 +63,9 @@ def quaternion_to_scaled_rotation(
     :param lattice_metric: Reserved non-cubic metric hook; only ``None`` is currently
         supported. Keyword argument, optional, defaults to ``None``.
     :return: Exact scaled rotation in the project row-vector convention.
-    :raises CrystallographyValueError: If ``quat`` is the zero quaternion.
+    :raises CrystallographyValueError: If ``quat`` is malformed, contains non-integer
+        entries, or is the zero quaternion.
+    :raises CrystallographyNotImplementedError: If ``lattice_metric`` is not ``None``.
     """
     _require_cubic(lattice_metric)
     if canonicalize:

--- a/GBOpt/crystallography/reduction.py
+++ b/GBOpt/crystallography/reduction.py
@@ -16,9 +16,7 @@ from fractions import Fraction
 
 import numpy as np
 
-from GBOpt.Utils.integer_linalg import dot_int
-
-from .integer import as_int_array, integer_det3
+from .integer import as_int_array, dot_int, integer_det3
 from .types import CrystallographyValueError
 
 
@@ -157,6 +155,8 @@ def gauss_reduce_2d(v1: np.ndarray, v2: np.ndarray) -> tuple[np.ndarray, np.ndar
     :param v1: First integer-valued in-plane basis vector.
     :param v2: Second integer-valued in-plane basis vector.
     :return: Reduced basis ``(shorter, longer)``.
+    :raises CrystallographyValueError: If either input is not a one-dimensional exact
+        integer vector or the vector lengths differ.
     """
     q1 = np.zeros_like(v1, dtype=object)
     q2 = np.zeros_like(v2, dtype=object)

--- a/GBOpt/crystallography/rotation.py
+++ b/GBOpt/crystallography/rotation.py
@@ -11,14 +11,13 @@ documentation.
 from __future__ import annotations
 
 import math
-import operator
 from typing import Literal
 
 import numpy as np
 from numpy.typing import ArrayLike
 
 from ._guards import _require_cubic
-from .integer import as_int_array, integer_det3, row_gcd_reduce
+from .integer import as_int_array, as_positive_int, integer_det3, row_gcd_reduce
 from .types import (
     CrystallographyDivisibilityError,
     CrystallographyValueError,
@@ -26,33 +25,51 @@ from .types import (
 )
 
 
-def _require_positive_integer(value: object, name: str) -> int:
-    """Return value as a Python int only if it is a positive integer scalar.
+def _minimal_integral_row_pair(
+    direction: np.ndarray,
+    row_rotation: ScaledRotation,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Construct one exactly paired integer row under a scaled rotation.
 
-    :param value: Candidate scalar to validate.
-    :param name: Name used in error messages.
-    :return: value converted to Python int.
-    :raises CrystallographyValueError: If value is boolean, is not indexable as an
-        integer, or is not positive.
+    ``row_rotation`` represents the row-vector mapping ``q = p @ M / N``. The supplied
+    direction is first GCD-reduced to a primitive integer row. That primitive row is
+    then multiplied by the smallest positive integer scale for which every component of
+    its rotated image is divisible by ``N``. The returned rows therefore satisfy
+    ``image_row == paired_row @ M / N`` exactly in integer arithmetic.
+
+    :param direction: Integer-valued row direction. It may be non-primitive, but it must
+        be one-dimensional and valid for :func:`row_gcd_reduce`.
+    :param row_rotation: Valid exact row-convention scaled rotation ``M / N``.
+    :return: ``(paired_row, image_row)`` as object-dtype integer arrays. ``paired_row``
+        is the minimally scaled primitive input direction and ``image_row`` is its exact
+        integral image under ``row_rotation``.
+    :raises CrystallographyValueError: If ``direction`` is not a valid integer row or if
+        the computed scale fails to produce an exactly divisible image, which indicates
+        an internal inconsistency in the pairing calculation.
     """
-    if isinstance(value, (bool, np.bool_)):
+    primitive = row_gcd_reduce(np.asarray(direction, dtype=object))
+    numerator_matrix = np.asarray(row_rotation.matrix, dtype=object)
+    denominator = int(row_rotation.denominator)
+    image_numerator = primitive @ numerator_matrix
+
+    common_divisor = math.gcd(
+        denominator,
+        *(abs(int(component)) for component in image_numerator),
+    )
+    scale = denominator // common_divisor
+    paired_row = scale * primitive
+    scaled_image = paired_row @ numerator_matrix
+
+    if any(int(component) % denominator for component in scaled_image):
         raise CrystallographyValueError(
-            f"{name} must be a positive integer; got {value!r}."
+            "Internal error while constructing exact paired P/Q rows."
         )
 
-    try:
-        integer = operator.index(value)
-    except TypeError as exc:
-        raise CrystallographyValueError(
-            f"{name} must be a positive integer; got {value!r}."
-        ) from exc
-
-    if integer <= 0:
-        raise CrystallographyValueError(
-            f"{name} must be a positive integer; got {value!r}."
-        )
-
-    return int(integer)
+    image_row = np.array(
+        [int(component) // denominator for component in scaled_image],
+        dtype=object,
+    )
+    return paired_row, image_row
 
 
 def _scaled_row_images(
@@ -175,7 +192,7 @@ def validate_scaled_rotation_matrix(
     expected_denom = (
         None
         if denominator is None
-        else _require_positive_integer(denominator, "denominator")
+        else as_positive_int(denominator, "denominator")
     )
 
     if reduce_common_factor:

--- a/GBOpt/crystallography/rotation.py
+++ b/GBOpt/crystallography/rotation.py
@@ -189,6 +189,7 @@ def validate_scaled_rotation_matrix(
         identity, the Gram diagonal is not a perfect square, the determinant is
         inconsistent with the derived denominator, or the supplied denominator does not
         match the derived denominator.
+    :raises CrystallographyNotImplementedError: If ``lattice_metric`` is not ``None``.
     """
     _require_cubic(lattice_metric)
     int_matrix = as_int_array(input_matrix, (3, 3), "input_matrix")
@@ -245,6 +246,8 @@ def transpose_rotation_convention(rotation: ScaledRotation) -> ScaledRotation:
     :param rotation: Row-convention scaled rotation to transpose.
     :return: Validated scaled rotation with numerator ``rotation.matrix.T``, the same
         denominator, and the same source.
+    :raises CrystallographyValueError: If ``rotation`` does not satisfy the exact
+        scaled-rotation orthogonality and determinant identities.
     """
     return validate_scaled_rotation_matrix(
         np.asarray(rotation.matrix, dtype=object).T,
@@ -278,6 +281,9 @@ def scaled_row_image(
         returned array is object dtype.
     :raises CrystallographyDivisibilityError: If the image is not exactly integer-valued
         and ``allow_inexact=False``.
+    :raises CrystallographyValueError: If ``row`` is not an exact integer vector of
+        length three or, when ``validate_rotation`` is true, ``rotation`` fails the
+        exact scaled-rotation identities.
     """
     if validate_rotation:
         assert_scaled_rotation(rotation)

--- a/GBOpt/crystallography/rotation.py
+++ b/GBOpt/crystallography/rotation.py
@@ -80,20 +80,23 @@ def _scaled_row_images(
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Apply a row-convention scaled rotation to exactly three integer rows.
 
-    This is the batched companion to ``scaled_row_image`` for 3 by 3 row matrices. It
-    validates ``rotation`` once, then applies ``row @ rotation.matrix /
-    rotation.denominator`` to each row of ``rows``. When a row image divides evenly by
-    the denominator, the exact integer image is returned. Otherwise, the corresponding
-    ``allow_inexact`` flag controls whether the primitive numerator direction is
+    This batched companion to ``scaled_row_image`` validates the rotation once and then
+    applies ``row @ rotation.matrix / rotation.denominator`` to each input row. Exactly
+    divisible images are returned directly. For an inexact image, the corresponding
+    ``allow_inexact`` flag determines whether the primitive numerator direction is
     returned or an exception is raised.
 
-    :param rows: 3 by 3 integer-valued row matrix. Each row is transformed independently
-        under ``rotation``.
+    :param rows: 3 by 3 integer-valued row matrix whose rows are transformed
+        independently.
     :param rotation: Row-convention scaled rotation to apply.
-    :param allow_inexact: Three Boolean flags, one per row.
-    :return: Three object-dtype integer arrays containing the transformed row images in
-        row order.
-    :raises CrystallographyDivisibilityError: If any row image is not exactly
+    :param allow_inexact: Three Boolean flags controlling whether each respective row
+        may return a primitive numerator direction instead of an exactly divisible
+        image. Keyword argument.
+    :return: Three object-dtype integer arrays containing the transformed rows in input
+        order.
+    :raises CrystallographyValueError: If ``rows`` or ``rotation`` fails exact
+        validation.
+    :raises CrystallographyDivisibilityError: If a row image is not exactly
         integer-valued and its corresponding ``allow_inexact`` flag is ``False``.
     """
     int_rows = as_int_array(rows, (len(rows), 3), "rows")

--- a/GBOpt/crystallography/types.py
+++ b/GBOpt/crystallography/types.py
@@ -153,15 +153,15 @@ def _require_int_array(array: ArrayLike, shape: tuple[int, ...], name: str) -> _
 
 
 def _array_repr(array: ArrayLike, *, name: str) -> str:
-    """Return a compact single-line representation for an ndarray field.
+    """Return a compact single-line representation of an array field.
 
-    The representation includes shape, dtype, writeability, and a compact value preview
-    suitable for logging. Whitespace is normalized so one dataclass instance generally
-    occupies one log line.
+    The representation includes the field name, shape, dtype, writeability, and a
+    compact value preview. Whitespace is normalized so that one dataclass instance
+    generally occupies one log line.
 
     :param array: Array-like field value to represent.
-    :param name: Field name to include in the returned representation.
-    :return: Single-line representation of the array field.
+    :param name: Field name included in the returned representation. Keyword argument.
+    :return: Compact single-line representation of the array field.
     """
     arr = np.asarray(array)
     values = np.array2string(

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ rather than the deprecated direct `GBMaker(...)` constructor. Supported core
 input formats are:
 
 - `FiveDOFSpec(params)` for the legacy `[alpha, beta, gamma, theta, phi]`
-  ZXZ-plus-inclination parameterization. This currently builds in
-  `mode="approximate"`; exactification is reserved for a future Stage E hook.
+  ZXZ-plus-inclination parameterization. `mode="exact"` rationalizes inputs
+  that correspond to cubic CSL boundaries; use `mode="approximate"` for
+  arbitrary or intentionally legacy-equivalent floating inputs.
 - `PQSpec(P, Q)` for exact row-wise orientation matrices, where rows give
   the crystal directions aligned with lab x, y, and z for the left and right
   grains.
@@ -25,10 +26,10 @@ input formats are:
 
 Construction modes are:
 
-- `mode="exact"` for exact integer P/Q construction. This requires `PQSpec` or
-  `CSLExactSpec` until five-DOF exactification is implemented.
+- `mode="exact"` for exact integer P/Q construction. This requires `PQSpec`,
+  `CSLExactSpec`, or a `FiveDOFSpec` that can be rationalized to a cubic CSL.
 - `mode="prefer_exact"` to use exact construction when available and warn
-  before falling back where exactification is not implemented.
+  before falling back when exactification fails.
 - `mode="approximate"` for the floating-point builder. This is the intended
   mode for incoherent or arbitrary-angle interfaces, not just a fallback.
 

--- a/examples/density_optimization/README.md
+++ b/examples/density_optimization/README.md
@@ -84,8 +84,10 @@ Each call produces a two-panel figure:
 `optimize.py` builds the $\Sigma 5$5[001]{310} starting structure with
 `GBMaker.from_boundary_spec(..., FiveDOFSpec(...), mode="approximate")`.
 This preserves the legacy five-DOF example geometry while avoiding the
-deprecated direct constructor. Exact five-DOF reconstruction is
-not enabled until the future exactification hook is implemented.
+deprecated direct constructor. Exact five-DOF reconstruction is available for
+cubic CSL inputs; new workflows can switch this construction to
+`mode="prefer_exact"` or `mode="exact"` when exact stoichiometric construction
+is desired.
 
 ### Requirements
 

--- a/examples/gb_optimization/README.md
+++ b/examples/gb_optimization/README.md
@@ -94,8 +94,10 @@ python scripts/plot_mc_comparison.py --material Fe --boundary sigma5_310_STGB \
 The run scripts construct initial structures with
 `GBMaker.from_boundary_spec(..., FiveDOFSpec(...), mode="approximate")`.
 The boundary table below is still stored as legacy five-DOF misorientation
-arrays in `config/boundaries.py`; until five-DOF exactification is implemented,
-these examples intentionally use the approximate path.
+arrays in `config/boundaries.py`. These examples intentionally keep the
+approximate path for legacy reproducibility; new runs that should use exact
+stoichiometric construction can switch to `mode="prefer_exact"` or
+`mode="exact"` for five-DOF entries that rationalize to cubic CSL boundaries.
 
 ### Requirements
 

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,11 @@
 
 from setuptools import find_packages, setup
 
+from GBOpt import __version__
+
 setup(
     name="GBOpt",
-    version="0.1",
+    version=__version__,
     packages=find_packages(),
     install_requires=[
         "numpy<=2.1",

--- a/tests/test_boundary_spec.py
+++ b/tests/test_boundary_spec.py
@@ -1,4 +1,5 @@
 # Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
+
 import numpy as np
 import pytest
 
@@ -94,11 +95,9 @@ def _metadata_kwargs(**overrides):
         "basis_mode": "primitive",
         "input_area_index": 10,
         "primitive_area_index": 5,
-        "input_reduction_index": 2,
         "orientation_area_index": 5,
         "plane": (0, 0, 1),
         "rotation_denominator": 10,
-        "conventional_cell_multiplier": 10,
     }
     kwargs.update(overrides)
     return kwargs
@@ -558,7 +557,6 @@ def test_primitive_metadata_allows_orientation_area_not_multiple_of_primitive_ar
         **_metadata_kwargs(
             primitive_area_index=5,
             orientation_area_index=1,
-            conventional_cell_multiplier=10,
         )
     )
 
@@ -571,11 +569,9 @@ def test_primitive_metadata_normalizes_valid_fields():
         **_metadata_kwargs(
             input_area_index=np.int64(10),
             primitive_area_index=np.int64(5),
-            input_reduction_index=np.int64(2),
             orientation_area_index=np.int64(5),
             plane=[0, 0, 1],
             rotation_denominator=np.int64(10),
-            conventional_cell_multiplier=np.int64(10),
         )
     )
 
@@ -589,110 +585,170 @@ def test_primitive_metadata_normalizes_valid_fields():
     assert metadata.conventional_cell_multiplier == 10
 
 
+def test_primitive_cell_metadata_derives_none_reduction_without_input_area():
+    metadata = PrimitiveCellMetadata(
+        basis_mode="primitive",
+        primitive_area_index=5,
+        orientation_area_index=1,
+        plane=(0, 0, 1),
+        rotation_denominator=10,
+    )
+
+    assert metadata.input_area_index is None
+    assert metadata.input_reduction_index is None
+    assert metadata.conventional_cell_multiplier == 10
+
+
+def test_primitive_metadata_supplied_mode_records_input_area_as_single_reduction():
+    result = PrimitiveCellMetadata(
+        basis_mode="supplied",
+        input_area_index=5,
+        primitive_area_index=5,
+        orientation_area_index=5,
+        plane=(0, 0, 1),
+        rotation_denominator=5,
+    )
+
+    assert result.basis_mode == "supplied"
+    assert result.input_area_index == 5
+    assert result.primitive_area_index == 5
+    assert result.orientation_area_index == 5
+    assert result.input_reduction_index == 1
+    assert result.conventional_cell_multiplier == 10
+
+
 @pytest.mark.parametrize(
     ("overrides", "error_type", "message"),
     [
         pytest.param(
-            {"basis_mode": "literal"},
+            {"basis_mode": "orthogonal"},
             BoundarySpecValueError,
             r"PrimitiveCellMetadata\.basis_mode",
-            id="invalid_basis_mode",
+            id="invalid-basis-mode",
         ),
         pytest.param(
             {"primitive_area_index": 0},
             BoundarySpecValueError,
-            r"primitive_area_index must be a positive integer",
-            id="non_positive_primitive_area_index",
+            r"PrimitiveCellMetadata\.primitive_area_index "
+            r"must be a positive integer",
+            id="zero-primitive-area-index",
+        ),
+        pytest.param(
+            {"primitive_area_index": -1},
+            BoundarySpecValueError,
+            r"PrimitiveCellMetadata\.primitive_area_index "
+            r"must be a positive integer",
+            id="negative-primitive-area-index",
+        ),
+        pytest.param(
+            {"primitive_area_index": 1.5},
+            BoundarySpecValueError,
+            r"PrimitiveCellMetadata\.primitive_area_index "
+            r"must be a positive integer",
+            id="noninteger-primitive-area-index",
         ),
         pytest.param(
             {"primitive_area_index": np.bool_(True)},
             BoundarySpecTypeError,
-            r"primitive_area_index must not be boolean",
-            id="boolean_primitive_area_index",
+            r"PrimitiveCellMetadata\.primitive_area_index "
+            r"must not be boolean",
+            id="boolean-primitive-area-index",
         ),
         pytest.param(
             {"input_area_index": 0},
             BoundarySpecValueError,
-            r"input_area_index must be a positive integer",
-            id="non_positive_input_area_index",
+            r"PrimitiveCellMetadata\.input_area_index "
+            r"must be a positive integer",
+            id="zero-input-area-index",
         ),
         pytest.param(
-            {"input_area_index": 11, "input_reduction_index": 2},
+            {"input_area_index": -1},
             BoundarySpecValueError,
-            r"input_area_index must be an integer multiple of primitive_area_index",
-            id="input_area_not_multiple_of_primitive_area",
+            r"PrimitiveCellMetadata\.input_area_index "
+            r"must be a positive integer",
+            id="negative-input-area-index",
         ),
         pytest.param(
-            {"input_area_index": 10, "input_reduction_index": None},
+            {"input_area_index": 7},
             BoundarySpecValueError,
-            r"input_reduction_index is required when input_area_index is provided",
-            id="missing_input_reduction_index",
-        ),
-        pytest.param(
-            {"input_area_index": 10, "input_reduction_index": 0},
-            BoundarySpecValueError,
-            r"input_reduction_index must be a positive integer",
-            id="non_positive_input_reduction_index",
-        ),
-        pytest.param(
-            {"input_area_index": 10, "input_reduction_index": 3},
-            BoundarySpecValueError,
-            r"input_reduction_index must equal input_area_index // primitive_area_index",
-            id="mismatched_input_reduction_index",
-        ),
-        pytest.param(
-            {"input_area_index": None, "input_reduction_index": 1},
-            BoundarySpecValueError,
-            r"input_reduction_index must be None when input_area_index is None",
-            id="input_reduction_without_input_area",
-        ),
-        pytest.param(
-            {"plane": (0, 0, 0)},
-            BoundarySpecValueError,
-            r"PrimitiveCellMetadata\.plane must not be all-zero",
-            id="zero_plane",
-        ),
-        pytest.param(
-            {"plane": (True, 0, 1)},
-            BoundarySpecTypeError,
-            r"PrimitiveCellMetadata\.plane\(0,\)=True is not an integer",
-            id="boolean_plane_entry",
-        ),
-        pytest.param(
-            {"plane": (1.5, 0, 0)},
-            BoundarySpecValueError,
-            r"PrimitiveCellMetadata\.plane\(0,\)=1\.5 is not exactly integer-valued",
-            id="non_integer_plane_entry",
-        ),
-        pytest.param(
-            {"rotation_denominator": 0},
-            BoundarySpecValueError,
-            r"rotation_denominator must be a positive integer",
-            id="non_positive_rotation_denominator",
-        ),
-        pytest.param(
-            {"conventional_cell_multiplier": 11},
-            BoundarySpecValueError,
-            r"conventional_cell_multiplier must equal 2 \* primitive_area_index",
-            id="wrong_conventional_cell_multiplier",
+            r"PrimitiveCellMetadata\.input_area_index "
+            r"must be an integer multiple of primitive_area_index",
+            id="indivisible-input-area-index",
         ),
         pytest.param(
             {"orientation_area_index": 0},
             BoundarySpecValueError,
-            r"orientation_area_index must be a positive integer",
-            id="non_positive_orientation_area_index",
+            r"PrimitiveCellMetadata\.orientation_area_index "
+            r"must be a positive integer",
+            id="zero-orientation-area-index",
         ),
         pytest.param(
-            {"orientation_area_index": np.bool_(True)},
-            BoundarySpecTypeError,
-            r"orientation_area_index must not be boolean",
-            id="boolean_orientation_area_index",
+            {"orientation_area_index": -1},
+            BoundarySpecValueError,
+            r"PrimitiveCellMetadata\.orientation_area_index "
+            r"must be a positive integer",
+            id="negative-orientation-area-index",
         ),
         pytest.param(
             {"orientation_area_index": 1.5},
             BoundarySpecValueError,
-            r"orientation_area_index must be a positive integer",
-            id="non_integer_orientation_area_index",
+            r"PrimitiveCellMetadata\.orientation_area_index "
+            r"must be a positive integer",
+            id="noninteger-orientation-area-index",
+        ),
+        pytest.param(
+            {"orientation_area_index": np.bool_(True)},
+            BoundarySpecTypeError,
+            r"PrimitiveCellMetadata\.orientation_area_index "
+            r"must not be boolean",
+            id="boolean-orientation-area-index",
+        ),
+        pytest.param(
+            {"plane": [1, 0]},
+            BoundarySpecValueError,
+            r"PrimitiveCellMetadata\.plane must have shape \(3,\)",
+            id="short-plane",
+        ),
+        pytest.param(
+            {"plane": [0, 0, 0]},
+            BoundarySpecValueError,
+            r"PrimitiveCellMetadata\.plane must not be all-zero",
+            id="zero-plane",
+        ),
+        pytest.param(
+            {"plane": [1.5, 0, 0]},
+            BoundarySpecValueError,
+            r"PrimitiveCellMetadata\.plane\(0,\)=1\.5 "
+            r"is not exactly integer-valued",
+            id="noninteger-plane",
+        ),
+        pytest.param(
+            {"plane": [True, 0, 0]},
+            BoundarySpecTypeError,
+            r"PrimitiveCellMetadata\.plane\(0,\)=True "
+            r"is not an integer",
+            id="boolean-plane",
+        ),
+        pytest.param(
+            {"rotation_denominator": 0},
+            BoundarySpecValueError,
+            r"PrimitiveCellMetadata\.rotation_denominator "
+            r"must be a positive integer",
+            id="zero-rotation-denominator",
+        ),
+        pytest.param(
+            {"rotation_denominator": 1.5},
+            BoundarySpecValueError,
+            r"PrimitiveCellMetadata\.rotation_denominator "
+            r"must be a positive integer",
+            id="noninteger-rotation-denominator",
+        ),
+        pytest.param(
+            {"rotation_denominator": True},
+            BoundarySpecTypeError,
+            r"PrimitiveCellMetadata\.rotation_denominator "
+            r"must not be boolean",
+            id="boolean-rotation-denominator",
         ),
     ],
 )
@@ -752,10 +808,8 @@ def test_boundary_embedding_stores_primitive_metadata():
         input_area_index=10,
         primitive_area_index=5,
         orientation_area_index=5,
-        input_reduction_index=2,
         plane=(0, 0, 1),
         rotation_denominator=10,
-        conventional_cell_multiplier=10,
     )
 
     emb = _make_embedding(metadata=metadata)

--- a/tests/test_crystallography_boundary.py
+++ b/tests/test_crystallography_boundary.py
@@ -22,6 +22,7 @@ from GBOpt.crystallography.pq import (
     recover_exact_row_rotation_from_paired_pq,
 )
 from GBOpt.crystallography.quaternion import quaternion_to_scaled_rotation
+from GBOpt.crystallography.types import CrystallographyValueError
 
 # --------------------------------------------------------------------------------------
 # Shared test data
@@ -296,6 +297,27 @@ def test_pq_spec_primitive_orthogonal_fallback_preserves_input_reduction_metadat
         emb.metadata.input_reduction_index
         == emb.metadata.input_area_index // emb.metadata.primitive_area_index
     )
+
+
+def test_pq_spec_primitive_translates_crystallography_failure(monkeypatch):
+    def raise_primitive_failure(*args, **kwargs):
+        raise CrystallographyValueError("forced primitive validation failure")
+
+    monkeypatch.setattr(
+        "GBOpt.crystallography.boundary.primitive_embedding_from_row_rotation",
+        raise_primitive_failure,
+    )
+
+    spec = PQSpec(
+        P=list(SIGMA5_TWIST_PRIMITIVE_P),
+        Q=list(SIGMA5_TWIST_PRIMITIVE_Q),
+    )
+
+    with pytest.raises(
+        BoundarySpecError,
+        match="forced primitive validation failure",
+    ):
+        pq_spec_to_embedding(spec)
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/test_crystallography_boundary.py
+++ b/tests/test_crystallography_boundary.py
@@ -5,7 +5,6 @@ import pytest
 from GBOpt.BoundarySpec import (
     BoundaryEmbedding,
     BoundarySpecError,
-    BoundarySpecOrthogonalityError,
     CSLApproxSpec,
     CSLExactSpec,
     FiveDOFSpec,
@@ -502,51 +501,6 @@ def test_csl_exact_spec_uses_orthogonal_embedding_when_rotation_does_not_preserv
     assert emb.metadata.input_reduction_index is None
     assert emb.metadata.orientation_area_index == 1
     assert emb.metadata.plane == (1, 0, 0)
-    assert emb.metadata.rotation_denominator == 10
-    assert emb.metadata.conventional_cell_multiplier == 10
-
-
-def test_csl_exact_spec_to_embedding_orthogonality_error_uses_orthogonal_fallback(
-    monkeypatch,
-):
-    primitive_calls = []
-
-    def raise_orthogonality_error(row_rotation, plane, **kwargs):
-        primitive_calls.append(
-            {
-                "plane": tuple(int(x) for x in plane),
-                "source": kwargs.get("source"),
-                "max_exact_atoms": kwargs.get("max_exact_atoms"),
-            }
-        )
-        raise BoundarySpecOrthogonalityError("forced orthogonality failure")
-
-    monkeypatch.setattr(
-        "GBOpt.crystallography.boundary.primitive_embedding_from_row_rotation",
-        raise_orthogonality_error,
-    )
-
-    spec = CSLExactSpec(axis=[0, 0, 1], plane=[0, 0, 1], quat=[3, 0, 0, 1])
-    emb = csl_exact_spec_to_embedding(spec)
-
-    assert primitive_calls == [
-        {
-            "plane": (0, 0, 1),
-            "source": "csl",
-            "max_exact_atoms": 10_000,
-        }
-    ]
-
-    _assert_embedding_flags(emb, exact=True, coherent=True, source="csl")
-    _assert_proper_rotation_pair(emb)
-
-    assert emb.metadata is not None
-    assert emb.metadata.basis_mode == "primitive"
-    assert emb.metadata.input_area_index is None
-    assert emb.metadata.primitive_area_index == 5
-    assert emb.metadata.input_reduction_index is None
-    assert emb.metadata.orientation_area_index == 5
-    assert emb.metadata.plane == (0, 0, 1)
     assert emb.metadata.rotation_denominator == 10
     assert emb.metadata.conventional_cell_multiplier == 10
 

--- a/tests/test_crystallography_boundary.py
+++ b/tests/test_crystallography_boundary.py
@@ -20,7 +20,6 @@ from GBOpt.crystallography.boundary import (
 )
 from GBOpt.crystallography.integer import as_int_array, integer_det3
 from GBOpt.crystallography.pq import (
-    canonicalize_pq,
     recover_exact_row_rotation_from_paired_pq,
 )
 from GBOpt.crystallography.quaternion import quaternion_to_scaled_rotation
@@ -121,21 +120,25 @@ def test_pq_spec_to_embedding_identity_r_left_r_right(identity_pq_spec):
     np.testing.assert_allclose(emb.R_right, np.eye(3), atol=1e-12, rtol=0.0)
 
 
-def test_pq_spec_to_embedding_sigma5_r_right_matches_canonical(sigma5_supplied_pq_spec):
-    emb = pq_spec_to_embedding(sigma5_supplied_pq_spec)
+def test_pq_spec_to_embedding_sigma5_r_right_matches_expected(
+    sigma5_supplied_pq_spec,
+):
+    embedding = pq_spec_to_embedding(sigma5_supplied_pq_spec)
 
-    P_raw = np.array(SIGMA5_36_P, dtype=float)
-    Q_raw = np.array(SIGMA5_36_Q, dtype=float)
-    _, Q_c = canonicalize_pq(P_raw, Q_raw)
-
-    Q_c_float = np.asarray(Q_c, dtype=float)
-    R_right_expected = Q_c_float / np.linalg.norm(
-        Q_c_float,
-        axis=1,
-        keepdims=True,
+    expected = np.array(
+        [
+            [4.0 / 5.0, -3.0 / 5.0, 0.0],
+            [3.0 / 5.0, 4.0 / 5.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
     )
 
-    np.testing.assert_allclose(emb.R_right, R_right_expected, atol=1e-12, rtol=0.0)
+    np.testing.assert_allclose(
+        embedding.R_right,
+        expected,
+        atol=1.0e-12,
+        rtol=0.0,
+    )
 
 
 def test_pq_spec_to_embedding_sigma5_r_right_is_proper_rotation(

--- a/tests/test_crystallography_boundary.py
+++ b/tests/test_crystallography_boundary.py
@@ -451,16 +451,44 @@ def test_csl_exact_spec_to_embedding_twist_rotations_derive_from_final_pq():
 
 
 def test_csl_exact_spec_to_embedding_large_denominator_stays_exact():
-    spec = CSLExactSpec(axis=[128, 1, 1], plane=[1, 0, 0], quat=[128, 128, 1, 1])
-    emb = csl_exact_spec_to_embedding(spec, max_exact_atoms=10**9)
+    spec = CSLExactSpec(
+        axis=[128, 1, 1],
+        plane=[1, 0, 0],
+        quat=[128, 128, 1, 1],
+    )
+
+    emb = csl_exact_spec_to_embedding(
+        spec,
+        max_primitive_area_index=10**9,
+        max_pq_determinant=10**9,
+    )
+
     assert emb.exact is True
     assert emb.P is not None
     assert emb.Q is not None
-    for R in (emb.R_left, emb.R_right):
-        np.testing.assert_allclose(R @ R.T, np.eye(3), atol=1e-10)
-    np.testing.assert_array_equal(emb.P.astype(int), np.eye(3, dtype=int))
-    expected_Q = np.array([[16383, 0, 256], [256, 0, -16383], [0, 1, 0]], dtype=int)
-    np.testing.assert_array_equal(emb.Q.astype(int), expected_Q)
+
+    for rotation in (emb.R_left, emb.R_right):
+        np.testing.assert_allclose(
+            rotation @ rotation.T,
+            np.eye(3),
+            atol=1e-10,
+        )
+
+    np.testing.assert_array_equal(
+        emb.P.astype(int),
+        np.eye(3, dtype=int),
+    )
+    np.testing.assert_array_equal(
+        emb.Q.astype(int),
+        np.array(
+            [
+                [16383, 0, 256],
+                [256, 0, -16383],
+                [0, 1, 0],
+            ],
+            dtype=int,
+        ),
+    )
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/test_crystallography_csl.py
+++ b/tests/test_crystallography_csl.py
@@ -91,21 +91,21 @@ def test_sigma_from_snf_diagonal_returns_sigma1_moduli():
 
 
 @pytest.mark.parametrize(
-    ("denominator", "diagonal"),
+    "denominator",
     [
-        pytest.param(0, (1, 1, 1), id="zero"),
-        pytest.param(-5, (1, 1, 5), id="negative"),
+        pytest.param(0, id="zero"),
+        pytest.param(-5, id="negative"),
+        pytest.param(5.5, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param("5", id="string"),
     ],
 )
-def test_sigma_from_snf_diagonal_rejects_nonpositive_denominator(
-    denominator,
-    diagonal,
-):
+def test_sigma_from_snf_diagonal_rejects_invalid_denominator(denominator):
     with pytest.raises(
         CrystallographyValueError,
-        match=f"denominator must be positive; got {denominator}",
+        match="denominator must be a positive integer",
     ):
-        sigma_from_snf_diagonal(denominator, diagonal)
+        sigma_from_snf_diagonal(denominator, (1, 5, 25))
 
 
 # --------------------------------------------------------------------------------------
@@ -225,6 +225,7 @@ def test_verify_coincidence_basis_rejects_sigma_mismatch_by_determinant():
         pytest.param(-1, id="negative"),
         pytest.param(1.5, id="float"),
         pytest.param("5", id="string"),
+        pytest.param(True, id="bool"),
     ],
 )
 def test_verify_coincidence_basis_rejects_invalid_sigma(sigma):
@@ -391,6 +392,7 @@ def test_dsc_basis_rejects_sigma_mismatch():
         pytest.param(-1, id="negative"),
         pytest.param(1.5, id="float"),
         pytest.param("5", id="string"),
+        pytest.param(True, id="bool"),
     ],
 )
 def test_dsc_basis_rejects_invalid_sigma(sigma):

--- a/tests/test_crystallography_embedding.py
+++ b/tests/test_crystallography_embedding.py
@@ -1,5 +1,4 @@
 # Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
-from typing import Any
 
 import numpy as np
 import pytest
@@ -9,19 +8,25 @@ from GBOpt.BoundarySpec import (
     BoundaryEmbedding,
     BoundarySpecError,
     BoundarySpecOrthogonalityError,
+    PrimitiveCellMetadata,
 )
+from GBOpt.crystallography.csl import csl_from_scaled_rotation
 from GBOpt.crystallography.embedding import (
+    _exact_embedding_from_precomputed_csl,
     _paired_pq_from_direction_rows,
+    _validated_exact_orientation_rows,
     embedding_from_pq,
     embedding_from_rotation_rows,
     exact_embedding_from_row_rotation_and_plane,
     orthogonal_embedding_from_row_rotation_and_plane,
     primitive_embedding_from_row_rotation,
-    primitive_metadata,
 )
 from GBOpt.crystallography.integer import as_int_array
 from GBOpt.crystallography.plane import inplane_area_index
 from GBOpt.crystallography.pq import recover_exact_row_rotation_from_paired_pq
+from GBOpt.crystallography.quaternion import quaternion_to_scaled_rotation
+from GBOpt.crystallography.rotation import transpose_rotation_convention
+from GBOpt.crystallography.types import CrystallographyValueError
 
 # --------------------------------------------------------------------------------------
 # Fixtures
@@ -38,21 +43,18 @@ def identity_orientation_rows():
 @pytest.fixture
 def sigma5_53deg_rotation():
     """Sigma5 [001] 53.13 deg scaled rotation -- quaternion (2, 0, 0, 1), N=5."""
-    from GBOpt.crystallography.quaternion import quaternion_to_scaled_rotation
     return quaternion_to_scaled_rotation((2, 0, 0, 1))
 
 
 @pytest.fixture
 def sigma5_36deg_rotation():
     """Sigma5 [001] 36.87 deg scaled rotation -- quaternion (3, 0, 0, 1), N=10."""
-    from GBOpt.crystallography.quaternion import quaternion_to_scaled_rotation
     return quaternion_to_scaled_rotation((3, 0, 0, 1))
 
 
 @pytest.fixture
 def sigma3_111_rotation():
     """Sigma3 [111] 60 deg twin scaled rotation -- quaternion (1, 1, 1, 0), N=3."""
-    from GBOpt.crystallography.quaternion import quaternion_to_scaled_rotation
     return quaternion_to_scaled_rotation((1, 1, 1, 0))
 
 
@@ -74,149 +76,102 @@ def _assert_proper_rotation_pair(embedding, *, atol=1e-10):
 
 
 # --------------------------------------------------------------------------------------
-# primitive_metadata
+# _validated_exact_orientation_rows
 # --------------------------------------------------------------------------------------
 
 
-def test_primitive_metadata_valid_returns_metadata():
-    result = primitive_metadata(
-        basis_mode="primitive",
-        input_area_index=10,
-        primitive_area_index=5,
-        orientation_area_index=5,
-        plane=np.array([0, 0, 1]),
-        rotation_denominator=5,
+def test_validated_exact_orientation_rows_preserves_large_exact_rows():
+    large_value = 10**400
+    matrix = np.array(
+        [
+            [large_value, 0, 0],
+            [0, large_value + 1, 0],
+            [0, 0, 1],
+        ],
+        dtype=object,
     )
 
-    assert result.basis_mode == "primitive"
-    assert result.input_area_index == 10
-    assert result.primitive_area_index == 5
-    assert result.orientation_area_index == 5
-    assert result.input_reduction_index == 2
-    assert result.plane == (0, 0, 1)
-    assert result.rotation_denominator == 5
-    assert result.conventional_cell_multiplier == 10
+    result = _validated_exact_orientation_rows(matrix, "P")
 
-
-def test_primitive_metadata_supplied_mode_records_input_area_as_single_reduction():
-    result = primitive_metadata(
-        basis_mode="supplied",
-        input_area_index=5,
-        primitive_area_index=5,
-        orientation_area_index=5,
-        plane=np.array([0, 0, 1]),
-        rotation_denominator=5,
-    )
-
-    assert result.basis_mode == "supplied"
-    assert result.input_area_index == 5
-    assert result.primitive_area_index == 5
-    assert result.orientation_area_index == 5
-    assert result.input_reduction_index == 1
-    assert result.conventional_cell_multiplier == 10
-
-
-def test_primitive_metadata_requires_divisible_input_area_index():
-    with pytest.raises(BoundarySpecError, match="integer multiple"):
-        primitive_metadata(
-            basis_mode="primitive",
-            input_area_index=7,
-            primitive_area_index=5,
-            orientation_area_index=1,
-            plane=np.array([0, 0, 1]),
-            rotation_denominator=5,
-        )
-
-
-def test_primitive_metadata_allows_orientation_area_not_multiple_of_primitive_area():
-    result = primitive_metadata(
-        basis_mode="primitive",
-        input_area_index=None,
-        primitive_area_index=5,
-        orientation_area_index=1,
-        plane=np.array([0, 0, 1]),
-        rotation_denominator=5,
-    )
-
-    assert result.primitive_area_index == 5
-    assert result.orientation_area_index == 1
-    assert result.input_area_index is None
-    assert result.input_reduction_index is None
-
-
-def test_primitive_metadata_conventional_cell_multiplier_is_twice_primitive():
-    result = primitive_metadata(
-        basis_mode="primitive",
-        input_area_index=None,
-        primitive_area_index=5,
-        orientation_area_index=5,
-        plane=np.array([1, 0, 0]),
-        rotation_denominator=5,
-    )
-
-    assert result.conventional_cell_multiplier == 2 * result.primitive_area_index
-
-
-@pytest.mark.parametrize("basis_mode", ["orthogonal", "", None])
-def test_primitive_metadata_rejects_invalid_basis_mode(basis_mode):
-    with pytest.raises(BoundarySpecError, match="basis_mode"):
-        primitive_metadata(
-            basis_mode=basis_mode,
-            primitive_area_index=1,
-            plane=np.array([0, 0, 1]),
-            rotation_denominator=1,
-        )
+    assert result.shape == (3, 3)
+    assert result.dtype == object
+    assert all(type(value) is int for value in result.flat)
+    np.testing.assert_array_equal(result, matrix)
 
 
 @pytest.mark.parametrize(
-    ("kwargs", "match"),
+    ("matrix", "match"),
     [
         pytest.param(
-            {"primitive_area_index": 0},
-            "primitive_area_index",
-            id="primitive-area-index-zero",
+            np.eye(2, dtype=object),
+            "shape",
+            id="wrong-shape",
         ),
         pytest.param(
-            {"primitive_area_index": -1},
-            "primitive_area_index",
-            id="primitive-area-index-negative",
-        ),
-        pytest.param(
-            {"input_area_index": 0},
-            "input_area_index",
-            id="input-area-index-zero",
-        ),
-        pytest.param(
-            {"input_area_index": -1},
-            "input_area_index",
-            id="input-area-index-negative",
-        ),
-        pytest.param(
-            {"orientation_area_index": 0},
-            "orientation_area_index",
-            id="orientation-area-index-zero",
-        ),
-        pytest.param(
-            {"orientation_area_index": -1},
-            "orientation_area_index",
-            id="orientation-area-index-negative",
+            [
+                [1, 0, 0],
+                [0, 1.5, 0],
+                [0, 0, 1],
+            ],
+            "exactly integer-valued",
+            id="noninteger-entry",
         ),
     ],
 )
-def test_primitive_metadata_rejects_nonpositive_metadata_values(
-    kwargs: dict[str, Any],
-    match: str,
-):
-    params: dict[str, Any] = {
-        "basis_mode": "primitive",
-        "primitive_area_index": 1,
-        "plane": np.array([0, 0, 1]),
-        "rotation_denominator": 1,
-    }
-    params.update(kwargs)
+def test_validated_exact_orientation_rows_rejects_malformed_matrix(matrix, match):
+    with pytest.raises(CrystallographyValueError, match=match):
+        _validated_exact_orientation_rows(matrix, "P")
 
-    with pytest.raises(BoundarySpecError, match=match):
-        primitive_metadata(**params)
+
+def test_validated_exact_orientation_rows_rejects_zero_row():
+    matrix = np.array(
+        [
+            [1, 0, 0],
+            [0, 0, 0],
+            [0, 0, 1],
+        ],
+        dtype=object,
+    )
+
+    with pytest.raises(
+        CrystallographyValueError,
+        match="P row 1 must be nonzero",
+    ):
+        _validated_exact_orientation_rows(matrix, "P")
+
+
+def test_validated_exact_orientation_rows_rejects_nonorthogonal_rows():
+    matrix = np.array(
+        [
+            [1, 0, 0],
+            [1, 1, 0],
+            [0, 0, 1],
+        ],
+        dtype=object,
+    )
+
+    with pytest.raises(
+        CrystallographyValueError,
+        match=r"rows 0 and 1 have exact dot product 1",
+    ):
+        _validated_exact_orientation_rows(matrix, "P")
+
+
+def test_validated_exact_orientation_rows_rejects_left_handed_frame():
+    matrix = np.array(
+        [
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, -1],
+        ],
+        dtype=object,
+    )
+
+    with pytest.raises(
+        CrystallographyValueError,
+        match=r"right-handed.*exact determinant is -1",
+    ):
+        _validated_exact_orientation_rows(matrix, "P")
 
 
 # --------------------------------------------------------------------------------------
@@ -251,7 +206,7 @@ def test_embedding_from_pq_non_orthogonal_raises(identity_orientation_rows):
 
 def test_embedding_from_pq_passes_metadata(identity_orientation_rows):
     P, Q = identity_orientation_rows
-    meta = primitive_metadata(
+    meta = PrimitiveCellMetadata(
         basis_mode="primitive",
         input_area_index=None,
         primitive_area_index=1,
@@ -315,45 +270,36 @@ def test_embedding_from_rotation_rows_rejects_non_orthogonal_rotation():
 # --------------------------------------------------------------------------------------
 
 
-def test_primitive_embedding_exact_and_coherent(sigma5_53deg_rotation):
+def test_primitive_embedding_generates_successfully(sigma5_53deg_rotation):
     plane = np.array([0, 0, 1])
     result = primitive_embedding_from_row_rotation(
         sigma5_53deg_rotation, plane, source="csl"
     )
     assert result.exact is True
     assert result.coherent is True
-
-
-def test_primitive_embedding_preserves_source_label(sigma5_53deg_rotation):
-    plane = np.array([0, 0, 1])
-    result = primitive_embedding_from_row_rotation(
-        sigma5_53deg_rotation, plane, source="csl"
-    )
     assert result.source == "csl"
-
-
-def test_primitive_embedding_proper_rotations(sigma5_53deg_rotation):
-    plane = np.array([0, 0, 1])
-    result = primitive_embedding_from_row_rotation(
-        sigma5_53deg_rotation, plane, source="csl"
-    )
     _assert_proper_rotation_pair(result)
-
-
-def test_primitive_embedding_records_primitive_metadata(sigma5_53deg_rotation):
-    plane = np.array([0, 0, 1])
-    result = primitive_embedding_from_row_rotation(
-        sigma5_53deg_rotation, plane, source="csl"
-    )
     assert result.metadata is not None
     assert result.metadata.basis_mode == "primitive"
 
 
-def test_primitive_embedding_max_exact_atoms_raises(sigma5_53deg_rotation):
-    plane = np.array([0, 0, 1])
-    with pytest.raises(BoundarySpecError, match="max_exact_atoms"):
+def test_primitive_embedding_enforces_primitive_area_limit(sigma5_53deg_rotation):
+    with pytest.raises(BoundarySpecError, match="max_primitive_area_index=4"):
         primitive_embedding_from_row_rotation(
-            sigma5_53deg_rotation, plane, source="csl", max_exact_atoms=1
+            sigma5_53deg_rotation,
+            np.array([0, 0, 1]),
+            source="csl",
+            max_primitive_area_index=4,
+        )
+
+
+def test_primitive_embedding_enforces_pq_determinant_limit(sigma5_53deg_rotation):
+    with pytest.raises(BoundarySpecError, match="max_pq_determinant=4"):
+        primitive_embedding_from_row_rotation(
+            sigma5_53deg_rotation,
+            np.array([0, 0, 1]),
+            source="csl",
+            max_pq_determinant=4,
         )
 
 
@@ -387,9 +333,7 @@ def test_primitive_embedding_pq_rows_satisfy_row_rotation_contract(
         np.testing.assert_array_equal(image, q_row)
 
 
-def test_primitive_embedding_records_input_area_reduction_index(
-    sigma5_53deg_rotation,
-):
+def test_primitive_embedding_records_input_area_reduction_index(sigma5_53deg_rotation):
     plane = np.array([0, 0, 1])
 
     baseline = primitive_embedding_from_row_rotation(
@@ -419,23 +363,25 @@ def test_primitive_embedding_records_input_area_reduction_index(
 # --------------------------------------------------------------------------------------
 
 
-def test_orthogonal_embedding_exact_and_coherent(sigma5_53deg_rotation):
+def test_orthogonal_embedding_generates_successfully(sigma5_53deg_rotation):
     plane = np.array([1, 0, 0])
     result = orthogonal_embedding_from_row_rotation_and_plane(
         sigma5_53deg_rotation, plane, source="csl"
     )
     assert result.exact is True
     assert result.coherent is True
-
-
-def test_orthogonal_embedding_sigma5_rows_normalize_to_proper_rotations(
-    sigma5_53deg_rotation,
-):
-    plane = np.array([1, 0, 0])
-    result = orthogonal_embedding_from_row_rotation_and_plane(
-        sigma5_53deg_rotation, plane, source="csl"
-    )
     _assert_proper_rotation_pair(result)
+
+    assert result.P is not None
+    assert result.Q is not None
+    assert result.P.dtype == object
+    assert result.Q.dtype == object
+
+    P = as_int_array(result.P, (3, 3), "P")
+    Q = as_int_array(result.Q, (3, 3), "Q")
+
+    np.testing.assert_array_equal(P, result.P)
+    np.testing.assert_array_equal(Q, result.Q)
 
 
 def test_orthogonal_embedding_sigma3_111_proper_rotations(sigma3_111_rotation):
@@ -465,30 +411,24 @@ def test_orthogonal_embedding_sigma3_111_records_primitive_and_orientation_area_
     assert result.metadata.rotation_denominator == 3
 
 
-def test_orthogonal_embedding_max_exact_atoms_raises(sigma5_53deg_rotation):
-    plane = np.array([1, 0, 0])
-    with pytest.raises(BoundarySpecError, match="max_exact_atoms"):
+def test_orthogonal_embedding_enforces_primitive_area_limit(sigma5_53deg_rotation):
+    with pytest.raises(BoundarySpecError, match="max_primitive_area_index=4"):
         orthogonal_embedding_from_row_rotation_and_plane(
-            sigma5_53deg_rotation, plane, source="csl", max_exact_atoms=1
+            sigma5_53deg_rotation,
+            np.array([1, 0, 0]),
+            source="csl",
+            max_primitive_area_index=4,
         )
 
 
-def test_orthogonal_embedding_returns_exact_integer_pq_rows(sigma5_53deg_rotation):
-    plane = np.array([1, 0, 0])
-    result = orthogonal_embedding_from_row_rotation_and_plane(
-        sigma5_53deg_rotation, plane, source="csl"
-    )
-
-    assert result.P is not None
-    assert result.Q is not None
-    assert result.P.dtype == object
-    assert result.Q.dtype == object
-
-    P = as_int_array(result.P, (3, 3), "P")
-    Q = as_int_array(result.Q, (3, 3), "Q")
-
-    np.testing.assert_array_equal(P, result.P)
-    np.testing.assert_array_equal(Q, result.Q)
+def test_orthogonal_embedding_enforces_pq_determinant_limit(sigma5_53deg_rotation):
+    with pytest.raises(BoundarySpecError, match="max_pq_determinant=24"):
+        orthogonal_embedding_from_row_rotation_and_plane(
+            sigma5_53deg_rotation,
+            np.array([1, 0, 0]),
+            source="csl",
+            max_pq_determinant=24,
+        )
 
 
 def test_orthogonal_embedding_rows_are_orthogonal_integer_directions(
@@ -512,9 +452,7 @@ def test_orthogonal_embedding_rows_are_orthogonal_integer_directions(
     np.testing.assert_array_equal(Q_gram, np.diag(np.diag(Q_gram)))
 
 
-def test_orthogonal_embedding_records_input_area_reduction_index(
-    sigma5_53deg_rotation,
-):
+def test_orthogonal_embedding_records_input_area_reduction_index(sigma5_53deg_rotation):
     plane = np.array([1, 0, 0])
 
     baseline = orthogonal_embedding_from_row_rotation_and_plane(
@@ -539,9 +477,7 @@ def test_orthogonal_embedding_records_input_area_reduction_index(
     assert result.metadata.input_reduction_index == 4
 
 
-def test_orthogonal_embedding_preserves_sigma3_misorientation(
-    sigma3_111_rotation,
-):
+def test_orthogonal_embedding_preserves_sigma3_misorientation(sigma3_111_rotation):
     result = orthogonal_embedding_from_row_rotation_and_plane(
         sigma3_111_rotation,
         np.array([1, 1, 1]),
@@ -629,9 +565,7 @@ def test_paired_pq_from_direction_rows_builds_expected_sigma5_pair(
     np.testing.assert_array_equal(Q, expected_Q)
 
 
-def test_paired_pq_from_direction_rows_preserves_exact_rotation(
-    sigma5_53deg_rotation,
-):
+def test_paired_pq_from_direction_rows_preserves_exact_rotation(sigma5_53deg_rotation):
     P, Q = _paired_pq_from_direction_rows(
         np.eye(3, dtype=object),
         sigma5_53deg_rotation,
@@ -649,8 +583,6 @@ def test_paired_pq_from_direction_rows_preserves_exact_rotation(
 
 
 def test_paired_pq_from_direction_rows_enlarges_rows_as_exact_pairs():
-    from GBOpt.crystallography.quaternion import quaternion_to_scaled_rotation
-
     identity_rotation = quaternion_to_scaled_rotation((1, 0, 0, 0))
 
     P, Q = _paired_pq_from_direction_rows(
@@ -673,14 +605,87 @@ def test_paired_pq_from_direction_rows_enlarges_rows_as_exact_pairs():
     assert inplane_area_index(P) == 3
 
 
+@pytest.mark.parametrize(
+    ("direction_rows", "match"),
+    [
+        pytest.param(
+            np.eye(2, dtype=object),
+            "shape",
+            id="wrong-shape",
+        ),
+        pytest.param(
+            [
+                [1, 0, 0],
+                [0, 1.5, 0],
+                [0, 0, 1],
+            ],
+            "exactly integer-valued",
+            id="noninteger-entry",
+        ),
+    ],
+)
+def test_paired_pq_from_direction_rows_rejects_malformed_direction_rows(
+    direction_rows,
+    match,
+    sigma5_53deg_rotation,
+):
+    with pytest.raises(CrystallographyValueError, match=match):
+        _paired_pq_from_direction_rows(
+            direction_rows,
+            sigma5_53deg_rotation,
+            primitive_area_index=5,
+        )
+
+
+@pytest.mark.parametrize(
+    "primitive_area_index",
+    [
+        pytest.param(0, id="zero"),
+        pytest.param(-1, id="negative"),
+        pytest.param(True, id="boolean"),
+        pytest.param(1.0, id="float"),
+    ],
+)
+def test_paired_pq_from_direction_rows_rejects_invalid_primitive_area_index(
+    primitive_area_index,
+    sigma5_53deg_rotation,
+):
+    with pytest.raises(
+        CrystallographyValueError,
+        match="primitive_area_index must be a positive integer",
+    ):
+        _paired_pq_from_direction_rows(
+            np.eye(3, dtype=object),
+            sigma5_53deg_rotation,
+            primitive_area_index=primitive_area_index,
+        )
+
+
+def test_paired_pq_from_direction_rows_enforces_final_pq_determinant_limit():
+    identity_rotation = quaternion_to_scaled_rotation((1, 0, 0, 0))
+
+    with pytest.raises(
+        BoundarySpecError,
+        match=(
+            r"max_pq_determinant=2.*"
+            r"\|det\(P\)\|=3.*"
+            r"\|det\(Q\)\|=3"
+        ),
+    ):
+        _paired_pq_from_direction_rows(
+            np.eye(3, dtype=object),
+            identity_rotation,
+            primitive_area_index=3,
+            max_pq_determinant=2,
+        )
+
+
 # --------------------------------------------------------------------------------------
 # exact_embedding_from_row_rotation_and_plane
 # --------------------------------------------------------------------------------------
 
 
-def test_exact_embedding_uses_primitive_path_for_preserved_plane(
-    sigma5_53deg_rotation,
-):
+def test_exact_embedding_uses_primitive_path_for_preserved_plane(sigma5_53deg_rotation):
     result = exact_embedding_from_row_rotation_and_plane(
         sigma5_53deg_rotation,
         np.array([0, 0, 1]),
@@ -706,12 +711,12 @@ def test_exact_embedding_falls_back_when_primitive_rows_are_not_orthogonal(
 
     monkeypatch.setattr(
         embedding_module,
-        "primitive_embedding_from_row_rotation",
+        "_primitive_embedding_from_inplane",
         reject_primitive,
     )
     monkeypatch.setattr(
         embedding_module,
-        "orthogonal_embedding_from_row_rotation_and_plane",
+        "_orthogonal_embedding_from_inplane",
         return_orthogonal,
     )
 
@@ -733,7 +738,7 @@ def test_exact_embedding_does_not_fallback_on_cell_size_error(
 
     monkeypatch.setattr(
         embedding_module,
-        "primitive_embedding_from_row_rotation",
+        "_primitive_embedding_from_inplane",
         reject_primitive,
     )
 
@@ -743,3 +748,90 @@ def test_exact_embedding_does_not_fallback_on_cell_size_error(
             np.array([0, 0, 1]),
             source="csl",
         )
+
+
+def test_exact_embedding_uses_primitive_path_for_antiparallel_plane(monkeypatch):
+    # A 180-degree rotation about y maps [1, 0, 0] to [-1, 0, 0].
+    row_rotation = quaternion_to_scaled_rotation((0, 0, 1, 0))
+    expected = object()
+
+    def return_primitive(*args, **kwargs):
+        return expected
+
+    def reject_orthogonal(*args, **kwargs):
+        pytest.fail(
+            "The orthogonal path should not be used when the plane normal "
+            "is preserved up to sign."
+        )
+
+    monkeypatch.setattr(
+        embedding_module,
+        "_primitive_embedding_from_inplane",
+        return_primitive,
+    )
+    monkeypatch.setattr(
+        embedding_module,
+        "_orthogonal_embedding_from_inplane",
+        reject_orthogonal,
+    )
+
+    result = exact_embedding_from_row_rotation_and_plane(
+        row_rotation,
+        np.array([1, 0, 0]),
+        source="csl",
+    )
+
+    assert result is expected
+
+
+def test_exact_embedding_constructs_primitive_antiparallel_plane():
+    row_rotation = quaternion_to_scaled_rotation((0, 0, 1, 0))
+
+    result = exact_embedding_from_row_rotation_and_plane(
+        row_rotation,
+        np.array([1, 0, 0]),
+        source="csl",
+    )
+
+    assert result.exact is True
+    assert result.coherent is True
+    assert result.metadata is not None
+    assert result.metadata.basis_mode == "primitive"
+    assert result.metadata.plane == (1, 0, 0)
+
+    expected_rotation = (
+        np.asarray(row_rotation.matrix, dtype=np.float64)
+        / row_rotation.denominator
+    )
+    np.testing.assert_allclose(
+        result.R_left.T @ result.R_right,
+        expected_rotation,
+        atol=1.0e-12,
+        rtol=0.0,
+    )
+
+
+def test_precomputed_csl_path_matches_public_exact_selector(sigma5_53deg_rotation):
+    plane = np.array([1, 0, 0], dtype=object)
+    column_rotation = transpose_rotation_convention(
+        sigma5_53deg_rotation
+    )
+    csl = csl_from_scaled_rotation(column_rotation)
+
+    expected = exact_embedding_from_row_rotation_and_plane(
+        sigma5_53deg_rotation,
+        plane,
+        source="csl",
+    )
+    actual = _exact_embedding_from_precomputed_csl(
+        sigma5_53deg_rotation,
+        plane,
+        csl,
+        source="csl",
+    )
+
+    np.testing.assert_array_equal(actual.P, expected.P)
+    np.testing.assert_array_equal(actual.Q, expected.Q)
+    np.testing.assert_allclose(actual.R_left, expected.R_left)
+    np.testing.assert_allclose(actual.R_right, expected.R_right)
+    assert actual.metadata == expected.metadata

--- a/tests/test_crystallography_embedding.py
+++ b/tests/test_crystallography_embedding.py
@@ -10,6 +10,7 @@ from GBOpt.BoundarySpec import (
     BoundarySpecOrthogonalityError,
 )
 from GBOpt.crystallography.embedding import (
+    _paired_pq_from_direction_rows,
     embedding_from_pq,
     embedding_from_rotation_rows,
     orthogonal_embedding_from_row_rotation_and_plane,
@@ -17,6 +18,8 @@ from GBOpt.crystallography.embedding import (
     primitive_metadata,
 )
 from GBOpt.crystallography.integer import as_int_array
+from GBOpt.crystallography.plane import inplane_area_index
+from GBOpt.crystallography.pq import recover_exact_row_rotation_from_paired_pq
 
 # --------------------------------------------------------------------------------------
 # Fixtures
@@ -532,3 +535,137 @@ def test_orthogonal_embedding_records_input_area_reduction_index(
     assert result.metadata.input_area_index == input_area_index
     assert result.metadata.primitive_area_index == primitive_area_index
     assert result.metadata.input_reduction_index == 4
+
+
+def test_orthogonal_embedding_preserves_sigma3_misorientation(
+    sigma3_111_rotation,
+):
+    result = orthogonal_embedding_from_row_rotation_and_plane(
+        sigma3_111_rotation,
+        np.array([1, 1, 1]),
+        source="csl",
+    )
+
+    expected_rotation = (
+        np.asarray(sigma3_111_rotation.matrix, dtype=np.float64)
+        / sigma3_111_rotation.denominator
+    )
+
+    np.testing.assert_allclose(
+        result.R_left.T @ result.R_right,
+        expected_rotation,
+        atol=1.0e-12,
+        rtol=0.0,
+    )
+
+
+def test_orthogonal_embedding_preserves_sigma3_row_image_directions(
+    sigma3_111_rotation,
+):
+    result = orthogonal_embedding_from_row_rotation_and_plane(
+        sigma3_111_rotation,
+        np.array([1, 1, 1]),
+        source="csl",
+    )
+
+    assert result.P is not None
+    assert result.Q is not None
+
+    numerator_matrix = np.asarray(
+        sigma3_111_rotation.matrix,
+        dtype=object,
+    )
+
+    for p_row, q_row in zip(result.P, result.Q, strict=True):
+        image_numerator = (
+            np.asarray(p_row, dtype=object) @ numerator_matrix
+        )
+        q_row = np.asarray(q_row, dtype=object)
+
+        np.testing.assert_array_equal(
+            np.cross(
+                np.asarray(image_numerator, dtype=np.int64),
+                np.asarray(q_row, dtype=np.int64),
+            ),
+            np.zeros(3, dtype=np.int64),
+        )
+        assert int(image_numerator @ q_row) > 0
+
+
+# --------------------------------------------------------------------------------------
+# _paired_pq_from_direction_rows
+# --------------------------------------------------------------------------------------
+
+
+def test_paired_pq_from_direction_rows_builds_expected_sigma5_pair(
+    sigma5_53deg_rotation,
+):
+    P, Q = _paired_pq_from_direction_rows(
+        np.eye(3, dtype=object),
+        sigma5_53deg_rotation,
+        primitive_area_index=5,
+    )
+
+    expected_P = np.array(
+        [
+            [5, 0, 0],
+            [0, 5, 0],
+            [0, 0, 1],
+        ],
+        dtype=object,
+    )
+    expected_Q = np.array(
+        [
+            [3, -4, 0],
+            [4, 3, 0],
+            [0, 0, 1],
+        ],
+        dtype=object,
+    )
+
+    np.testing.assert_array_equal(P, expected_P)
+    np.testing.assert_array_equal(Q, expected_Q)
+
+
+def test_paired_pq_from_direction_rows_preserves_exact_rotation(
+    sigma5_53deg_rotation,
+):
+    P, Q = _paired_pq_from_direction_rows(
+        np.eye(3, dtype=object),
+        sigma5_53deg_rotation,
+        primitive_area_index=5,
+    )
+
+    recovered = recover_exact_row_rotation_from_paired_pq(P, Q)
+
+    np.testing.assert_array_equal(
+        np.asarray(recovered.matrix, dtype=object)
+        * sigma5_53deg_rotation.denominator,
+        np.asarray(sigma5_53deg_rotation.matrix, dtype=object)
+        * recovered.denominator,
+    )
+
+
+def test_paired_pq_from_direction_rows_enlarges_rows_as_exact_pairs():
+    from GBOpt.crystallography.quaternion import quaternion_to_scaled_rotation
+
+    identity_rotation = quaternion_to_scaled_rotation((1, 0, 0, 0))
+
+    P, Q = _paired_pq_from_direction_rows(
+        np.eye(3, dtype=object),
+        identity_rotation,
+        primitive_area_index=3,
+    )
+
+    expected = np.array(
+        [
+            [1, 0, 0],
+            [0, 3, 0],
+            [0, 0, 1],
+        ],
+        dtype=object,
+    )
+
+    np.testing.assert_array_equal(P, expected)
+    np.testing.assert_array_equal(Q, expected)
+    assert inplane_area_index(P) == 3

--- a/tests/test_crystallography_embedding.py
+++ b/tests/test_crystallography_embedding.py
@@ -4,6 +4,7 @@ from typing import Any
 import numpy as np
 import pytest
 
+import GBOpt.crystallography.embedding as embedding_module
 from GBOpt.BoundarySpec import (
     BoundaryEmbedding,
     BoundarySpecError,
@@ -13,6 +14,7 @@ from GBOpt.crystallography.embedding import (
     _paired_pq_from_direction_rows,
     embedding_from_pq,
     embedding_from_rotation_rows,
+    exact_embedding_from_row_rotation_and_plane,
     orthogonal_embedding_from_row_rotation_and_plane,
     primitive_embedding_from_row_rotation,
     primitive_metadata,
@@ -669,3 +671,75 @@ def test_paired_pq_from_direction_rows_enlarges_rows_as_exact_pairs():
     np.testing.assert_array_equal(P, expected)
     np.testing.assert_array_equal(Q, expected)
     assert inplane_area_index(P) == 3
+
+
+# --------------------------------------------------------------------------------------
+# exact_embedding_from_row_rotation_and_plane
+# --------------------------------------------------------------------------------------
+
+
+def test_exact_embedding_uses_primitive_path_for_preserved_plane(
+    sigma5_53deg_rotation,
+):
+    result = exact_embedding_from_row_rotation_and_plane(
+        sigma5_53deg_rotation,
+        np.array([0, 0, 1]),
+        source="csl",
+    )
+
+    assert result.metadata is not None
+    assert result.metadata.plane == (0, 0, 1)
+    assert result.metadata.primitive_area_index == 5
+
+
+def test_exact_embedding_falls_back_when_primitive_rows_are_not_orthogonal(
+    monkeypatch,
+    sigma5_53deg_rotation,
+):
+    expected = object()
+
+    def reject_primitive(*args, **kwargs):
+        raise BoundarySpecOrthogonalityError("not orthogonal")
+
+    def return_orthogonal(*args, **kwargs):
+        return expected
+
+    monkeypatch.setattr(
+        embedding_module,
+        "primitive_embedding_from_row_rotation",
+        reject_primitive,
+    )
+    monkeypatch.setattr(
+        embedding_module,
+        "orthogonal_embedding_from_row_rotation_and_plane",
+        return_orthogonal,
+    )
+
+    result = exact_embedding_from_row_rotation_and_plane(
+        sigma5_53deg_rotation,
+        np.array([0, 0, 1]),
+        source="csl",
+    )
+
+    assert result is expected
+
+
+def test_exact_embedding_does_not_fallback_on_cell_size_error(
+    monkeypatch,
+    sigma5_53deg_rotation,
+):
+    def reject_primitive(*args, **kwargs):
+        raise BoundarySpecError("cell too large")
+
+    monkeypatch.setattr(
+        embedding_module,
+        "primitive_embedding_from_row_rotation",
+        reject_primitive,
+    )
+
+    with pytest.raises(BoundarySpecError, match="cell too large"):
+        exact_embedding_from_row_rotation_and_plane(
+            sigma5_53deg_rotation,
+            np.array([0, 0, 1]),
+            source="csl",
+        )

--- a/tests/test_crystallography_exactification.py
+++ b/tests/test_crystallography_exactification.py
@@ -298,3 +298,12 @@ def test_exactify_five_dof_rejects_invalid_bounds(keyword, value):
 def test_exactify_five_dof_rejects_malformed_params():
     with pytest.raises(CrystallographyValueError, match=r"shape \(5,\)"):
         exactify_five_dof(np.zeros(4))
+
+
+def test_exactify_five_dof_zero_parameters_return_identity_pq():
+    P, Q = exactify_five_dof(np.zeros(5))
+
+    expected = np.eye(3, dtype=object)
+
+    np.testing.assert_array_equal(P, expected)
+    np.testing.assert_array_equal(Q, expected)

--- a/tests/test_crystallography_exactification.py
+++ b/tests/test_crystallography_exactification.py
@@ -5,14 +5,296 @@
 import numpy as np
 import pytest
 
-from GBOpt.crystallography.exactification import exactify_five_dof
+from GBOpt.BoundarySpec import BoundarySpecError, PQSpec
+from GBOpt.crystallography.boundary import pq_spec_to_embedding
+from GBOpt.crystallography.exactification import (
+    _rationalize_direction,
+    exactify_five_dof,
+)
+from GBOpt.crystallography.orientation import (
+    orientation_matrices_from_five_dof,
+    validate_orientation_matrix,
+)
+from GBOpt.crystallography.pq import recover_exact_row_rotation_from_paired_pq
+from GBOpt.crystallography.types import (
+    CrystallographyNotImplementedError,
+    CrystallographyValueError,
+)
+
+SIGMA5_PARAMS = np.array([np.arctan2(3, 4), 0.0, 0.0, 0.0, 0.0])
+SIGMA3_INCLINED_PARAMS = np.array(
+    [
+        3 * np.pi / 4,
+        np.arccos(-1 / 3),
+        np.pi / 4,
+        np.pi / 4,
+        -np.arcsin(1 / np.sqrt(3.0)),
+    ]
+)
+
+EXACTIFICATION_CASES = [
+    pytest.param(
+        SIGMA5_PARAMS,
+        np.array(
+            [
+                [5, 0, 0],
+                [0, 5, 0],
+                [0, 0, 1],
+            ],
+            dtype=object,
+        ),
+        np.array(
+            [
+                [4, -3, 0],
+                [3, 4, 0],
+                [0, 0, 1],
+            ],
+            dtype=object,
+        ),
+        id="sigma5-twist",
+    ),
+    pytest.param(
+        SIGMA3_INCLINED_PARAMS,
+        np.array(
+            [
+                [1, 1, 1],
+                [1, 1, -2],
+                [-1, 1, 0],
+            ],
+            dtype=object,
+        ),
+        np.array(
+            [
+                [1, 1, 1],
+                [-1, -1, 2],
+                [1, -1, 0],
+            ],
+            dtype=object,
+        ),
+        id="inclined-sigma3",
+    ),
+]
 
 
-def test_exactify_five_dof_is_not_implemented():
-    params = np.zeros(5, dtype=float)
+def _assert_matches_five_dof(P, Q, params):
+    expected_left, expected_right = orientation_matrices_from_five_dof(params)
+    actual_left = validate_orientation_matrix(P, "P")
+    actual_right = validate_orientation_matrix(Q, "Q")
+
+    np.testing.assert_allclose(actual_left[0], expected_left[0], atol=1.0e-12)
+    np.testing.assert_allclose(
+        actual_left.T @ actual_right,
+        expected_left.T @ expected_right,
+        atol=1.0e-12,
+    )
+
+
+# --------------------------------------------------------------------------------------
+# _rationalize_direction
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("direction", "expected"),
+    [
+        pytest.param(
+            [2.0, 4.0, 6.0],
+            [1, 2, 3],
+            id="gcd-reduced",
+        ),
+        pytest.param(
+            [-2.0, -4.0, -6.0],
+            [-1, -2, -3],
+            id="negative-direction-preserved",
+        ),
+        pytest.param(
+            [0.0, 0.0, -5.0],
+            [0, 0, -1],
+            id="negative-axis",
+        ),
+    ],
+)
+def test_rationalize_direction_returns_primitive_integer_direction(
+    direction,
+    expected,
+):
+    result = _rationalize_direction(
+        direction,
+        max_denominator=100,
+        tol=1.0e-12,
+        name="direction",
+    )
+
+    np.testing.assert_array_equal(result, expected)
+    assert result.dtype == object
+
+
+@pytest.mark.parametrize(
+    ("direction", "match"),
+    [
+        pytest.param(
+            [1.0, 2.0],
+            r"shape \(3,\)",
+            id="wrong-shape",
+        ),
+        pytest.param(
+            [1.0, np.nan, 0.0],
+            "finite values",
+            id="nan",
+        ),
+        pytest.param(
+            [1.0, np.inf, 0.0],
+            "finite values",
+            id="infinite",
+        ),
+        pytest.param(
+            [0.0, 0.0, 0.0],
+            "nonzero",
+            id="zero",
+        ),
+    ],
+)
+def test_rationalize_direction_rejects_invalid_direction(direction, match):
+    with pytest.raises(CrystallographyValueError, match=match):
+        _rationalize_direction(
+            direction,
+            max_denominator=100,
+            tol=1.0e-12,
+            name="direction",
+        )
+
+
+def test_rationalize_direction_rejects_approximation_outside_tolerance():
+    with pytest.raises(
+        CrystallographyValueError,
+        match="could not be exactified",
+    ):
+        _rationalize_direction(
+            [1.0, np.sqrt(2.0), 0.0],
+            max_denominator=8,
+            tol=1.0e-12,
+            name="direction",
+        )
+
+
+# --------------------------------------------------------------------------------------
+# exactify_five_dof
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("params", "expected_P", "expected_Q"), EXACTIFICATION_CASES)
+def test_exactify_five_dof_returns_expected_paired_pq(
+    params,
+    expected_P,
+    expected_Q,
+):
+    P, Q = exactify_five_dof(params)
+
+    np.testing.assert_array_equal(P, expected_P)
+    np.testing.assert_array_equal(Q, expected_Q)
+    _assert_matches_five_dof(P, Q, params)
+
+    recovered = recover_exact_row_rotation_from_paired_pq(P, Q)
+    recovered_matrix = (
+        np.asarray(recovered.matrix, dtype=np.float64) / recovered.denominator
+    )
+    expected_left, expected_right = orientation_matrices_from_five_dof(params)
+    np.testing.assert_allclose(
+        recovered_matrix,
+        expected_left.T @ expected_right,
+        atol=1.0e-12,
+    )
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.param(SIGMA5_PARAMS, id="sigma5-twist"),
+        pytest.param(SIGMA3_INCLINED_PARAMS, id="inclined-sigma3"),
+    ],
+)
+def test_exactified_pq_round_trips_through_primitive_pq_spec(params):
+    P, Q = exactify_five_dof(params)
+
+    embedding = pq_spec_to_embedding(PQSpec(P=P, Q=Q, basis_mode="primitive"))
+
+    expected_left, expected_right = orientation_matrices_from_five_dof(params)
+    np.testing.assert_allclose(embedding.R_left[0], expected_left[0], atol=1.0e-12)
+    np.testing.assert_allclose(
+        embedding.R_left.T @ embedding.R_right,
+        expected_left.T @ expected_right,
+        atol=1.0e-12,
+    )
+
+
+def test_exactify_five_dof_rejects_non_csl_misorientation():
+    with pytest.raises(CrystallographyValueError, match="could not be exactified"):
+        exactify_five_dof(np.array([0.0, 0.0, 0.1, 0.0, 0.0]))
+
+
+def test_exactify_five_dof_rejects_sigma_above_limit():
+    with pytest.raises(CrystallographyValueError, match="exceeds max_sigma=4"):
+        exactify_five_dof(SIGMA5_PARAMS, max_sigma=4)
+
+
+def test_exactify_five_dof_rejects_small_max_denominator():
+    with pytest.raises(
+        CrystallographyValueError,
+        match="could not be exactified within max_denominator=2",
+    ):
+        exactify_five_dof(SIGMA5_PARAMS, max_denominator=2)
+
+
+def test_exactify_five_dof_rejects_misorientation_outside_angle_tolerance():
+    params = SIGMA5_PARAMS.copy()
+    params[0] += 1.0e-10
+
+    with pytest.raises(CrystallographyValueError, match="angle_tol=1e-12"):
+        exactify_five_dof(params, angle_tol=1.0e-12)
+
+
+def test_exactify_five_dof_rejects_inexact_boundary_plane():
+    params = np.array([0.0, 0.0, 0.0, 0.3, 0.0])
 
     with pytest.raises(
-        NotImplementedError,
-        match=r"five-DOF parameters to exact canonical P/Q matrices",
+        CrystallographyValueError,
+        match="boundary plane normal could not be exactified",
     ):
-        exactify_five_dof(params)
+        exactify_five_dof(
+            params,
+            max_denominator=8,
+            plane_tol=1.0e-12,
+        )
+
+
+def test_exactify_five_dof_enforces_exact_cell_size_limit():
+    with pytest.raises(BoundarySpecError, match="exceeds max_exact_atoms"):
+        exactify_five_dof(SIGMA5_PARAMS, max_exact_atoms=4)
+
+
+def test_exactify_five_dof_rejects_non_cubic_lattice_metric():
+    with pytest.raises(
+        CrystallographyNotImplementedError,
+        match="non-cubic lattice metrics are not implemented",
+    ):
+        exactify_five_dof(np.zeros(5), lattice_metric=np.eye(3))
+
+
+@pytest.mark.parametrize(
+    ("keyword", "value"),
+    [
+        pytest.param("max_exact_atoms", 0, id="nonpositive-max-exact-atoms"),
+        pytest.param("max_sigma", True, id="boolean-max-sigma"),
+        pytest.param("max_denominator", 1.5, id="noninteger-max-denominator"),
+        pytest.param("angle_tol", 0.0, id="nonpositive-angle-tolerance"),
+        pytest.param("plane_tol", np.inf, id="nonfinite-plane-tolerance"),
+    ],
+)
+def test_exactify_five_dof_rejects_invalid_bounds(keyword, value):
+    with pytest.raises(CrystallographyValueError, match=keyword):
+        exactify_five_dof(np.zeros(5), **{keyword: value})
+
+
+def test_exactify_five_dof_rejects_malformed_params():
+    with pytest.raises(CrystallographyValueError, match=r"shape \(5,\)"):
+        exactify_five_dof(np.zeros(4))

--- a/tests/test_crystallography_exactification.py
+++ b/tests/test_crystallography_exactification.py
@@ -5,6 +5,7 @@
 import numpy as np
 import pytest
 
+import GBOpt.crystallography.exactification as exactification_module
 from GBOpt.BoundarySpec import BoundarySpecError, PQSpec
 from GBOpt.crystallography.boundary import pq_spec_to_embedding
 from GBOpt.crystallography.exactification import (
@@ -240,7 +241,10 @@ def test_exactify_five_dof_rejects_sigma_above_limit():
 def test_exactify_five_dof_rejects_small_max_denominator():
     with pytest.raises(
         CrystallographyValueError,
-        match="could not be exactified within max_denominator=2",
+        match=(
+            r"max_denominator=2.*angle_tol=1e-09.*"
+            r"angular error"
+        ),
     ):
         exactify_five_dof(SIGMA5_PARAMS, max_denominator=2)
 
@@ -267,11 +271,6 @@ def test_exactify_five_dof_rejects_inexact_boundary_plane():
         )
 
 
-def test_exactify_five_dof_enforces_exact_cell_size_limit():
-    with pytest.raises(BoundarySpecError, match="exceeds max_exact_atoms"):
-        exactify_five_dof(SIGMA5_PARAMS, max_exact_atoms=4)
-
-
 def test_exactify_five_dof_rejects_non_cubic_lattice_metric():
     with pytest.raises(
         CrystallographyNotImplementedError,
@@ -283,7 +282,16 @@ def test_exactify_five_dof_rejects_non_cubic_lattice_metric():
 @pytest.mark.parametrize(
     ("keyword", "value"),
     [
-        pytest.param("max_exact_atoms", 0, id="nonpositive-max-exact-atoms"),
+        pytest.param(
+            "max_primitive_area_index",
+            0,
+            id="nonpositive-max-primitive-area-index",
+        ),
+        pytest.param(
+            "max_pq_determinant",
+            0,
+            id="nonpositive-max-pq-determinant",
+        ),
         pytest.param("max_sigma", True, id="boolean-max-sigma"),
         pytest.param("max_denominator", 1.5, id="noninteger-max-denominator"),
         pytest.param("angle_tol", 0.0, id="nonpositive-angle-tolerance"),
@@ -307,3 +315,90 @@ def test_exactify_five_dof_zero_parameters_return_identity_pq():
 
     np.testing.assert_array_equal(P, expected)
     np.testing.assert_array_equal(Q, expected)
+
+
+def test_exactify_five_dof_enforces_primitive_area_limit():
+    with pytest.raises(
+        BoundarySpecError,
+        match="max_primitive_area_index=4",
+    ):
+        exactify_five_dof(
+            SIGMA5_PARAMS,
+            max_primitive_area_index=4,
+        )
+
+
+def test_exactify_five_dof_enforces_pq_determinant_limit():
+    with pytest.raises(
+        BoundarySpecError,
+        match="max_pq_determinant=24",
+    ):
+        exactify_five_dof(
+            SIGMA5_PARAMS,
+            max_pq_determinant=24,
+        )
+
+
+@pytest.mark.parametrize(
+    ("direction", "expected"),
+    [
+        pytest.param(
+            [1.0e308, 1.0e308, 0.0],
+            [1, 1, 0],
+            id="large-finite-components",
+        ),
+        pytest.param(
+            [1.0e-320, 0.0, 0.0],
+            [1, 0, 0],
+            id="subnormal-components",
+        ),
+    ],
+)
+def test_rationalize_direction_is_scale_safe(direction, expected):
+    result = _rationalize_direction(
+        direction,
+        max_denominator=100,
+        tol=1.0e-12,
+        name="direction",
+    )
+
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_exactify_five_dof_accepts_candidate_within_requested_angle_tolerance():
+    params = SIGMA5_PARAMS.copy()
+    params[0] += 1.0e-8
+
+    P, Q = exactify_five_dof(
+        params,
+        max_denominator=3,
+        angle_tol=1.0e-7,
+    )
+
+    expected_P, expected_Q = exactify_five_dof(SIGMA5_PARAMS)
+    np.testing.assert_array_equal(P, expected_P)
+    np.testing.assert_array_equal(Q, expected_Q)
+
+
+def test_exactify_five_dof_forwards_pq_determinant_limit_to_final_pairing(
+    monkeypatch,
+):
+    original_pairing = exactification_module._paired_pq_from_direction_rows
+    received_kwargs = {}
+
+    def record_pairing(*args, **kwargs):
+        received_kwargs.update(kwargs)
+        return original_pairing(*args, **kwargs)
+
+    monkeypatch.setattr(
+        exactification_module,
+        "_paired_pq_from_direction_rows",
+        record_pairing,
+    )
+
+    exactification_module.exactify_five_dof(
+        SIGMA5_PARAMS,
+        max_pq_determinant=100,
+    )
+
+    assert received_kwargs["max_pq_determinant"] == 100

--- a/tests/test_crystallography_integer.py
+++ b/tests/test_crystallography_integer.py
@@ -5,6 +5,7 @@ import pytest
 from GBOpt.crystallography.integer import (
     as_int_array,
     as_int_vector,
+    as_positive_int,
     cross_int3,
     dot_int,
     integer_adj3,
@@ -48,6 +49,40 @@ def test_as_int_vector_wrong_length_raises_crystallography_value_error():
 def test_as_int_vector_non_integer_input_raises_crystallography_value_error():
     with pytest.raises(CrystallographyValueError, match="exactly integer-valued"):
         as_int_vector([1.5, 2, 3], 3, "v")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(1, 1, id="python-int"),
+        pytest.param(np.int64(7), 7, id="numpy-int"),
+    ],
+)
+def test_as_positive_int_returns_python_int(value, expected):
+    result = as_positive_int(value, "limit")
+
+    assert result == expected
+    assert type(result) is int
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero"),
+        pytest.param(-1, id="negative"),
+        pytest.param(1.0, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param(np.bool_(True), id="numpy-bool"),
+        pytest.param("1", id="string"),
+        pytest.param(None, id="none"),
+    ],
+)
+def test_as_positive_int_rejects_invalid_values(value):
+    with pytest.raises(
+        CrystallographyValueError,
+        match="limit must be a positive integer",
+    ):
+        as_positive_int(value, "limit")
 
 
 def test_row_gcd_reduce_reduces_by_common_component_gcd():

--- a/tests/test_crystallography_pq.py
+++ b/tests/test_crystallography_pq.py
@@ -6,7 +6,6 @@ import pytest
 from crystallography_fixtures import SIGMA5_TWIST_PRIMITIVE_P, SIGMA5_TWIST_PRIMITIVE_Q
 
 from GBOpt.crystallography.pq import (
-    canonicalize_pq,
     canonicalize_pq_paired,
     recover_exact_row_rotation_from_paired_pq,
 )
@@ -29,144 +28,6 @@ def _sigma5_twist_primitive_pair():
         np.array(SIGMA5_TWIST_PRIMITIVE_P, dtype=float),
         np.array(SIGMA5_TWIST_PRIMITIVE_Q, dtype=float),
     )
-
-
-# --------------------------------------------------------------------------------------
-# canonicalize_pq
-# --------------------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    ("P", "Q"),
-    [
-        pytest.param(IDENTITY_PQ, IDENTITY_PQ, id="identity"),
-        pytest.param(
-            IDENTITY_PQ,
-            SIGMA5_Q,
-            id="sigma5",
-        ),
-    ],
-)
-def test_canonicalize_pq_is_idempotent(P, Q):
-    P1, Q1 = canonicalize_pq(P, Q)
-    P2, Q2 = canonicalize_pq(P1, Q1)
-
-    np.testing.assert_array_equal(P1, P2)
-    np.testing.assert_array_equal(Q1, Q2)
-
-
-@pytest.mark.parametrize(
-    ("P", "Q"),
-    [
-        pytest.param(
-            IDENTITY_PQ,
-            IDENTITY_PQ,
-            id="identity",
-        ),
-        pytest.param(
-            IDENTITY_PQ,
-            SIGMA5_Q,
-            id="sigma5",
-        ),
-        pytest.param(
-            np.array([[-1, 0, 0], [0, -1, 0], [0, 0, 1]], dtype=float),
-            IDENTITY_PQ,
-            id="sign-fixes",
-        ),
-    ],
-)
-def test_canonicalize_pq_returns_right_handed_rows(P, Q):
-    P_c, Q_c = canonicalize_pq(P, Q)
-
-    assert det3_int(P_c) > 0
-    assert det3_int(Q_c) > 0
-
-
-@pytest.mark.parametrize(
-    ("P_a", "P_b", "Q_a", "Q_b"),
-    [
-        pytest.param(
-            IDENTITY_PQ,
-            np.diag([2, 3, 4]).astype(float),
-            IDENTITY_PQ,
-            IDENTITY_PQ,
-            id="row-scaling",
-        ),
-        pytest.param(
-            IDENTITY_PQ,
-            np.array([[1, 0, 0], [0, 1, 1], [0, 0, 1]], dtype=float),
-            IDENTITY_PQ,
-            IDENTITY_PQ,
-            id="inplane-basis-change",
-        ),
-        pytest.param(
-            IDENTITY_PQ,
-            np.array([[1, 0, 0], [0, 2, 1], [0, 1, 1]], dtype=float),
-            IDENTITY_PQ,
-            IDENTITY_PQ,
-            id="longer-inplane-combination",
-        ),
-        pytest.param(
-            IDENTITY_PQ,
-            np.array([[1, 0, 0], [0, -1, 0], [0, 0, -1]], dtype=float),
-            IDENTITY_PQ,
-            IDENTITY_PQ,
-            id="inplane-sign-flip",
-        ),
-        pytest.param(
-            IDENTITY_PQ,
-            np.array([[-1, 0, 0], [0, 1, 0], [0, 0, -1]], dtype=float),
-            IDENTITY_PQ,
-            IDENTITY_PQ,
-            id="boundary-normal-sign-flip",
-        ),
-        pytest.param(
-            IDENTITY_PQ,
-            np.array([[1, 0, 0], [0, 0, 1], [0, 1, 0]], dtype=float),
-            IDENTITY_PQ,
-            IDENTITY_PQ,
-            id="swapped-inplane-rows",
-        ),
-        pytest.param(
-            IDENTITY_PQ,
-            IDENTITY_PQ,
-            SIGMA5_Q,
-            np.array([[3, 1, 0], [-1, 3, 0], [0, 0, 1]], dtype=float),
-            id="swapped-q-inplane-rows",
-        ),
-    ],
-)
-def test_canonicalize_pq_treats_equivalent_inputs_as_same(P_a, P_b, Q_a, Q_b):
-    P_a_c, Q_a_c = canonicalize_pq(P_a, Q_a)
-    P_b_c, Q_b_c = canonicalize_pq(P_b, Q_b)
-
-    np.testing.assert_array_equal(P_b_c, P_a_c)
-    np.testing.assert_array_equal(Q_b_c, Q_a_c)
-
-
-@pytest.mark.parametrize(
-    ("P", "Q"),
-    [
-        pytest.param(
-            np.array([[0.5, 0, 0], [0, 0.5, 0], [0, 0, 0.5]], dtype=float),
-            IDENTITY_PQ,
-            id="rational",
-        ),
-        pytest.param(
-            np.array([[1, 0, 0], [0, 1.5, 0], [0, 0, 1]], dtype=float),
-            IDENTITY_PQ,
-            id="mixed-rational",
-        ),
-        pytest.param(
-            np.array([[100000.4, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float),
-            IDENTITY_PQ,
-            id="large-noninteger",
-        ),
-    ],
-)
-def test_canonicalize_pq_rejects_invalid_values(P, Q):
-    with pytest.raises(CrystallographyValueError, match="integer-valued"):
-        canonicalize_pq(P, Q)
 
 
 # --------------------------------------------------------------------------------------
@@ -263,6 +124,14 @@ def test_canonicalize_pq_paired_rejects_invalid_values(P, Q):
         canonicalize_pq_paired(P, Q)
 
 
+def test_canonicalize_pq_paired_rejects_zero_rows():
+    P = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=float)
+    Q = IDENTITY_PQ
+
+    with pytest.raises(CrystallographyValueError, match="zero row"):
+        canonicalize_pq_paired(P, Q)
+
+
 # --------------------------------------------------------------------------------------
 # recover_exact_row_rotation_from_paired_pq
 # --------------------------------------------------------------------------------------
@@ -354,7 +223,6 @@ def test_recover_exact_row_rotation_normalizes_negative_det_p():
 @pytest.mark.parametrize(
     "func",
     [
-        pytest.param(canonicalize_pq, id="canonicalize-pq"),
         pytest.param(canonicalize_pq_paired, id="canonicalize-pq-paired"),
         pytest.param(recover_exact_row_rotation_from_paired_pq, id="recover-rotation"),
     ],
@@ -362,18 +230,3 @@ def test_recover_exact_row_rotation_normalizes_negative_det_p():
 def test_pq_functions_reject_wrong_shape(func):
     with pytest.raises(CrystallographyValueError, match="shape"):
         func(np.eye(2, dtype=float), IDENTITY_PQ)
-
-
-@pytest.mark.parametrize(
-    "func",
-    [
-        pytest.param(canonicalize_pq, id="canonicalize-pq"),
-        pytest.param(canonicalize_pq_paired, id="canonicalize-pq-paired"),
-    ],
-)
-def test_canonicalize_pq_functions_reject_zero_rows(func):
-    P = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=float)
-    Q = IDENTITY_PQ
-
-    with pytest.raises(CrystallographyValueError, match="zero row"):
-        func(P, Q)

--- a/tests/test_crystallography_quaternion.py
+++ b/tests/test_crystallography_quaternion.py
@@ -203,6 +203,15 @@ def test_integer_quaternion_from_unit_unrecoverable_quaternion_raises():
         integer_quaternion_from_unit(irrational, max_denominator=2)
 
 
+def test_integer_quaternion_from_unit_accepts_numpy_max_denominator():
+    result = integer_quaternion_from_unit(
+        SIGMA5_QUAT_NORM,
+        max_denominator=np.int64(5),
+    )
+
+    assert result == (2, 0, 0, 1)
+
+
 # --------------------------------------------------------------------------------------
 # quaternion_to_rotation_matrix
 # --------------------------------------------------------------------------------------

--- a/tests/test_crystallography_quaternion.py
+++ b/tests/test_crystallography_quaternion.py
@@ -6,6 +6,7 @@ import pytest
 from crystallography_fixtures import CSL_SCENARIO_DICTS
 
 from GBOpt.crystallography.quaternion import (
+    _integer_quaternion_candidate_from_unit,
     integer_quaternion_from_unit,
     normalize_integer_quaternion,
     quaternion_to_rotation_matrix,
@@ -206,10 +207,38 @@ def test_integer_quaternion_from_unit_unrecoverable_quaternion_raises():
 def test_integer_quaternion_from_unit_accepts_numpy_max_denominator():
     result = integer_quaternion_from_unit(
         SIGMA5_QUAT_NORM,
-        max_denominator=np.int64(5),
+        max_denominator=np.int64(5),  # type: ignore[ty:invalid-argument-type]
     )
 
     assert result == (2, 0, 0, 1)
+
+
+def test_integer_quaternion_candidate_does_not_apply_fixed_match_tolerance():
+    perturbed = SIGMA5_QUAT_NORM.copy()
+    perturbed[0] += 1.0e-8
+    perturbed /= np.linalg.norm(perturbed)
+
+    result = _integer_quaternion_candidate_from_unit(
+        perturbed,
+        max_denominator=3,
+    )
+
+    assert result == SIGMA5_QUAT
+
+
+@pytest.mark.parametrize(
+    "quat",
+    [
+        pytest.param(["bad", 0, 0, 1], id="string-component"),
+        pytest.param(object(), id="non-array-object"),
+    ],
+)
+def test_integer_quaternion_from_unit_translates_conversion_errors(quat):
+    with pytest.raises(
+        CrystallographyValueError,
+        match="finite four-component quaternion",
+    ):
+        integer_quaternion_from_unit(quat)
 
 
 # --------------------------------------------------------------------------------------
@@ -259,15 +288,39 @@ def test_quaternion_to_rotation_matrix_sigma5_36deg_matches_expected():
 @pytest.mark.parametrize(
     ("quat", "match"),
     [
-        pytest.param([1, 0, 0], "length 4", id="too-short"),
-        pytest.param([[1, 0, 0, 0]], "length 4", id="two-dimensional-row"),
-        pytest.param(np.ones((2, 2)), "length 4", id="two-by-two"),
-        pytest.param([0.0, 0.0, 0.0, 0.0], "non-zero and finite", id="zero"),
-        pytest.param([np.nan, 0.0, 0.0, 1.0], "non-zero and finite", id="nan"),
-        pytest.param([np.inf, 0.0, 0.0, 1.0], "non-zero and finite", id="inf"),
-        pytest.param([1.5, 0.0, 0.0, 1.0], "integer-valued", id="non-unit-non-integer"),
+        pytest.param([1, 0, 0], r"shape \(4,\)", id="too-short"),
+        pytest.param([[1, 0, 0, 0]], r"shape \(4,\)", id="two-dimensional-row"),
+        pytest.param(np.ones((2, 2)), r"shape \(4,\)", id="two-by-two"),
+        pytest.param([0.0, 0.0, 0.0, 0.0], "non-zero", id="zero"),
+        pytest.param([np.nan, 0.0, 0.0, 1.0], "finite values", id="nan"),
+        pytest.param([np.inf, 0.0, 0.0, 1.0], "finite values", id="inf"),
+        pytest.param(
+            [1.5, 0.0, 0.0, 1.0],
+            "exact integer quaternion",
+            id="non-unit-non-integer",
+        ),
     ],
 )
-def test_quaternion_to_rotation_matrix_rejects_invalid_quaternions(quat, match):
+def test_quaternion_to_rotation_matrix_rejects_invalid_quaternions(
+    quat,
+    match,
+):
     with pytest.raises(CrystallographyValueError, match=match):
-        quaternion_to_rotation_matrix(np.array(quat, dtype=float))
+        quaternion_to_rotation_matrix(
+            np.array(quat, dtype=float),
+        )
+
+
+@pytest.mark.parametrize(
+    "quat",
+    [
+        pytest.param(["bad", 0, 0, 1], id="string-component"),
+        pytest.param(object(), id="non-array-object"),
+    ],
+)
+def test_quaternion_to_rotation_matrix_translates_conversion_errors(quat):
+    with pytest.raises(
+        CrystallographyValueError,
+        match="finite four-component quaternion",
+    ):
+        quaternion_to_rotation_matrix(quat)

--- a/tests/test_crystallography_rotation.py
+++ b/tests/test_crystallography_rotation.py
@@ -4,6 +4,7 @@ import pytest
 
 from GBOpt.crystallography.quaternion import quaternion_to_scaled_rotation
 from GBOpt.crystallography.rotation import (
+    _minimal_integral_row_pair,
     assert_scaled_rotation,
     scaled_row_image,
     transpose_rotation_convention,
@@ -29,6 +30,71 @@ SIGMA5_QUAT = (2, 0, 0, 1)
 @pytest.fixture
 def sigma5_rotation():
     return quaternion_to_scaled_rotation(SIGMA5_QUAT)
+
+
+# --------------------------------------------------------------------------------------
+# _minimal_integral_row_pair
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("direction", "expected_reference", "expected_image"),
+    [
+        pytest.param(
+            [1, 0, 0],
+            [5, 0, 0],
+            [3, -4, 0],
+            id="requires-denominator-scaling",
+        ),
+        pytest.param(
+            [2, 0, 0],
+            [5, 0, 0],
+            [3, -4, 0],
+            id="reduces-input-before-scaling",
+        ),
+        pytest.param(
+            [0, 0, 7],
+            [0, 0, 1],
+            [0, 0, 1],
+            id="already-integral-image",
+        ),
+        pytest.param(
+            [1, 1, 0],
+            [5, 5, 0],
+            [7, -1, 0],
+            id="mixed-components",
+        ),
+    ],
+)
+def test_minimal_integral_row_pair_returns_expected_exact_pair(
+    sigma5_rotation,
+    direction,
+    expected_reference,
+    expected_image,
+):
+    reference_row, image_row = _minimal_integral_row_pair(
+        np.array(direction, dtype=object),
+        sigma5_rotation,
+    )
+
+    np.testing.assert_array_equal(reference_row, expected_reference)
+    np.testing.assert_array_equal(image_row, expected_image)
+    assert reference_row.dtype == object
+    assert image_row.dtype == object
+
+
+def test_minimal_integral_row_pair_satisfies_exact_rotation_contract(
+    sigma5_rotation,
+):
+    reference_row, image_row = _minimal_integral_row_pair(
+        np.array([1, 1, 0], dtype=object),
+        sigma5_rotation,
+    )
+
+    np.testing.assert_array_equal(
+        reference_row @ np.asarray(sigma5_rotation.matrix, dtype=object),
+        sigma5_rotation.denominator * image_row,
+    )
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/test_gb_params.py
+++ b/tests/test_gb_params.py
@@ -451,6 +451,32 @@ def test_convert_rejects_boolean_sigma(capsys):
     assert "sigma must not be boolean" in stderr
 
 
+def test_convert_pq_to_five_dof_enforces_max_pq_determinant(capsys):
+    source = {
+        # fmt:off
+        "format": "pq",
+        "P": [[0, 0, 1], [3, 1, 0], [-1, 3, 0]],
+        "Q": [[0, 0, 1], [3, -1, 0], [1, 3, 0]],
+        "basis_mode": "supplied",
+        # fmt:on
+    }
+
+    stderr = _run_main_error(
+        capsys,
+        "convert",
+        "--to",
+        "five_dof",
+        "--max-pq-determinant",
+        9,
+        "--input-json",
+        json.dumps(source),
+    )
+
+    assert "Exact P/Q determinant exceeds max_pq_determinant=9" in stderr
+    assert "|det(P)|=10" in stderr
+    assert "|det(Q)|=10" in stderr
+
+
 # --------------------------------------------------------------------------------------
 # Input sources and command errors
 # --------------------------------------------------------------------------------------
@@ -493,15 +519,7 @@ def test_convert_rejects_malformed_json(capsys):
     "args",
     [
         pytest.param(
-            (
-                "exactify",
-                "--params",
-                0,
-                0,
-                0,
-                0,
-                0,
-            ),
+            ("exactify", "--params", 0, 0, 0, 0, 0),
             id="exactify-command",
         ),
         pytest.param(

--- a/tests/test_gb_params.py
+++ b/tests/test_gb_params.py
@@ -1,5 +1,7 @@
 # Copyright 2025, Battelle Energy Alliance, LLC, ALL RIGHTS RESERVED
 
+from __future__ import annotations
+
 import io
 import json
 import subprocess
@@ -487,26 +489,40 @@ def test_convert_rejects_malformed_json(capsys):
     assert "Expecting property name" in stderr
 
 
-def test_exactify_reports_unavailable_operation_as_error(capsys):
-    stderr = _run_main_error(
-        capsys,
-        "exactify",
-        "--params", 0, 0, 0, 0, 0,
-    )
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(
+            (
+                "exactify",
+                "--params",
+                0,
+                0,
+                0,
+                0,
+                0,
+            ),
+            id="exactify-command",
+        ),
+        pytest.param(
+            (
+                "convert",
+                "--to",
+                "pq",
+                "--input-json",
+                json.dumps(FIVE_DOF_ZERO_SOURCE),
+            ),
+            id="convert-command",
+        ),
+    ],
+)
+def test_five_dof_exactification_commands_output_identity_pq(
+    capsys,
+    args,
+):
+    payload = _run_main_json(capsys, *args)
 
-    assert "exactification is not implemented" in stderr
-
-
-def test_convert_five_dof_to_pq_reports_exactification_gap(capsys):
-    stderr = _run_main_error(
-        capsys,
-        "convert",
-        "--to", "pq",
-        "--input-json", json.dumps(FIVE_DOF_ZERO_SOURCE),
-    )
-
-    assert "exactification" in stderr
-    assert "not implemented" in stderr
+    assert payload == IDENTITY_PQ_SOURCE
 
 
 def test_convert_rejects_unsupported_csl_target_at_parse_time(capsys):

--- a/tests/test_gbmaker.py
+++ b/tests/test_gbmaker.py
@@ -1075,7 +1075,7 @@ class TestGBMaker(unittest.TestCase):
 
         self.gbm.x_dim_min = 35.0
 
-        self.assertGreaterEqual(self.gbm.box_dims[0][1], 20.0)
+        self.assertGreaterEqual(self.gbm.box_dims[0][1], 35.0)
         self.assertLess(self.gbm.x_dim, original_x_dim)
 
         self.gbm.vacuum_thickness = 50.0
@@ -2236,42 +2236,31 @@ class TestGBMakerGenerateGB(unittest.TestCase):
     def test_vacuum_zero_trim_preserves_fluorite_stoichiometry_per_grain(self):
         a0 = 5.47
         theta5 = 2 * np.arctan(1 / 3)
-        misorientation = np.array([theta5, 0, 0, 0, -theta5 / 2])
-        gb = GBMaker(
-            a0,
-            "fluorite",
-            0.0,
-            misorientation,
-            ("U", "O"),
-            vacuum=0,
-            repeat_factor=(2, 5),
-            x_dim_min=50,
-            interaction_distance=11.0,
+        mis = np.array([theta5, 0, 0, 0, -theta5 / 2])
+        gbm = GBMaker(a0, "fluorite", 0.0, mis, ("U", "O"),
+                      vacuum=0, repeat_factor=(2, 5), x_dim_min=50,
+                      interaction_distance=11.0)
+        ws = gbm.whole_system
+        names, counts = np.unique(ws["name"], return_counts=True)
+        c = {str(n): int(v) for n, v in zip(names, counts)}
+        self.assertEqual(
+            c["O"], 2 * c["U"],
+            f"Fluorite vacuum=0 bicrystal is not stoichiometric: {c}"
         )
-
-        _assert_fluorite_stoichiometry(gb.left_grain, label="left grain")
-        _assert_fluorite_stoichiometry(gb.right_grain, label="right grain")
-        _assert_fluorite_stoichiometry(gb.whole_system, label="whole system")
 
     def test_vacuum_zero_trim_preserves_rocksalt_stoichiometry_per_grain(self):
         a0 = 5.64
         theta5 = 2 * np.arctan(1 / 3)
-        misorientation = np.array([theta5, 0, 0, 0, -theta5 / 2])
-        gb = GBMaker(
-            a0,
-            "rocksalt",
-            0.0,
-            misorientation,
-            ("Na", "Cl"),
-            vacuum=0,
-            repeat_factor=(2, 4),
-            x_dim_min=50,
-            interaction_distance=11.0,
+        mis = np.array([theta5, 0, 0, 0, -theta5 / 2])
+        gbm = GBMaker(a0, "rocksalt", 0.0, mis, ("Na", "Cl"),
+                      vacuum=0, repeat_factor=(2, 4), x_dim_min=50,
+                      interaction_distance=11.0)
+        names, counts = np.unique(gbm.whole_system["name"], return_counts=True)
+        c = {str(n): int(v) for n, v in zip(names, counts)}
+        self.assertEqual(
+            c["Na"], c["Cl"],
+            f"Rocksalt vacuum=0 bicrystal is not stoichiometric: {c}",
         )
-
-        _assert_rocksalt_stoichiometry(gb.left_grain, label="left grain")
-        _assert_rocksalt_stoichiometry(gb.right_grain, label="right grain")
-        _assert_rocksalt_stoichiometry(gb.whole_system, label="whole system")
 
     @pytest.mark.filterwarnings(
         r"ignore:Repeat factor in [yz] modified to \d+ to satisfy the "
@@ -2281,7 +2270,8 @@ class TestGBMakerGenerateGB(unittest.TestCase):
         r"ignore:Required [yz]-spacing .* A exceeds threshold .* A; boundary is "
         r"non-periodic along [yz]\.:UserWarning"
     )
-    def test_known_fluorite_vacuum_zero_trim_regressions_are_stoichiometric(self):
+    def test_known_fluorite_vacuum0_trim_regressions_are_stoichiometric(self):
+        """Legacy float-path trimming must preserve complete fluorite origins."""
         case_names = (
             "sigma29_100_0_7_3bar_0_3bar_7_STGB",
             "sigma3_110_1_1bar_0_1_1bar_4_ATGB",

--- a/tests/test_gbmaker_from_boundary_spec.py
+++ b/tests/test_gbmaker_from_boundary_spec.py
@@ -9,6 +9,7 @@ from GBOpt.BoundarySpec import (
     BoundarySpecError,
     CSLApproxSpec,
     CSLExactSpec,
+    FiveDOFSpec,
     PQSpec,
 )
 from GBOpt.crystallography import (
@@ -43,6 +44,9 @@ SIGMA5_TWIST_EXACT_SPEC = CSLExactSpec(
     axis=[0, 0, 1],
     plane=[0, 0, 1],
     quat=[3, 0, 0, 1],
+)
+SIGMA5_TILT_FIVE_DOF_SPEC = FiveDOFSpec(
+    params=[np.arctan2(3, 4), 0.0, 0.0, 0.0, 0.0]
 )
 
 EXACT_SPECS = [
@@ -123,22 +127,56 @@ def test_from_boundary_spec_defaults_to_exact_mode(build_gb, spec):
     assert set(gb.whole_system["name"]) == {"Cu"}
 
 
+@pytest.mark.parametrize(
+    "spec",
+    [
+        pytest.param(SIGMA5_TILT_EXACT_SPEC, id="csl-exact"),
+        pytest.param(SIGMA5_TILT_FIVE_DOF_SPEC, id="five-dof"),
+    ],
+)
 def test_from_boundary_spec_equivalent_exact_specs_build_equivalent_bicrystals(
     build_gb,
+    spec,
 ):
-    gb_pq = build_gb(SIGMA5_TILT_PQ_SPEC, mode="exact")
-    gb_csl = build_gb(SIGMA5_TILT_EXACT_SPEC, mode="exact")
+    reference = build_gb(SIGMA5_TILT_PQ_SPEC, mode="exact")
+    result = build_gb(spec, mode="exact")
 
     np.testing.assert_array_equal(
-        _sorted_atoms(gb_csl.whole_system),
-        _sorted_atoms(gb_pq.whole_system),
+        _sorted_atoms(result.whole_system),
+        _sorted_atoms(reference.whole_system),
     )
     np.testing.assert_allclose(
-        gb_csl.box_dims,
-        gb_pq.box_dims,
-        atol=1e-12,
+        result.box_dims,
+        reference.box_dims,
+        atol=1.0e-12,
         rtol=0.0,
     )
+
+
+def test_from_boundary_spec_exact_five_dof_reports_exactification_failure(
+    build_gb,
+):
+    spec = FiveDOFSpec(
+        params=[0.0, 0.0, 0.1, 0.0, 0.0]
+    )
+
+    with pytest.raises(
+        BoundarySpecError,
+        match="could not be exactified",
+    ):
+        build_gb(spec, mode="exact")
+
+
+def test_from_boundary_spec_prefer_exact_uses_exact_five_dof_path(
+    build_gb,
+):
+    gb = build_gb(
+        SIGMA5_TILT_FIVE_DOF_SPEC,
+        mode="prefer_exact",
+    )
+
+    assert gb.whole_system.size > 0
+    assert gb.uses_exact_construction is True
 
 
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
### Summary
Completes the adoption bridge and packages the release. `exactify_five_dof` takes any
cubic-CSL boundary expressed in five-DOF notation and returns a `CSLExactSpec` at the
nearest rational-CSL misorientation, allowing the boundary to participate in stoichiometric
exact construction without the user needing to re-express it. Also adds
`GBOpt.__version__ = "0.2.0"`, bumps `setup.py`, and authors `CHANGELOG.md`.

### Closes / References
Closes #49
Closes #57
Refs #42

*Note:* Depends on #56 

### Reviewer notes
- `64f5e0a` ("Make boundary-spec tests warning-clean") resolves 73 deprecation and runtime
  warnings accumulated across the non-slow suite. No behavior change; materially improves
  CI signal-to-noise.
- The versioning commits are small and naturally accompany the final feature stage; they are
  not a separate PR.